### PR TITLE
feat: implement screen configuration interface

### DIFF
--- a/src/components/ScreenConfigDialog.tsx
+++ b/src/components/ScreenConfigDialog.tsx
@@ -1,0 +1,261 @@
+import { useState, useCallback, useEffect } from 'react'
+import {
+  Dialog,
+  Flex,
+  Text,
+  TextField,
+  Button,
+  Select,
+  Grid,
+  Box,
+  Card,
+  Separator,
+} from '@radix-ui/themes'
+import { CopyIcon, EyeOpenIcon, EyeNoneIcon } from '@radix-ui/react-icons'
+import { useDashboardStore, dashboardActions } from '../store'
+import type { ScreenConfig } from '../store/types'
+import { generateSlug } from '../utils/slug'
+
+interface ScreenConfigDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  screenId?: string
+}
+
+const GRID_PRESETS: { label: string; columns: number; rows: number }[] = [
+  { label: 'Compact (8x6)', columns: 8, rows: 6 },
+  { label: 'Standard (12x8)', columns: 12, rows: 8 },
+  { label: 'Large (16x10)', columns: 16, rows: 10 },
+  { label: 'Extra Large (24x12)', columns: 24, rows: 12 },
+]
+
+// Helper function to find screen in tree structure
+const findScreenById = (screenList: ScreenConfig[], id: string): ScreenConfig | undefined => {
+  for (const screen of screenList) {
+    if (screen.id === id) return screen
+    if (screen.children) {
+      const found = findScreenById(screen.children, id)
+      if (found) return found
+    }
+  }
+  return undefined
+}
+
+export function ScreenConfigDialog({ open, onOpenChange, screenId }: ScreenConfigDialogProps) {
+  const screens = useDashboardStore((state) => state.screens)
+  const currentScreen = screenId ? findScreenById(screens, screenId) : null
+
+  const [name, setName] = useState(currentScreen?.name || '')
+  const [columns, setColumns] = useState(currentScreen?.grid?.resolution.columns || 12)
+  const [rows, setRows] = useState(currentScreen?.grid?.resolution.rows || 8)
+  const [isVisible, setIsVisible] = useState(true) // TODO: Add visibility to ScreenConfig type
+
+  // Update state when screen changes
+  useEffect(() => {
+    if (currentScreen) {
+      setName(currentScreen.name)
+      setColumns(currentScreen.grid?.resolution.columns || 12)
+      setRows(currentScreen.grid?.resolution.rows || 8)
+    }
+  }, [currentScreen])
+
+  const handleSave = useCallback(() => {
+    if (!screenId || !currentScreen) return
+
+    // Validate columns and rows
+    if (columns < 1 || columns > 24 || rows < 1 || rows > 20) {
+      return // Don't save invalid values
+    }
+
+    const updates: Partial<ScreenConfig> = {
+      name,
+      slug: generateSlug(name),
+      grid: {
+        resolution: { columns, rows },
+        items: currentScreen.grid?.items || [],
+      },
+    }
+
+    dashboardActions.updateScreen(screenId, updates)
+    onOpenChange(false)
+  }, [screenId, currentScreen, name, columns, rows, onOpenChange])
+
+  const handleDuplicate = useCallback(() => {
+    if (!currentScreen) return
+
+    const newScreen: ScreenConfig = {
+      ...currentScreen,
+      id: `${currentScreen.id}-copy-${Date.now()}`,
+      name: `${currentScreen.name} (Copy)`,
+      slug: `${currentScreen.slug}-copy`,
+      children: undefined, // Don't duplicate children
+    }
+
+    dashboardActions.addScreen(newScreen, currentScreen.parentId)
+    onOpenChange(false)
+  }, [currentScreen, onOpenChange])
+
+  const handlePresetSelect = useCallback((value: string) => {
+    const preset = GRID_PRESETS.find((p) => p.label === value)
+    if (preset) {
+      setColumns(preset.columns)
+      setRows(preset.rows)
+    }
+  }, [])
+
+  const GridPreview = () => {
+    const cellSize = Math.min(300 / columns, 200 / rows)
+    return (
+      <Card>
+        <Box p="3">
+          <Text size="2" weight="medium" mb="2">
+            Grid Preview
+          </Text>
+          <Grid
+            columns={`${columns}`}
+            rows={`${rows}`}
+            gap="1"
+            style={{
+              width: columns * cellSize,
+              height: rows * cellSize,
+              maxWidth: '100%',
+              aspectRatio: `${columns} / ${rows}`,
+            }}
+          >
+            {Array.from({ length: columns * rows }).map((_, i) => (
+              <Box
+                key={i}
+                style={{
+                  backgroundColor: 'var(--gray-a3)',
+                  borderRadius: '2px',
+                  minHeight: '10px',
+                }}
+              />
+            ))}
+          </Grid>
+        </Box>
+      </Card>
+    )
+  }
+
+  if (!screenId || !currentScreen) {
+    return null
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content maxWidth="600px">
+        <Dialog.Title>Configure Screen</Dialog.Title>
+        <Dialog.Description>
+          Customize the screen settings including name and grid resolution
+        </Dialog.Description>
+
+        <Flex direction="column" gap="4" mt="4">
+          {/* Screen Name */}
+          <Box>
+            <Text as="label" size="2" weight="medium" mb="1">
+              Screen Name
+            </Text>
+            <TextField.Root
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Enter screen name"
+            />
+          </Box>
+
+          <Separator size="4" />
+
+          {/* Grid Resolution */}
+          <Box>
+            <Text as="div" size="2" weight="medium" mb="2">
+              Grid Resolution
+            </Text>
+
+            {/* Presets */}
+            <Select.Root onValueChange={handlePresetSelect}>
+              <Select.Trigger placeholder="Choose a preset" />
+              <Select.Content>
+                {GRID_PRESETS.map((preset) => (
+                  <Select.Item key={preset.label} value={preset.label}>
+                    {preset.label}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select.Root>
+
+            {/* Custom Resolution */}
+            <Grid columns="2" gap="3" mt="3">
+              <Box>
+                <Text as="label" size="1" color="gray" mb="1">
+                  Columns (1-24)
+                </Text>
+                <TextField.Root
+                  type="number"
+                  min="1"
+                  max="24"
+                  value={columns.toString()}
+                  onChange={(e) => {
+                    const val = parseInt(e.target.value, 10)
+                    if (val >= 1 && val <= 24) setColumns(val)
+                  }}
+                />
+              </Box>
+              <Box>
+                <Text as="label" size="1" color="gray" mb="1">
+                  Rows (1-20)
+                </Text>
+                <TextField.Root
+                  type="number"
+                  min="1"
+                  max="20"
+                  value={rows.toString()}
+                  onChange={(e) => {
+                    const val = parseInt(e.target.value, 10)
+                    if (val >= 1 && val <= 20) setRows(val)
+                  }}
+                />
+              </Box>
+            </Grid>
+
+            {/* Grid Preview */}
+            <Box mt="3">
+              <GridPreview />
+            </Box>
+          </Box>
+
+          <Separator size="4" />
+
+          {/* Screen Actions */}
+          <Box>
+            <Text as="div" size="2" weight="medium" mb="2">
+              Screen Actions
+            </Text>
+            <Flex gap="2">
+              <Button variant="soft" onClick={handleDuplicate}>
+                <CopyIcon />
+                Duplicate Screen
+              </Button>
+              <Button
+                variant="soft"
+                color={isVisible ? 'gray' : 'orange'}
+                onClick={() => setIsVisible(!isVisible)}
+              >
+                {isVisible ? <EyeOpenIcon /> : <EyeNoneIcon />}
+                {isVisible ? 'Visible' : 'Hidden'}
+              </Button>
+            </Flex>
+          </Box>
+        </Flex>
+
+        <Flex gap="3" mt="5" justify="end">
+          <Dialog.Close>
+            <Button variant="soft" color="gray">
+              Cancel
+            </Button>
+          </Dialog.Close>
+          <Button onClick={handleSave}>Save Changes</Button>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  )
+}

--- a/src/components/ViewTabs.tsx
+++ b/src/components/ViewTabs.tsx
@@ -1,9 +1,10 @@
 import { Tabs, Button, Flex, IconButton, ScrollArea, DropdownMenu, Box } from '@radix-ui/themes'
-import { Cross2Icon, PlusIcon, HamburgerMenuIcon } from '@radix-ui/react-icons'
+import { Cross2Icon, PlusIcon, HamburgerMenuIcon, GearIcon } from '@radix-ui/react-icons'
 import { useDashboardStore, dashboardActions } from '../store'
 import type { ScreenConfig } from '../store/types'
 import { useEffect, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
+import { ScreenConfigDialog } from './ScreenConfigDialog'
 
 interface ViewTabsProps {
   onAddView?: () => void
@@ -14,6 +15,7 @@ export function ViewTabs({ onAddView }: ViewTabsProps) {
   const currentScreenId = useDashboardStore((state) => state.currentScreenId)
   const mode = useDashboardStore((state) => state.mode)
   const [isMobile, setIsMobile] = useState(false)
+  const [configScreenId, setConfigScreenId] = useState<string | undefined>()
   const navigate = useNavigate()
 
   // Helper function to find screen by ID
@@ -72,29 +74,58 @@ export function ViewTabs({ onAddView }: ViewTabsProps) {
         <Tabs.Trigger key={screen.id} value={screen.id} style={{ paddingLeft: `${level * 20}px` }}>
           <Flex align="center" gap="2" style={{ width: '100%' }}>
             <span style={{ flex: 1 }}>{screen.name}</span>
-            {mode === 'edit' && screens.length > 1 && (
-              <Box
-                onClick={(e) => handleRemoveView(screen.id, e)}
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  width: '20px',
-                  height: '20px',
-                  borderRadius: '4px',
-                  cursor: 'pointer',
-                  color: 'var(--gray-11)',
-                  transition: 'background-color 0.2s',
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.backgroundColor = 'var(--gray-a3)'
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.backgroundColor = 'transparent'
-                }}
-              >
-                <Cross2Icon width="14" height="14" />
-              </Box>
+            {mode === 'edit' && (
+              <Flex gap="1">
+                <Box
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setConfigScreenId(screen.id)
+                  }}
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width: '20px',
+                    height: '20px',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                    color: 'var(--gray-11)',
+                    transition: 'background-color 0.2s',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.backgroundColor = 'var(--gray-a3)'
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.backgroundColor = 'transparent'
+                  }}
+                >
+                  <GearIcon width="14" height="14" />
+                </Box>
+                {screens.length > 1 && (
+                  <Box
+                    onClick={(e) => handleRemoveView(screen.id, e)}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      width: '20px',
+                      height: '20px',
+                      borderRadius: '4px',
+                      cursor: 'pointer',
+                      color: 'var(--gray-11)',
+                      transition: 'background-color 0.2s',
+                    }}
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.backgroundColor = 'var(--gray-a3)'
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.backgroundColor = 'transparent'
+                    }}
+                  >
+                    <Cross2Icon width="14" height="14" />
+                  </Box>
+                )}
+              </Flex>
             )}
           </Flex>
         </Tabs.Trigger>
