### PR TITLE
feat: implement YAML export/import functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "@tanstack/react-router-devtools": "^1.122.0",
     "@tanstack/react-start": "^1.122.1",
     "@tanstack/react-store": "^0.7.1",
+    "@types/js-yaml": "^4.0.9",
+    "js-yaml": "^4.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-grid-layout": "^1.5.2",

--- a/src/components/ImportPreviewDialog.tsx
+++ b/src/components/ImportPreviewDialog.tsx
@@ -1,0 +1,145 @@
+import { Dialog, Button, Text, Flex, Box, ScrollArea, Badge, Callout } from '@radix-ui/themes'
+import { InfoCircledIcon, CheckCircledIcon } from '@radix-ui/react-icons'
+import type { DashboardConfig } from '../store/types'
+
+interface ImportPreviewDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  config: DashboardConfig | null
+  versionMessage?: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ImportPreviewDialog({
+  open,
+  onOpenChange,
+  config,
+  versionMessage,
+  onConfirm,
+  onCancel,
+}: ImportPreviewDialogProps) {
+  if (!config) return null
+
+  const totalScreens = countScreens(config.screens)
+  const totalGridItems = countGridItems(config.screens)
+
+  function countScreens(screens: DashboardConfig['screens']): number {
+    return screens.reduce((count, screen) => {
+      return count + 1 + (screen.children ? countScreens(screen.children) : 0)
+    }, 0)
+  }
+
+  function countGridItems(screens: DashboardConfig['screens']): number {
+    return screens.reduce((count, screen) => {
+      const itemCount = screen.grid?.items?.length || 0
+      const childCount = screen.children ? countGridItems(screen.children) : 0
+      return count + itemCount + childCount
+    }, 0)
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content maxWidth="600px">
+        <Dialog.Title>Import Preview</Dialog.Title>
+        <Dialog.Description>
+          Review the configuration before importing. Your current configuration will be backed up
+          automatically.
+        </Dialog.Description>
+
+        {versionMessage && (
+          <Callout.Root color="blue" mt="3">
+            <Callout.Icon>
+              <InfoCircledIcon />
+            </Callout.Icon>
+            <Callout.Text>{versionMessage}</Callout.Text>
+          </Callout.Root>
+        )}
+
+        <Box mt="4">
+          <Flex direction="column" gap="3">
+            <Flex align="center" gap="2">
+              <Text size="2" weight="medium">
+                Version:
+              </Text>
+              <Badge>{config.version}</Badge>
+            </Flex>
+
+            <Flex align="center" gap="2">
+              <Text size="2" weight="medium">
+                Theme:
+              </Text>
+              <Badge variant="outline">{config.theme || 'auto'}</Badge>
+            </Flex>
+
+            <Flex align="center" gap="2">
+              <Text size="2" weight="medium">
+                Total Screens:
+              </Text>
+              <Badge color="blue">{totalScreens}</Badge>
+            </Flex>
+
+            <Flex align="center" gap="2">
+              <Text size="2" weight="medium">
+                Total Grid Items:
+              </Text>
+              <Badge color="green">{totalGridItems}</Badge>
+            </Flex>
+          </Flex>
+        </Box>
+
+        <Box mt="4">
+          <Text size="2" weight="medium" mb="2">
+            Screen Structure:
+          </Text>
+          <ScrollArea style={{ maxHeight: '200px' }}>
+            <Box
+              p="3"
+              style={{
+                backgroundColor: 'var(--gray-a2)',
+                borderRadius: 'var(--radius-2)',
+              }}
+            >
+              {renderScreenTree(config.screens)}
+            </Box>
+          </ScrollArea>
+        </Box>
+
+        <Flex gap="3" mt="4" justify="end">
+          <Dialog.Close>
+            <Button variant="soft" color="gray" onClick={onCancel}>
+              Cancel
+            </Button>
+          </Dialog.Close>
+          <Button variant="solid" onClick={onConfirm}>
+            <CheckCircledIcon />
+            Import Configuration
+          </Button>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  )
+}
+
+function renderScreenTree(screens: DashboardConfig['screens'], level = 0): React.ReactElement {
+  return (
+    <>
+      {screens.map((screen) => (
+        <Box key={screen.id} ml={level > 0 ? '4' : '0'}>
+          <Flex align="center" gap="2" mb="1">
+            <Text size="2">
+              {level > 0 && '└─ '}
+              {screen.name}
+            </Text>
+            {screen.grid?.items && screen.grid.items.length > 0 && (
+              <Badge size="1" variant="soft">
+                {screen.grid.items.length} items
+              </Badge>
+            )}
+          </Flex>
+          {screen.children && renderScreenTree(screen.children, level + 1)}
+        </Box>
+      ))}
+    </>
+  )
+}

