### PR TITLE
feat: build button card component for basic entities

### DIFF
--- a/src/components/ButtonCard.tsx
+++ b/src/components/ButtonCard.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react';
+import { Card, Flex, Text, Spinner, Box } from '@radix-ui/themes';
+import { LightningBoltIcon, SunIcon, CheckIcon } from '@radix-ui/react-icons';
+import { useEntity } from '~/hooks';
+import { useHomeAssistant } from '~/contexts/HomeAssistantContext';
+import type { HassEntity } from '~/store/entityTypes';
+
+interface ButtonCardProps {
+  entityId: string;
+  size?: 'small' | 'medium' | 'large';
+}
+
+const getEntityIcon = (entity: HassEntity) => {
+  const domain = entity.entity_id.split('.')[0];
+  
+  switch (domain) {
+    case 'light':
+      return <SunIcon width="20" height="20" />;
+    case 'switch':
+      return <LightningBoltIcon width="20" height="20" />;
+    case 'input_boolean':
+      return <CheckIcon width="20" height="20" />;
+    default:
+      return <LightningBoltIcon width="20" height="20" />;
+  }
+};
+
+export function ButtonCard({ entityId, size = 'medium' }: ButtonCardProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const { entity, isConnected } = useEntity(entityId);
+  const homeAssistant = useHomeAssistant();
+  
+  if (!entity || !isConnected) {
+    return (
+      <Card variant="classic" style={{ opacity: 0.5 }}>
+        <Flex p="3" align="center" justify="center">
+          <Text size="2" color="gray">
+            {!isConnected ? 'Disconnected' : 'Entity not found'}
+          </Text>
+        </Flex>
+      </Card>
+    );
+  }
+  
+  const domain = entity.entity_id.split('.')[0];
+  const friendlyName = entity.attributes.friendly_name || entity.entity_id;
+  const isOn = entity.state === 'on';
+  
+  const handleClick = async () => {
+    if (!homeAssistant || isLoading) return;
+    
+    setIsLoading(true);
+    
+    try {
+      // Determine the correct service based on domain
+      let service = 'toggle';
+      if (domain === 'light' || domain === 'switch') {
+        service = 'toggle';
+      } else if (domain === 'input_boolean') {
+        service = 'toggle';
+      }
+      
+      await homeAssistant.callService(domain, service, {
+        entity_id: entity.entity_id,
+      });
+    } catch (error) {
+      console.error('Failed to call service:', error);
+    } finally {
+      // Add a small delay to show the loading state
+      setTimeout(() => {
+        setIsLoading(false);
+      }, 300);
+    }
+  };
+  
+  const cardSize = {
+    small: { p: '2', iconSize: '16', fontSize: '1' },
+    medium: { p: '3', iconSize: '20', fontSize: '2' },
+    large: { p: '4', iconSize: '24', fontSize: '3' },
+  }[size];
+  
+  return (
+    <Card
+      variant="classic"
+      style={{
+        cursor: isLoading ? 'wait' : 'pointer',
+        backgroundColor: isOn ? 'var(--amber-3)' : undefined,
+        borderColor: isOn ? 'var(--amber-6)' : undefined,
+        borderWidth: isOn ? '2px' : '1px',
+        borderStyle: 'solid',
+        transition: 'all 0.2s ease',
+        transform: isLoading ? 'scale(0.98)' : undefined,
+      }}
+      onClick={handleClick}
+    >
+      <Flex
+        p={cardSize.p}
+        direction="column"
+        align="center"
+        justify="center"
+        gap="2"
+        style={{ minHeight: size === 'large' ? '120px' : size === 'medium' ? '100px' : '80px' }}
+      >
+        {isLoading ? (
+          <Spinner size={cardSize.fontSize as ('1' | '2' | '3')} />
+        ) : (
+          <Box
+            style={{
+              color: isOn ? 'var(--amber-9)' : 'var(--gray-9)',
+              transform: `scale(${size === 'large' ? 1.2 : size === 'medium' ? 1 : 0.8})`,
+            }}
+          >
+            {getEntityIcon(entity)}
+          </Box>
+        )}
+        
+        <Text
+          size={cardSize.fontSize as ('1' | '2' | '3')}
+          weight={isOn ? 'medium' : 'regular'}
+          align="center"
+          style={{
+            color: isOn ? 'var(--amber-11)' : undefined,
+            maxWidth: '100%',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {friendlyName}
+        </Text>
+        
+        <Text
+          size="1"
+          color={isOn ? 'amber' : 'gray'}
+          weight="medium"
+        >
+          {entity.state.toUpperCase()}
+        </Text>
+      </Flex>
+    </Card>
+  );
+}

--- a/src/components/ButtonCard.tsx
+++ b/src/components/ButtonCard.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Card, Flex, Text, Spinner, Box } from '@radix-ui/themes';
 import { LightningBoltIcon, SunIcon, CheckIcon } from '@radix-ui/react-icons';
 import { useEntity } from '~/hooks';
-import { useHomeAssistant } from '~/contexts/HomeAssistantContext';
+import { useHomeAssistantOptional } from '~/contexts/HomeAssistantContext';
 import type { HassEntity } from '~/store/entityTypes';
 
 interface ButtonCardProps {
@@ -28,7 +28,7 @@ const getEntityIcon = (entity: HassEntity) => {
 export function ButtonCard({ entityId, size = 'medium' }: ButtonCardProps) {
   const [isLoading, setIsLoading] = useState(false);
   const { entity, isConnected } = useEntity(entityId);
-  const homeAssistant = useHomeAssistant();
+  const homeAssistant = useHomeAssistantOptional();
   
   if (!entity || !isConnected) {
     return (

--- a/src/components/DevHomeAssistantProvider.tsx
+++ b/src/components/DevHomeAssistantProvider.tsx
@@ -5,16 +5,11 @@ import { useDevHass } from '~/hooks/useDevHass';
 export function DevHomeAssistantProvider({ children }: { children: ReactNode }) {
   const devHass = useDevHass();
   
-  // If we have a hass object from dev mode, use it
-  if (devHass) {
-    return (
-      <HomeAssistantProvider hass={devHass}>
-        {children}
-      </HomeAssistantProvider>
-    );
-  }
-  
-  // Otherwise, render children without the provider
-  // This allows hooks to use useHomeAssistantOptional
-  return <>{children}</>;
+  // Always wrap children in the provider, even with null hass
+  // This prevents "useHomeAssistant must be used within a HomeAssistantProvider" errors
+  return (
+    <HomeAssistantProvider hass={devHass}>
+      {children}
+    </HomeAssistantProvider>
+  );
 }

--- a/src/components/SectionGrid.tsx
+++ b/src/components/SectionGrid.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
-import { Box } from '@radix-ui/themes';
+import { Box, Grid } from '@radix-ui/themes';
 import { Section } from './Section';
+import { ButtonCard } from './ButtonCard';
 import { SectionConfig, GridItem } from '../store/types';
 import { dashboardActions, useDashboardStore } from '../store';
 import './SectionGrid.css';
@@ -134,16 +135,26 @@ export function SectionGrid({ screenId, sections }: SectionGridProps) {
             onDelete={() => handleDeleteSection(section.id)}
             onAddEntities={(entityIds) => handleAddEntities(section.id, entityIds)}
           >
-            {/* Entity items will go here */}
+            {/* Entity items grid */}
             {section.items.length > 0 && (
-              <Box>
-                {/* Placeholder for entity items */}
+              <Grid 
+                columns={{ 
+                  initial: '2',
+                  xs: '3',
+                  sm: '4',
+                  md: '6',
+                }}
+                gap="3"
+                width="100%"
+              >
                 {section.items.map((item) => (
-                  <Box key={item.id} p="2" style={{ background: 'var(--gray-a3)' }}>
-                    Entity: {item.entityId}
-                  </Box>
+                  <ButtonCard 
+                    key={item.id} 
+                    entityId={item.entityId}
+                    size="medium"
+                  />
                 ))}
-              </Box>
+              </Grid>
             )}
           </Section>
         </Box>

--- a/src/components/__tests__/ButtonCard.test.tsx
+++ b/src/components/__tests__/ButtonCard.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ButtonCard } from '../ButtonCard';
 import { useEntity } from '~/hooks';
-import { useHomeAssistant } from '~/contexts/HomeAssistantContext';
+import { useHomeAssistantOptional } from '~/contexts/HomeAssistantContext';
 import type { HomeAssistant } from '~/contexts/HomeAssistantContext';
 
 // Mock the hooks
@@ -12,7 +12,7 @@ vi.mock('~/hooks', () => ({
 }));
 
 vi.mock('~/contexts/HomeAssistantContext', () => ({
-  useHomeAssistant: vi.fn(),
+  useHomeAssistantOptional: vi.fn(),
   HomeAssistant: vi.fn(),
 }));
 
@@ -64,7 +64,7 @@ describe('ButtonCard', () => {
         version: '2024.1.0',
       },
     };
-    vi.mocked(useHomeAssistant).mockReturnValue(mockHass);
+    vi.mocked(useHomeAssistantOptional).mockReturnValue(mockHass);
   });
 
   it('should render entity not found when entity is null', () => {
@@ -243,7 +243,7 @@ describe('ButtonCard', () => {
       isConnected: true,
       isLoading: false,
     });
-    vi.mocked(useHomeAssistant).mockReturnValue(null as unknown as HomeAssistant);
+    vi.mocked(useHomeAssistantOptional).mockReturnValue(null);
     
     render(<ButtonCard entityId="light.living_room" />);
     

--- a/src/components/__tests__/ButtonCard.test.tsx
+++ b/src/components/__tests__/ButtonCard.test.tsx
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ButtonCard } from '../ButtonCard';
+import { useEntity } from '~/hooks';
+import { useHomeAssistant } from '~/contexts/HomeAssistantContext';
+import type { HomeAssistant } from '~/contexts/HomeAssistantContext';
+
+// Mock the hooks
+vi.mock('~/hooks', () => ({
+  useEntity: vi.fn(),
+}));
+
+vi.mock('~/contexts/HomeAssistantContext', () => ({
+  useHomeAssistant: vi.fn(),
+  HomeAssistant: vi.fn(),
+}));
+
+describe('ButtonCard', () => {
+  const mockCallService = vi.fn();
+  const mockEntity = {
+    entity_id: 'light.living_room',
+    state: 'off',
+    attributes: {
+      friendly_name: 'Living Room Light',
+    },
+    last_changed: '2024-01-01T00:00:00Z',
+    last_updated: '2024-01-01T00:00:00Z',
+    context: {
+      id: 'test',
+      parent_id: null,
+      user_id: null,
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const mockHass: HomeAssistant = {
+      callService: mockCallService,
+      states: {},
+      connection: {
+        subscribeEvents: vi.fn(),
+      },
+      user: {
+        name: 'Test User',
+        id: 'test-user',
+        is_admin: true,
+      },
+      themes: {},
+      language: 'en',
+      config: {
+        latitude: 0,
+        longitude: 0,
+        elevation: 0,
+        unit_system: {
+          length: 'km',
+          mass: 'kg',
+          temperature: '°C',
+          volume: 'L',
+        },
+        location_name: 'Home',
+        time_zone: 'UTC',
+        components: [],
+        version: '2024.1.0',
+      },
+    };
+    vi.mocked(useHomeAssistant).mockReturnValue(mockHass);
+  });
+
+  it('should render entity not found when entity is null', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: undefined,
+      isConnected: true,
+      isLoading: false,
+    });
+    
+    render(<ButtonCard entityId="unknown.entity" />);
+    
+    expect(screen.getByText('Entity not found')).toBeInTheDocument();
+  });
+
+  it('should render disconnected when not connected', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: mockEntity,
+      isConnected: false,
+      isLoading: false,
+    });
+    
+    render(<ButtonCard entityId="light.living_room" />);
+    
+    expect(screen.getByText('Disconnected')).toBeInTheDocument();
+  });
+
+  it('should render entity with friendly name and state', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: mockEntity,
+      isConnected: true,
+      isLoading: false,
+    });
+    
+    render(<ButtonCard entityId="light.living_room" />);
+    
+    expect(screen.getByText('Living Room Light')).toBeInTheDocument();
+    expect(screen.getByText('OFF')).toBeInTheDocument();
+  });
+
+  it('should render entity with different states', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...mockEntity,
+        state: 'on',
+      },
+      isConnected: true,
+      isLoading: false,
+    });
+    
+    render(<ButtonCard entityId="light.living_room" />);
+    
+    expect(screen.getByText('ON')).toBeInTheDocument();
+  });
+
+  it('should call toggle service when clicked', async () => {
+    const user = userEvent.setup();
+    vi.mocked(useEntity).mockReturnValue({
+      entity: mockEntity,
+      isConnected: true,
+      isLoading: false,
+    });
+    mockCallService.mockResolvedValue(undefined);
+    
+    render(<ButtonCard entityId="light.living_room" />);
+    
+    const card = screen.getByText('Living Room Light').closest('[class*="Card"]');
+    await user.click(card!);
+    
+    expect(mockCallService).toHaveBeenCalledWith('light', 'toggle', {
+      entity_id: 'light.living_room',
+    });
+  });
+
+  it('should handle switch entities', async () => {
+    const user = userEvent.setup();
+    const switchEntity = {
+      ...mockEntity,
+      entity_id: 'switch.garage_door',
+      attributes: {
+        friendly_name: 'Garage Door',
+      },
+    };
+    vi.mocked(useEntity).mockReturnValue({
+      entity: switchEntity,
+      isConnected: true,
+      isLoading: false,
+    });
+    
+    render(<ButtonCard entityId="switch.garage_door" />);
+    
+    const card = screen.getByText('Garage Door').closest('[class*="Card"]');
+    await user.click(card!);
+    
+    expect(mockCallService).toHaveBeenCalledWith('switch', 'toggle', {
+      entity_id: 'switch.garage_door',
+    });
+  });
+
+  it('should handle input_boolean entities', async () => {
+    const user = userEvent.setup();
+    const inputBooleanEntity = {
+      ...mockEntity,
+      entity_id: 'input_boolean.vacation_mode',
+      attributes: {
+        friendly_name: 'Vacation Mode',
+      },
+    };
+    vi.mocked(useEntity).mockReturnValue({
+      entity: inputBooleanEntity,
+      isConnected: true,
+      isLoading: false,
+    });
+    
+    render(<ButtonCard entityId="input_boolean.vacation_mode" />);
+    
+    const card = screen.getByText('Vacation Mode').closest('[class*="Card"]');
+    await user.click(card!);
+    
+    expect(mockCallService).toHaveBeenCalledWith('input_boolean', 'toggle', {
+      entity_id: 'input_boolean.vacation_mode',
+    });
+  });
+
+  it('should show loading state during service call', async () => {
+    const user = userEvent.setup();
+    vi.mocked(useEntity).mockReturnValue({
+      entity: mockEntity,
+      isConnected: true,
+      isLoading: false,
+    });
+    
+    // Make the service call hang
+    let resolvePromise: () => void;
+    const promise = new Promise<void>((resolve) => {
+      resolvePromise = resolve;
+    });
+    mockCallService.mockReturnValue(promise);
+    
+    render(<ButtonCard entityId="light.living_room" />);
+    
+    const card = screen.getByText('Living Room Light').closest('[class*="Card"]');
+    await user.click(card!);
+    
+    // Should show loading spinner
+    expect(card).toHaveStyle({ cursor: 'wait' });
+    
+    // Resolve the promise
+    resolvePromise!();
+    await promise;
+  });
+
+  it('should handle service call errors', async () => {
+    const user = userEvent.setup();
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(useEntity).mockReturnValue({
+      entity: mockEntity,
+      isConnected: true,
+      isLoading: false,
+    });
+    mockCallService.mockRejectedValue(new Error('Service call failed'));
+    
+    render(<ButtonCard entityId="light.living_room" />);
+    
+    const card = screen.getByText('Living Room Light').closest('[class*="Card"]');
+    await user.click(card!);
+    
+    expect(consoleSpy).toHaveBeenCalledWith('Failed to call service:', expect.any(Error));
+    
+    consoleSpy.mockRestore();
+  });
+
+  it('should not call service when hass is not available', async () => {
+    const user = userEvent.setup();
+    vi.mocked(useEntity).mockReturnValue({
+      entity: mockEntity,
+      isConnected: true,
+      isLoading: false,
+    });
+    vi.mocked(useHomeAssistant).mockReturnValue(null as unknown as HomeAssistant);
+    
+    render(<ButtonCard entityId="light.living_room" />);
+    
+    const card = screen.getByText('Living Room Light').closest('[class*="Card"]');
+    await user.click(card!);
+    
+    expect(mockCallService).not.toHaveBeenCalled();
+  });
+
+  it('should render different sizes correctly', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: mockEntity,
+      isConnected: true,
+      isLoading: false,
+    });
+    
+    const { rerender } = render(<ButtonCard entityId="light.living_room" size="small" />);
+    expect(screen.getByText('Living Room Light')).toBeInTheDocument();
+    
+    rerender(<ButtonCard entityId="light.living_room" size="medium" />);
+    expect(screen.getByText('Living Room Light')).toBeInTheDocument();
+    
+    rerender(<ButtonCard entityId="light.living_room" size="large" />);
+    expect(screen.getByText('Living Room Light')).toBeInTheDocument();
+  });
+
+  it('should use entity_id when friendly_name is not available', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...mockEntity,
+        attributes: {},
+      },
+      isConnected: true,
+      isLoading: false,
+    });
+    
+    render(<ButtonCard entityId="light.living_room" />);
+    
+    expect(screen.getByText('light.living_room')).toBeInTheDocument();
+  });
+
+  it('should apply on state styling', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...mockEntity,
+        state: 'on',
+      },
+      isConnected: true,
+      isLoading: false,
+    });
+    
+    render(<ButtonCard entityId="light.living_room" />);
+    
+    const card = screen.getByText('Living Room Light').closest('[class*="Card"]');
+    expect(card).toHaveStyle({
+      borderWidth: '2px',
+    });
+  });
+});


### PR DESCRIPTION
Closes #18

## Summary
- Implemented ButtonCard component using Radix UI Card for displaying and controlling Home Assistant entities
- Added support for switches, lights, and input_boolean entities with appropriate icons
- Implemented real-time state updates via entity subscription system
- Added loading states and error handling for service calls

## Implementation Details
- **ButtonCard Component**: Touch-optimized card with entity state display and toggle functionality
- **Visual Feedback**: Different styling for on/off states with amber color theme
- **Loading States**: Shows spinner during service calls with subtle scale animation
- **Entity Types**: Supports light (sun icon), switch (lightning bolt), and input_boolean (check icon)
- **Size Variants**: Small, medium, and large sizes for different use cases
- **Grid Integration**: Updated SectionGrid to render ButtonCards in responsive grid layout

## Testing
- [x] Comprehensive test suite with 13 tests covering all functionality
- [x] TypeScript checks pass
- [x] Linting passes (fixed ButtonCard specific issues)
- [x] Manual testing in development mode
- [x] Tested entity state changes and service calls
- [x] Tested disconnection scenarios

## Screenshots
The button cards provide an intuitive touch interface for controlling Home Assistant entities with clear visual feedback for entity states.