@@ -129,6 +160,14 @@ export function ViewTabs({ onAddView }: ViewTabsProps) {
           {screen.name}
           {currentScreenId === screen.id && ' ✓'}
         </DropdownMenu.Item>
+        {mode === 'edit' && (
+          <DropdownMenu.Item
+            onSelect={() => setConfigScreenId(screen.id)}
+            style={{ paddingLeft: `${20 + level * 20}px` }}
+          >
+            <GearIcon /> Configure {screen.name}
+          </DropdownMenu.Item>
+        )}
         {screen.children &&
           screen.children.length > 0 &&
           renderDropdownItems(screen.children, level + 1)}
@@ -142,43 +181,57 @@ export function ViewTabs({ onAddView }: ViewTabsProps) {
 
   if (isMobile) {
     return (
-      <Flex align="center" gap="2" p="2" style={{ borderBottom: '1px solid var(--gray-a5)' }}>
-        <DropdownMenu.Root>
-          <DropdownMenu.Trigger>
-            <Button variant="soft" size="2">
-              <HamburgerMenuIcon />
-              {currentScreenName}
-            </Button>
-          </DropdownMenu.Trigger>
-          <DropdownMenu.Content>
-            {renderDropdownItems(screens)}
-            {mode === 'edit' && (
-              <>
-                <DropdownMenu.Separator />
-                <DropdownMenu.Item onSelect={() => onAddView?.()}>
-                  <PlusIcon />
-                  Add New View
-                </DropdownMenu.Item>
-              </>
-            )}
-          </DropdownMenu.Content>
-        </DropdownMenu.Root>
-      </Flex>
+      <>
+        <Flex align="center" gap="2" p="2" style={{ borderBottom: '1px solid var(--gray-a5)' }}>
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger>
+              <Button variant="soft" size="2">
+                <HamburgerMenuIcon />
+                {currentScreenName}
+              </Button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content>
+              {renderDropdownItems(screens)}
+              {mode === 'edit' && (
+                <>
+                  <DropdownMenu.Separator />
+                  <DropdownMenu.Item onSelect={() => onAddView?.()}>
+                    <PlusIcon />
+                    Add New View
+                  </DropdownMenu.Item>
+                </>
+              )}
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
+        </Flex>
+        <ScreenConfigDialog
+          open={!!configScreenId}
+          onOpenChange={(open) => !open && setConfigScreenId(undefined)}
+          screenId={configScreenId}
+        />
+      </>
     )
   }
 
   return (
-    <Tabs.Root value={currentScreenId || ''} onValueChange={handleTabChange}>
-      <Flex align="center" gap="2" style={{ borderBottom: '1px solid var(--gray-a5)' }}>
-        <ScrollArea type="hover" scrollbars="horizontal" style={{ flex: 1 }}>
-          <Tabs.List>{renderScreenTabs(screens)}</Tabs.List>
-        </ScrollArea>
-        {mode === 'edit' && (
-          <IconButton size="2" variant="soft" onClick={onAddView} style={{ marginRight: '8px' }}>
-            <PlusIcon />
-          </IconButton>
-        )}
-      </Flex>
-    </Tabs.Root>
+    <>
+      <Tabs.Root value={currentScreenId || ''} onValueChange={handleTabChange}>
+        <Flex align="center" gap="2" style={{ borderBottom: '1px solid var(--gray-a5)' }}>
+          <ScrollArea type="hover" scrollbars="horizontal" style={{ flex: 1 }}>
+            <Tabs.List>{renderScreenTabs(screens)}</Tabs.List>
+          </ScrollArea>
+          {mode === 'edit' && (
+            <IconButton size="2" variant="soft" onClick={onAddView} style={{ marginRight: '8px' }}>
+              <PlusIcon />
+            </IconButton>
+          )}
+        </Flex>
+      </Tabs.Root>
+      <ScreenConfigDialog
+        open={!!configScreenId}
+        onOpenChange={(open) => !open && setConfigScreenId(undefined)}
+        screenId={configScreenId}
+      />
+    </>
   )
 }

--- a/src/components/__tests__/ScreenConfigDialog.test.tsx
+++ b/src/components/__tests__/ScreenConfigDialog.test.tsx
@@ -51,32 +51,24 @@ describe('ScreenConfigDialog', () => {
   })
 
   it('should not render when screenId is not provided', () => {
-    const { container } = render(
-      <ScreenConfigDialog open={true} onOpenChange={mockOnOpenChange} />
-    )
+    const { container } = render(<ScreenConfigDialog open={true} onOpenChange={mockOnOpenChange} />)
     expect(container.firstChild).toBeNull()
   })
 
   it('should render dialog when open with valid screenId', () => {
     render(
-      <ScreenConfigDialog
-        open={true}
-        onOpenChange={mockOnOpenChange}
-        screenId="test-screen"
-      />
+      <ScreenConfigDialog open={true} onOpenChange={mockOnOpenChange} screenId="test-screen" />
     )
 
     expect(screen.getByText('Configure Screen')).toBeInTheDocument()
-    expect(screen.getByText('Customize the screen settings including name and grid resolution')).toBeInTheDocument()
+    expect(
+      screen.getByText('Customize the screen settings including name and grid resolution')
+    ).toBeInTheDocument()
   })
 
   it('should display current screen values', () => {
     render(
-      <ScreenConfigDialog
-        open={true}
-        onOpenChange={mockOnOpenChange}
-        screenId="test-screen"
-      />
+      <ScreenConfigDialog open={true} onOpenChange={mockOnOpenChange} screenId="test-screen" />
     )
 
     const nameInput = screen.getByPlaceholderText('Enter screen name') as HTMLInputElement
@@ -84,20 +76,16 @@ describe('ScreenConfigDialog', () => {
 
     // Find inputs by their type and value since Radix UI doesn't properly associate labels
     const numberInputs = screen.getAllByRole('spinbutton') as HTMLInputElement[]
-    const columnsInput = numberInputs.find(input => input.value === '12')
-    const rowsInput = numberInputs.find(input => input.value === '8')
-    
+    const columnsInput = numberInputs.find((input) => input.value === '12')
+    const rowsInput = numberInputs.find((input) => input.value === '8')
+
     expect(columnsInput).toBeDefined()
     expect(rowsInput).toBeDefined()
   })
 
   it('should display preset selector', () => {
     render(
-      <ScreenConfigDialog
-        open={true}
-        onOpenChange={mockOnOpenChange}
-        screenId="test-screen"
-      />
+      <ScreenConfigDialog open={true} onOpenChange={mockOnOpenChange} screenId="test-screen" />
     )
 
     // Just verify the preset selector is present
@@ -109,11 +97,7 @@ describe('ScreenConfigDialog', () => {
     const user = userEvent.setup()
 
     render(
-      <ScreenConfigDialog
-        open={true}
-        onOpenChange={mockOnOpenChange}
-        screenId="test-screen"
-      />
+      <ScreenConfigDialog open={true} onOpenChange={mockOnOpenChange} screenId="test-screen" />
     )
 
     const nameInput = screen.getByPlaceholderText('Enter screen name')
@@ -123,7 +107,8 @@ describe('ScreenConfigDialog', () => {
     const saveButton = screen.getByRole('button', { name: 'Save Changes' })
     await user.click(saveButton)
 
-    expect(dashboardActions.updateScreen).toHaveBeenCalledWith('test-screen', 
+    expect(dashboardActions.updateScreen).toHaveBeenCalledWith(
+      'test-screen',
       expect.objectContaining({
         name: 'Updated Screen',
         slug: 'updated-screen',
@@ -136,11 +121,7 @@ describe('ScreenConfigDialog', () => {
     const user = userEvent.setup()
 
     render(
-      <ScreenConfigDialog
-        open={true}
-        onOpenChange={mockOnOpenChange}
-        screenId="test-screen"
-      />
+      <ScreenConfigDialog open={true} onOpenChange={mockOnOpenChange} screenId="test-screen" />
     )
 
     const duplicateButton = screen.getByRole('button', { name: /duplicate screen/i })
@@ -161,11 +142,7 @@ describe('ScreenConfigDialog', () => {
     const user = userEvent.setup()
 
     render(
-      <ScreenConfigDialog
-        open={true}
-        onOpenChange={mockOnOpenChange}
-        screenId="test-screen"
-      />
+      <ScreenConfigDialog open={true} onOpenChange={mockOnOpenChange} screenId="test-screen" />
     )
 
     const cancelButton = screen.getByRole('button', { name: 'Cancel' })
@@ -177,18 +154,14 @@ describe('ScreenConfigDialog', () => {
 
   it('should display validation constraints', () => {
     render(
-      <ScreenConfigDialog
-        open={true}
-        onOpenChange={mockOnOpenChange}
-        screenId="test-screen"
-      />
+      <ScreenConfigDialog open={true} onOpenChange={mockOnOpenChange} screenId="test-screen" />
     )
 
     // Check that the inputs have proper constraints
     const numberInputs = screen.getAllByRole('spinbutton') as HTMLInputElement[]
     const columnsInput = numberInputs[0]
     const rowsInput = numberInputs[1]
-    
+
     expect(columnsInput).toHaveAttribute('min', '1')
     expect(columnsInput).toHaveAttribute('max', '24')
     expect(rowsInput).toHaveAttribute('min', '1')
@@ -197,11 +170,7 @@ describe('ScreenConfigDialog', () => {
 
   it('should show grid preview', () => {
     render(
-      <ScreenConfigDialog
-        open={true}
-        onOpenChange={mockOnOpenChange}
-        screenId="test-screen"
-      />
+      <ScreenConfigDialog open={true} onOpenChange={mockOnOpenChange} screenId="test-screen" />
     )
 
     expect(screen.getByText('Grid Preview')).toBeInTheDocument()

--- a/src/components/__tests__/ScreenConfigDialog.test.tsx
+++ b/src/components/__tests__/ScreenConfigDialog.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event'
 import { ScreenConfigDialog } from '../ScreenConfigDialog'
 import { useDashboardStore, dashboardActions } from '../../store'
 import { createTestScreen } from '../../test-utils/screen-helpers'
+import type { DashboardState } from '../../store/types'
 
 vi.mock('../../store', () => ({
   useDashboardStore: vi.fn(),
@@ -29,10 +30,20 @@ describe('ScreenConfigDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(useDashboardStore).mockImplementation((selector) => {
-      const state = {
+      const state: DashboardState = {
+        mode: 'edit',
         screens: [testScreen],
+        currentScreenId: 'test-screen',
+        configuration: {
+          version: '1.0.0',
+          screens: [testScreen],
+          theme: 'auto',
+        },
+        gridResolution: { columns: 12, rows: 8 },
+        theme: 'auto',
+        isDirty: false,
       }
-      return selector(state)
+      return selector ? selector(state) : state
     })
     // Reset actions
     vi.mocked(dashboardActions.updateScreen).mockImplementation(() => {})

--- a/src/components/__tests__/ScreenConfigDialog.test.tsx
+++ b/src/components/__tests__/ScreenConfigDialog.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ScreenConfigDialog } from '../ScreenConfigDialog'
+import { useDashboardStore, dashboardActions } from '../../store'
+import { createTestScreen } from '../../test-utils/screen-helpers'
+
+vi.mock('../../store', () => ({
+  useDashboardStore: vi.fn(),
+  dashboardActions: {
+    updateScreen: vi.fn(),
+    addScreen: vi.fn(),
+  },
+}))
+
+describe('ScreenConfigDialog', () => {
+  const mockOnOpenChange = vi.fn()
+
+  const testScreen = createTestScreen({
+    id: 'test-screen',
+    name: 'Test Screen',
+    slug: 'test-screen',
+    grid: {
+      resolution: { columns: 12, rows: 8 },
+      items: [],
+    },
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useDashboardStore).mockImplementation((selector: any) => {
+      const state = {
+        screens: [testScreen],
+      }
+      return selector(state)
+    })
+    // Reset actions
+    vi.mocked(dashboardActions.updateScreen).mockImplementation(() => {})
+    vi.mocked(dashboardActions.addScreen).mockImplementation(() => {})
+  })
+
+  it('should not render when screenId is not provided', () => {
+    const { container } = render(
+      <ScreenConfigDialog open={true} onOpenChange={mockOnOpenChange} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('should render dialog when open with valid screenId', () => {
+    render(
+      <ScreenConfigDialog
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        screenId="test-screen"
+      />
+    )
+
+    expect(screen.getByText('Configure Screen')).toBeInTheDocument()
+    expect(screen.getByText('Customize the screen settings including name and grid resolution')).toBeInTheDocument()
+  })
+
+  it('should display current screen values', () => {
+    render(
+      <ScreenConfigDialog
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        screenId="test-screen"
+      />
+    )
+
+    const nameInput = screen.getByPlaceholderText('Enter screen name') as HTMLInputElement
+    expect(nameInput.value).toBe('Test Screen')
+
+    // Find inputs by their type and value since Radix UI doesn't properly associate labels
+    const numberInputs = screen.getAllByRole('spinbutton') as HTMLInputElement[]
+    const columnsInput = numberInputs.find(input => input.value === '12')
+    const rowsInput = numberInputs.find(input => input.value === '8')
+    
+    expect(columnsInput).toBeDefined()
+    expect(rowsInput).toBeDefined()
+  })
+
+  it('should display preset selector', () => {
+    render(
+      <ScreenConfigDialog
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        screenId="test-screen"
+      />
+    )
+
+    // Just verify the preset selector is present
+    expect(screen.getByText('Choose a preset')).toBeInTheDocument()
+    expect(screen.getByRole('combobox')).toBeInTheDocument()
+  })
+
+  it('should save name changes when save button is clicked', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ScreenConfigDialog
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        screenId="test-screen"
+      />
+    )
+
+    const nameInput = screen.getByPlaceholderText('Enter screen name')
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Updated Screen')
+
+    const saveButton = screen.getByRole('button', { name: 'Save Changes' })
+    await user.click(saveButton)
+
+    expect(dashboardActions.updateScreen).toHaveBeenCalledWith('test-screen', 
+      expect.objectContaining({
+        name: 'Updated Screen',
+        slug: 'updated-screen',
+      })
+    )
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('should duplicate screen when duplicate button is clicked', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ScreenConfigDialog
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        screenId="test-screen"
+      />
+    )
+
+    const duplicateButton = screen.getByRole('button', { name: /duplicate screen/i })
+    await user.click(duplicateButton)
+
+    expect(dashboardActions.addScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Test Screen (Copy)',
+        slug: 'test-screen-copy',
+        children: undefined,
+      }),
+      undefined
+    )
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('should cancel without saving when cancel button is clicked', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ScreenConfigDialog
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        screenId="test-screen"
+      />
+    )
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' })
+    await user.click(cancelButton)
+
+    expect(dashboardActions.updateScreen).not.toHaveBeenCalled()
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('should display validation constraints', () => {
+    render(
+      <ScreenConfigDialog
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        screenId="test-screen"
+      />
+    )
+
+    // Check that the inputs have proper constraints
+    const numberInputs = screen.getAllByRole('spinbutton') as HTMLInputElement[]
+    const columnsInput = numberInputs[0]
+    const rowsInput = numberInputs[1]
+    
+    expect(columnsInput).toHaveAttribute('min', '1')
+    expect(columnsInput).toHaveAttribute('max', '24')
+    expect(rowsInput).toHaveAttribute('min', '1')
+    expect(rowsInput).toHaveAttribute('max', '20')
+  })
+
+  it('should show grid preview', () => {
+    render(
+      <ScreenConfigDialog
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        screenId="test-screen"
+      />
+    )
+
+    expect(screen.getByText('Grid Preview')).toBeInTheDocument()
+    // The grid preview should render 96 cells (12 columns × 8 rows)
+    const gridCells = screen.getByText('Grid Preview').parentElement?.querySelectorAll('div > div')
+    expect(gridCells?.length).toBeGreaterThan(0)
+  })
+})

--- a/src/components/__tests__/ScreenConfigDialog.test.tsx
+++ b/src/components/__tests__/ScreenConfigDialog.test.tsx
@@ -28,7 +28,7 @@ describe('ScreenConfigDialog', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(useDashboardStore).mockImplementation((selector: any) => {
+    vi.mocked(useDashboardStore).mockImplementation((selector) => {
       const state = {
         screens: [testScreen],
       }

--- a/src/components/__tests__/ViewTabs.test.tsx
+++ b/src/components/__tests__/ViewTabs.test.tsx
@@ -184,7 +184,12 @@ describe('ViewTabs', () => {
 
       // Find the remove button within the Living Room tab
       const livingRoomTab = screen.getByRole('tab', { name: /Living Room/ })
-      const removeButton = livingRoomTab.querySelector('[style*="cursor: pointer"]')
+      // Look for the Box containing Cross2Icon (the remove button)
+      const removeButtons = livingRoomTab.querySelectorAll('[style*="cursor: pointer"]')
+      // The Cross2Icon button will be the one containing an svg with specific path for Cross2Icon
+      const removeButton = Array.from(removeButtons).find(btn => 
+        btn.querySelector('svg path[d*="M11.7816"]') // Part of Cross2Icon path
+      )
 
       await user.click(removeButton!)
 
@@ -222,7 +227,10 @@ describe('ViewTabs', () => {
 
       // First remove the kitchen screen
       const kitchenTab = screen.getByRole('tab', { name: /Kitchen/ })
-      const kitchenRemoveButton = kitchenTab.querySelector('[style*="cursor: pointer"]')
+      const kitchenRemoveButtons = kitchenTab.querySelectorAll('[style*="cursor: pointer"]')
+      const kitchenRemoveButton = Array.from(kitchenRemoveButtons).find(btn => 
+        btn.querySelector('svg path[d*="M11.7816"]') // Part of Cross2Icon path
+      )
       await user.click(kitchenRemoveButton!)
 
       // Wait for first removal
@@ -230,12 +238,15 @@ describe('ViewTabs', () => {
         expect(dashboardStore.state.screens.length).toBe(1)
       })
 
-      // Now remove the last screen
+      // Now try to find remove button on the last screen
       const livingRoomTab = screen.getByRole('tab', { name: /Living Room/ })
-      const livingRoomRemoveButton = livingRoomTab.querySelector('[style*="cursor: pointer"]')
+      const livingRoomButtons = livingRoomTab.querySelectorAll('[style*="cursor: pointer"]')
+      const livingRoomRemoveButton = Array.from(livingRoomButtons).find(btn => 
+        btn.querySelector('svg path[d*="M11.7816"]') // Part of Cross2Icon path
+      )
 
       // Since there's only one screen left, there should be no remove button
-      expect(livingRoomRemoveButton).toBeNull()
+      expect(livingRoomRemoveButton).toBeUndefined()
 
       // This test actually verifies that we DON'T allow removing the last screen
       // The UI should not show a remove button when there's only one screen left

--- a/src/components/__tests__/ViewTabs.test.tsx
+++ b/src/components/__tests__/ViewTabs.test.tsx
@@ -187,8 +187,8 @@ describe('ViewTabs', () => {
       // Look for the Box containing Cross2Icon (the remove button)
       const removeButtons = livingRoomTab.querySelectorAll('[style*="cursor: pointer"]')
       // The Cross2Icon button will be the one containing an svg with specific path for Cross2Icon
-      const removeButton = Array.from(removeButtons).find(btn => 
-        btn.querySelector('svg path[d*="M11.7816"]') // Part of Cross2Icon path
+      const removeButton = Array.from(removeButtons).find(
+        (btn) => btn.querySelector('svg path[d*="M11.7816"]') // Part of Cross2Icon path
       )
 
       await user.click(removeButton!)
@@ -228,8 +228,8 @@ describe('ViewTabs', () => {
       // First remove the kitchen screen
       const kitchenTab = screen.getByRole('tab', { name: /Kitchen/ })
       const kitchenRemoveButtons = kitchenTab.querySelectorAll('[style*="cursor: pointer"]')
-      const kitchenRemoveButton = Array.from(kitchenRemoveButtons).find(btn => 
-        btn.querySelector('svg path[d*="M11.7816"]') // Part of Cross2Icon path
+      const kitchenRemoveButton = Array.from(kitchenRemoveButtons).find(
+        (btn) => btn.querySelector('svg path[d*="M11.7816"]') // Part of Cross2Icon path
       )
       await user.click(kitchenRemoveButton!)
 
@@ -241,8 +241,8 @@ describe('ViewTabs', () => {
       // Now try to find remove button on the last screen
       const livingRoomTab = screen.getByRole('tab', { name: /Living Room/ })
       const livingRoomButtons = livingRoomTab.querySelectorAll('[style*="cursor: pointer"]')
-      const livingRoomRemoveButton = Array.from(livingRoomButtons).find(btn => 
-        btn.querySelector('svg path[d*="M11.7816"]') // Part of Cross2Icon path
+      const livingRoomRemoveButton = Array.from(livingRoomButtons).find(
+        (btn) => btn.querySelector('svg path[d*="M11.7816"]') // Part of Cross2Icon path
       )
 
       // Since there's only one screen left, there should be no remove button


### PR DESCRIPTION
Closes #41

## Summary
- Created ScreenConfigDialog component for configuring screen settings
- Added grid resolution configuration with presets and custom values
- Implemented screen name editing with automatic slug generation
- Added screen duplication functionality
- Integrated configuration dialog with ViewTabs component

## Features Implemented
- ✅ UI for setting grid resolution (columns x rows) per screen
- ✅ Screen name/title editing functionality
- ✅ Screen duplication functionality
- ✅ Default grid resolution settings (via presets)
- ✅ Preview of grid with current resolution
- ✅ Responsive configuration panel
- ✅ Input validation for grid dimensions (1-24 columns, 1-20 rows)

## Not Yet Implemented
- Screen tree reordering (drag to reorder/nest)
- Screen visibility toggle
- Default grid resolution settings persistence

## Testing
- Added comprehensive test suite for ScreenConfigDialog
- All tests passing
- TypeScript and linting checks pass