--- a/src/components/__tests__/ConfigurationMenu.test.tsx
+++ b/src/components/__tests__/ConfigurationMenu.test.tsx
@@ -5,10 +5,22 @@ import { Theme } from '@radix-ui/themes'
 import { ConfigurationMenu } from '../ConfigurationMenu'
 import * as persistence from '../../store/persistence'
 
+// Mock ImportPreviewDialog
+vi.mock('../ImportPreviewDialog', () => ({
+  ImportPreviewDialog: ({ open, onConfirm }: any) => 
+    open ? (
+      <div>
+        <button onClick={onConfirm}>Import</button>
+      </div>
+    ) : null,
+}))
+
 // Mock persistence functions
 vi.mock('../../store/persistence', () => ({
   exportConfigurationToFile: vi.fn(),
   exportConfigurationAsYAML: vi.fn().mockReturnValue('mock yaml'),
+  exportConfigurationToYAMLFile: vi.fn(),
+  copyYAMLToClipboard: vi.fn(),
   importConfigurationFromFile: vi.fn(),
   clearDashboardConfig: vi.fn(),
   getStorageInfo: vi.fn().mockReturnValue({
@@ -16,6 +28,8 @@ vi.mock('../../store/persistence', () => ({
     available: true,
     percentage: 10,
   }),
+  restoreConfigurationFromBackup: vi.fn(),
+  parseConfigurationFromFile: vi.fn(),
 }))
 
 // Mock window.location.reload
@@ -72,36 +86,37 @@ describe('ConfigurationMenu', () => {
 
   it('should export configuration as YAML', async () => {
     const user = userEvent.setup()
-    const originalCreateElement = document.createElement.bind(document)
-    let mockLink: HTMLAnchorElement | undefined
-
-    vi.spyOn(document, 'createElement').mockImplementation((tagName) => {
-      if (tagName === 'a') {
-        mockLink = originalCreateElement('a')
-        mockLink.click = vi.fn()
-        return mockLink
-      }
-      return originalCreateElement(tagName)
-    })
-
     renderWithTheme(<ConfigurationMenu />)
 
     await user.click(screen.getByRole('button', { name: /configuration/i }))
-    await user.click(screen.getByText('Export as YAML'))
+    await user.click(screen.getByText('Download as YAML'))
 
-    expect(persistence.exportConfigurationAsYAML).toHaveBeenCalled()
-    expect(mockLink!.download).toMatch(/^liebe-.*\.yaml$/)
-    expect(mockLink!.click).toHaveBeenCalled()
+    expect(persistence.exportConfigurationToYAMLFile).toHaveBeenCalled()
+  })
+
+  it('should copy YAML to clipboard', async () => {
+    const user = userEvent.setup()
+    vi.mocked(persistence.copyYAMLToClipboard).mockResolvedValueOnce(undefined)
+    renderWithTheme(<ConfigurationMenu />)
+
+    await user.click(screen.getByRole('button', { name: /configuration/i }))
+    await user.click(screen.getByText('Copy YAML to Clipboard'))
+
+    expect(persistence.copyYAMLToClipboard).toHaveBeenCalled()
   })
 
   it('should handle file import', async () => {
     const user = userEvent.setup()
+    vi.mocked(persistence.parseConfigurationFromFile).mockResolvedValueOnce({
+      config: { version: '1.0.0', screens: [], theme: 'auto' },
+      versionMessage: undefined,
+    })
     vi.mocked(persistence.importConfigurationFromFile).mockResolvedValueOnce(undefined)
 
     renderWithTheme(<ConfigurationMenu />)
 
     await user.click(screen.getByRole('button', { name: /configuration/i }))
-    await user.click(screen.getByText('Import from File'))
+    await user.click(screen.getByText('Import from File (JSON/YAML)'))
 
     // File input should exist but be hidden
     const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement
@@ -119,20 +134,28 @@ describe('ConfigurationMenu', () => {
     })
 
     await waitFor(() => {
+      expect(persistence.parseConfigurationFromFile).toHaveBeenCalledWith(file)
+    })
+
+    // Simulate clicking confirm in the preview dialog
+    const confirmButton = await screen.findByRole('button', { name: 'Import' })
+    await user.click(confirmButton)
+
+    await waitFor(() => {
       expect(persistence.importConfigurationFromFile).toHaveBeenCalledWith(file)
     })
   })
 
   it('should show import error', async () => {
     const user = userEvent.setup()
-    vi.mocked(persistence.importConfigurationFromFile).mockRejectedValueOnce(
+    vi.mocked(persistence.parseConfigurationFromFile).mockRejectedValueOnce(
       new Error('Invalid file format')
     )
 
     renderWithTheme(<ConfigurationMenu />)
 
     await user.click(screen.getByRole('button', { name: /configuration/i }))
-    await user.click(screen.getByText('Import from File'))
+    await user.click(screen.getByText('Import from File (JSON/YAML)'))
 
     const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement
     const file = new File(['invalid'], 'config.json', { type: 'application/json' })
@@ -165,12 +188,16 @@ describe('ConfigurationMenu', () => {
       available: false,
       percentage: 95,
     })
+    vi.mocked(persistence.parseConfigurationFromFile).mockResolvedValueOnce({
+      config: { version: '1.0.0', screens: [], theme: 'auto' },
+      versionMessage: undefined,
+    })
     vi.mocked(persistence.importConfigurationFromFile).mockResolvedValueOnce(undefined)
 
     renderWithTheme(<ConfigurationMenu />)
 
     await user.click(screen.getByRole('button', { name: /configuration/i }))
-    await user.click(screen.getByText('Import from File'))
+    await user.click(screen.getByText('Import from File (JSON/YAML)'))
 
     const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement
     const file = new File(['{}'], 'config.json', { type: 'application/json' })
@@ -181,6 +208,14 @@ describe('ConfigurationMenu', () => {
         files: [file],
       },
     })
+
+    await waitFor(() => {
+      expect(persistence.parseConfigurationFromFile).toHaveBeenCalledWith(file)
+    })
+
+    // Simulate clicking confirm in the preview dialog
+    const confirmButton = await screen.findByRole('button', { name: 'Import' })
+    await user.click(confirmButton)
 
     await waitFor(() => {
       expect(screen.getByText(/Storage is nearly full/)).toBeInTheDocument()

--- a/src/components/__tests__/ConfigurationMenu.test.tsx
+++ b/src/components/__tests__/ConfigurationMenu.test.tsx
@@ -7,7 +7,7 @@ import * as persistence from '../../store/persistence'
 
 // Mock ImportPreviewDialog
 vi.mock('../ImportPreviewDialog', () => ({
-  ImportPreviewDialog: ({ open, onConfirm }: any) => 
+  ImportPreviewDialog: ({ open, onConfirm }: { open: boolean; onConfirm: () => void }) =>
     open ? (
       <div>
         <button onClick={onConfirm}>Import</button>

--- a/src/components/__tests__/ModeToggle.test.tsx
+++ b/src/components/__tests__/ModeToggle.test.tsx
@@ -5,6 +5,11 @@ import { ModeToggle } from '../ModeToggle'
 import { dashboardStore, dashboardActions } from '../../store/dashboardStore'
 import { Theme } from '@radix-ui/themes'
 
+// Mock the persistence module to avoid async import issues in tests
+vi.mock('../../store/persistence', () => ({
+  saveDashboardMode: vi.fn(),
+}))
+
 describe('ModeToggle', () => {
   beforeEach(() => {
     // Reset to view mode before each test

--- a/src/store/__tests__/persistence.test.ts
+++ b/src/store/__tests__/persistence.test.ts
@@ -205,7 +205,7 @@ describe('persistence', () => {
       const file = new File(['invalid json'], 'config.json', { type: 'application/json' })
 
       await expect(importConfigurationFromFile(file)).rejects.toThrow(
-        'Failed to import configuration: Invalid file format'
+        'Failed to parse JSON:' // Error message now comes directly from parseConfigurationFromFile
       )
     })
 
@@ -216,7 +216,7 @@ describe('persistence', () => {
       })
 
       await expect(importConfigurationFromFile(file)).rejects.toThrow(
-        'Failed to import configuration: Invalid file format'
+        'Failed to import configuration: Invalid configuration format'
       )
     })
   })
@@ -227,11 +227,12 @@ describe('persistence', () => {
 
       const yaml = exportConfigurationAsYAML()
 
-      expect(yaml).toContain('# Liebe Dashboard Configuration')
-      expect(yaml).toContain('version: "1.0.0"')
+      // js-yaml output format differs from manual format
+      expect(yaml).toContain('Liebe Dashboard Configuration')
+      expect(yaml).toContain('version: 1.0.0') // js-yaml doesn't quote numbers
       expect(yaml).toContain('theme: auto')
       expect(yaml).toContain('screens:')
-      expect(yaml).toContain('name: "Test Screen"')
+      expect(yaml).toContain('name: Test Screen') // js-yaml doesn't quote unless necessary
     })
 
     it('should include items in YAML', () => {
@@ -273,9 +274,9 @@ describe('persistence', () => {
 
       expect(yaml).toContain('items:')
       expect(yaml).toContain('type: entity')
-      expect(yaml).toContain('entityId: "light.test"')
+      expect(yaml).toContain('entityId: light.test') // js-yaml doesn't quote unless necessary
       expect(yaml).toContain('type: separator')
-      expect(yaml).toContain('title: "Living Room"')
+      expect(yaml).toContain('title: Living Room') // js-yaml doesn't quote unless necessary
     })
   })
 


### PR DESCRIPTION
Closes #42

## Summary
- Added comprehensive YAML export/import functionality for dashboard configurations
- Users can now export their dashboards as YAML files for easy sharing and backup
- Import includes a preview dialog showing configuration details before applying changes

## Implementation Details
- **YAML Library**: Integrated `js-yaml` for proper YAML parsing and generation
- **Export Options**: 
  - Download as YAML file
  - Copy YAML to clipboard
  - Export as JSON (existing functionality)
- **Import Features**:
  - Support for .yaml, .yml, and .json files
  - Preview dialog showing configuration summary before import
  - Automatic backup of current configuration
  - Version compatibility checking
  - Detailed error messages for invalid files
- **UI Enhancements**:
  - Updated ConfigurationMenu with new export/import options
  - Created ImportPreviewDialog component using Radix UI
  - Added success/error notifications

## Testing
- [x] Tested YAML export functionality - generates valid YAML
- [x] Tested copy to clipboard - works correctly
- [x] Tested YAML import - parses and loads configurations
- [x] Tested import preview - shows accurate configuration summary
- [x] Tested version compatibility - shows warnings for older versions
- [x] Tested backup/restore functionality
- [x] TypeScript checks pass
- [x] Linting passes