### PR TITLE
feat: implement light controls with brightness slider

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-icons": "^1.3.2",
+    "@radix-ui/react-slider": "^1.3.5",
     "@radix-ui/react-switch": "^1.2.5",
     "@radix-ui/react-tabs": "^1.1.12",
     "@radix-ui/react-tooltip": "^1.2.7",

--- a/src/components/GridView.tsx
+++ b/src/components/GridView.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Box } from '@radix-ui/themes'
 import { ButtonCard } from './ButtonCard'
+import { LightCard } from './LightCard'
 import { Separator } from './Separator'
 import { DeleteConfirmDialog } from './DeleteConfirmDialog'
 import { GridLayoutSection } from './GridLayoutSection'
@@ -12,6 +13,51 @@ interface GridViewProps {
   screenId: string
   items: GridItem[]
   resolution: { columns: number; rows: number }
+}
+
+// Component to determine which card type to render based on entity
+function EntityCard({
+  entityId,
+  size = 'medium',
+  onDelete,
+  isSelected,
+  onSelect,
+}: {
+  entityId: string
+  size?: 'small' | 'medium' | 'large'
+  onDelete?: () => void
+  isSelected?: boolean
+  onSelect?: (selected: boolean) => void
+}) {
+  // We only need the entityId to determine the domain
+  // The actual entity data will be fetched by the card component
+
+  // Determine entity domain
+  const domain = entityId.split('.')[0]
+
+  // Use LightCard for light entities, ButtonCard for others
+  if (domain === 'light') {
+    return (
+      <LightCard
+        entityId={entityId}
+        size={size}
+        onDelete={onDelete}
+        isSelected={isSelected}
+        onSelect={onSelect}
+      />
+    )
+  }
+
+  // Default to ButtonCard for switches, input_booleans, and other entities
+  return (
+    <ButtonCard
+      entityId={entityId}
+      size={size}
+      onDelete={onDelete}
+      isSelected={isSelected}
+      onSelect={onSelect}
+    />
+  )
 }
 
 export function GridView({ screenId, items, resolution }: GridViewProps) {
@@ -109,7 +155,7 @@ export function GridView({ screenId, items, resolution }: GridViewProps) {
             )
           } else {
             return (
-              <ButtonCard
+              <EntityCard
                 entityId={item.entityId!}
                 size="medium"
                 onDelete={isEditMode ? () => handleDeleteItem(item.id) : undefined}

--- a/src/components/LightCard.css
+++ b/src/components/LightCard.css
@@ -1,0 +1,115 @@
+/* Light Card styles */
+.light-card {
+  user-select: none;
+}
+
+/* Toggle area hover effect */
+.light-toggle-area:hover {
+  background-color: var(--gray-a3);
+}
+
+/* Slider styles */
+.SliderRoot {
+  position: relative;
+  display: flex;
+  align-items: center;
+  user-select: none;
+  touch-action: none;
+  height: 20px;
+  min-width: 100px;
+}
+
+.SliderTrack {
+  background-color: var(--gray-a5);
+  position: relative;
+  flex-grow: 1;
+  border-radius: 9999px;
+  height: 6px;
+}
+
+.SliderRange {
+  position: absolute;
+  background-color: var(--amber-9);
+  border-radius: 9999px;
+  height: 100%;
+}
+
+.SliderThumb {
+  display: block;
+  width: 20px;
+  height: 20px;
+  background-color: white;
+  box-shadow: 0 2px 10px var(--gray-a7);
+  border-radius: 10px;
+  cursor: grab;
+  outline: none;
+}
+
+.SliderThumb:hover {
+  background-color: var(--gray-1);
+  box-shadow: 0 2px 10px var(--gray-a8);
+}
+
+.SliderThumb:focus {
+  box-shadow: 0 0 0 3px var(--amber-a5);
+}
+
+.SliderThumb:active {
+  cursor: grabbing;
+}
+
+/* Animation for loading state */
+@keyframes pulse-border {
+  0% {
+    border-color: var(--amber-6);
+  }
+  50% {
+    border-color: var(--amber-8);
+  }
+  100% {
+    border-color: var(--amber-6);
+  }
+}
+
+@keyframes pulse-border-error {
+  0% {
+    border-color: var(--red-6);
+  }
+  50% {
+    border-color: var(--red-8);
+  }
+  100% {
+    border-color: var(--red-6);
+  }
+}
+
+/* Drag handle for edit mode */
+.grid-item-drag-handle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 30px;
+  cursor: move;
+  background: linear-gradient(to bottom, var(--gray-a3) 0%, transparent 100%);
+  border-radius: var(--radius-2) var(--radius-2) 0 0;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.light-card:hover .grid-item-drag-handle {
+  opacity: 1;
+}
+
+.grid-item-drag-handle::before {
+  content: '';
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 30px;
+  height: 4px;
+  background: var(--gray-a6);
+  border-radius: 2px;
+  box-shadow: 0 6px 0 var(--gray-a6);
+}

--- a/src/components/LightCard.tsx
+++ b/src/components/LightCard.tsx
@@ -30,6 +30,8 @@ interface LightAttributes {
   effect_list?: string[]
   effect?: string
   supported_features?: number
+  supported_color_modes?: string[]
+  color_mode?: string
 }
 
 function LightCardComponent({
@@ -71,8 +73,19 @@ function LightCardComponent({
 
   const lightAttributes = entity?.attributes as LightAttributes | undefined
   const supportsBrightness = useMemo(() => {
+    // Modern Home Assistant uses supported_color_modes
+    if (lightAttributes?.supported_color_modes) {
+      return lightAttributes.supported_color_modes.includes('brightness') ||
+             lightAttributes.supported_color_modes.includes('color_temp') ||
+             lightAttributes.supported_color_modes.includes('hs') ||
+             lightAttributes.supported_color_modes.includes('xy') ||
+             lightAttributes.supported_color_modes.includes('rgb') ||
+             lightAttributes.supported_color_modes.includes('rgbw') ||
+             lightAttributes.supported_color_modes.includes('rgbww')
+    }
+    // Fallback to old supported_features check
     return (lightAttributes?.supported_features ?? 0) & SUPPORT_BRIGHTNESS
-  }, [lightAttributes?.supported_features])
+  }, [lightAttributes?.supported_features, lightAttributes?.supported_color_modes])
 
   // These will be used for color picker implementation
   // const supportsColor = useMemo(() => {

--- a/src/components/LightCard.tsx
+++ b/src/components/LightCard.tsx
@@ -1,0 +1,339 @@
+import { Card, Flex, Text, Spinner, Box, IconButton } from '@radix-ui/themes'
+import * as Slider from '@radix-ui/react-slider'
+import { SunIcon, Cross2Icon } from '@radix-ui/react-icons'
+import { useEntity, useServiceCall } from '~/hooks'
+import { memo, useState, useCallback, useMemo } from 'react'
+import { useDashboardStore } from '~/store'
+import './LightCard.css'
+
+interface LightCardProps {
+  entityId: string
+  size?: 'small' | 'medium' | 'large'
+  onDelete?: () => void
+  isSelected?: boolean
+  onSelect?: (selected: boolean) => void
+}
+
+// Light supported features bit flags from Home Assistant
+const SUPPORT_BRIGHTNESS = 1
+// const SUPPORT_COLOR_TEMP = 2
+// const SUPPORT_COLOR = 16
+
+interface LightAttributes {
+  brightness?: number
+  color_temp?: number
+  rgb_color?: [number, number, number]
+  hs_color?: [number, number]
+  xy_color?: [number, number]
+  min_mireds?: number
+  max_mireds?: number
+  effect_list?: string[]
+  effect?: string
+  supported_features?: number
+}
+
+function LightCardComponent({
+  entityId,
+  size = 'medium',
+  onDelete,
+  isSelected = false,
+  onSelect,
+}: LightCardProps) {
+  const { entity, isConnected, isStale } = useEntity(entityId)
+  const { loading: isLoading, error, turnOn, turnOff, clearError } = useServiceCall()
+  const mode = useDashboardStore((state) => state.mode)
+  const isEditMode = mode === 'edit'
+
+  // Local state for slider while dragging
+  const [localBrightness, setLocalBrightness] = useState<number | null>(null)
+  const [isDragging, setIsDragging] = useState(false)
+
+  const handleBrightnessChange = useCallback((value: number[]) => {
+    setLocalBrightness(value[0])
+  }, [])
+
+  const handleBrightnessCommit = useCallback(
+    async (value: number[]) => {
+      setIsDragging(false)
+      const brightness = Math.round((value[0] / 100) * 255)
+
+      // If setting to 0, turn off the light
+      if (brightness === 0) {
+        await turnOff(entityId)
+      } else {
+        await turnOn(entityId, { brightness })
+      }
+
+      setLocalBrightness(null)
+    },
+    [entityId, turnOn, turnOff]
+  )
+
+  const lightAttributes = entity?.attributes as LightAttributes | undefined
+  const supportsBrightness = useMemo(() => {
+    return (lightAttributes?.supported_features ?? 0) & SUPPORT_BRIGHTNESS
+  }, [lightAttributes?.supported_features])
+
+  // These will be used for color picker implementation
+  // const supportsColor = useMemo(() => {
+  //   return (lightAttributes?.supported_features ?? 0) & SUPPORT_COLOR
+  // }, [lightAttributes?.supported_features])
+
+  // const supportsColorTemp = useMemo(() => {
+  //   return (lightAttributes?.supported_features ?? 0) & SUPPORT_COLOR_TEMP
+  // }, [lightAttributes?.supported_features])
+
+  // Get current brightness (0-255 scale from HA, convert to 0-100 for UI)
+  const currentBrightness = useMemo(() => {
+    if (!entity || entity.state === 'off') return 0
+    const brightness = lightAttributes?.brightness ?? 255
+    return Math.round((brightness / 255) * 100)
+  }, [entity, lightAttributes?.brightness])
+
+  const displayBrightness =
+    isDragging && localBrightness !== null ? localBrightness : currentBrightness
+
+  if (!entity || !isConnected) {
+    return (
+      <Card variant="classic" style={{ opacity: 0.5 }}>
+        <Flex p="3" align="center" justify="center">
+          <Text size="2" color="gray">
+            {!isConnected ? 'Disconnected' : 'Entity not found'}
+          </Text>
+        </Flex>
+      </Card>
+    )
+  }
+
+  const cardSize = {
+    small: { p: '2', iconSize: '16', fontSize: '1' },
+    medium: { p: '3', iconSize: '20', fontSize: '2' },
+    large: { p: '4', iconSize: '24', fontSize: '3' },
+  }[size]
+
+  // Handle unavailable state
+  const isUnavailable = entity.state === 'unavailable'
+  if (isUnavailable) {
+    return (
+      <Card variant="classic" style={{ opacity: 0.6, borderStyle: 'dotted' }}>
+        <Flex p={cardSize.p} direction="column" align="center" justify="center" gap="2">
+          <Box style={{ color: 'var(--gray-9)', opacity: 0.5 }}>
+            <SunIcon width={cardSize.iconSize} height={cardSize.iconSize} />
+          </Box>
+          <Text size={cardSize.fontSize as '1' | '2' | '3'} color="gray" align="center">
+            {entity.attributes.friendly_name || entity.entity_id}
+          </Text>
+          <Text size="1" color="gray" weight="medium">
+            UNAVAILABLE
+          </Text>
+        </Flex>
+      </Card>
+    )
+  }
+
+  const friendlyName = entity.attributes.friendly_name || entity.entity_id
+  const isOn = entity.state === 'on'
+
+  const handleToggle = async () => {
+    if (isLoading || isDragging) return
+
+    // Clear any previous errors
+    if (error) {
+      clearError()
+    }
+
+    if (isOn) {
+      await turnOff(entity.entity_id)
+    } else {
+      await turnOn(entity.entity_id)
+    }
+  }
+
+  return (
+    <Card
+      variant="classic"
+      className="light-card"
+      style={{
+        cursor: isEditMode ? 'move' : isLoading ? 'wait' : 'pointer',
+        backgroundColor: isSelected ? 'var(--blue-3)' : isOn ? 'var(--amber-3)' : undefined,
+        borderColor: isSelected
+          ? 'var(--blue-6)'
+          : error
+            ? 'var(--red-6)'
+            : isStale
+              ? 'var(--orange-6)'
+              : isOn
+                ? 'var(--amber-6)'
+                : undefined,
+        borderWidth: isSelected || error || isOn || isStale ? '2px' : '1px',
+        borderStyle: isStale ? 'dashed' : 'solid',
+        transition: 'all 0.2s ease',
+        transform: isLoading ? 'scale(0.98)' : undefined,
+        animation: isLoading
+          ? (error ? 'pulse-border-error' : 'pulse-border') + ' 1.5s ease-in-out infinite'
+          : undefined,
+        opacity: isStale ? 0.8 : 1,
+        position: 'relative',
+      }}
+      onClick={isEditMode && onSelect ? () => onSelect(!isSelected) : undefined}
+      title={error || (isStale ? 'Entity data may be outdated' : undefined)}
+    >
+      {/* Drag handle in edit mode */}
+      {isEditMode && <div className="grid-item-drag-handle" />}
+
+      {/* Delete button in edit mode */}
+      {isEditMode && onDelete && (
+        <IconButton
+          size="1"
+          variant="soft"
+          color="red"
+          style={{
+            position: 'absolute',
+            top: '4px',
+            right: '4px',
+            opacity: isSelected ? 1 : 0.7,
+            transition: 'opacity 0.2s ease',
+          }}
+          onClick={(e) => {
+            e.stopPropagation()
+            onDelete()
+          }}
+          aria-label="Delete entity"
+        >
+          <Cross2Icon />
+        </IconButton>
+      )}
+
+      <Flex
+        p={cardSize.p}
+        direction="column"
+        align="center"
+        justify="center"
+        gap="3"
+        style={{ minHeight: size === 'large' ? '160px' : size === 'medium' ? '140px' : '120px' }}
+      >
+        {/* Icon and toggle button */}
+        <Box
+          onClick={!isEditMode ? handleToggle : undefined}
+          style={{
+            position: 'relative',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            cursor: !isEditMode && !isDragging ? 'pointer' : undefined,
+            padding: '8px',
+            borderRadius: '8px',
+            transition: 'background-color 0.2s ease',
+          }}
+          className="light-toggle-area"
+        >
+          <Box
+            style={{
+              color: isStale ? 'var(--orange-9)' : isOn ? 'var(--amber-9)' : 'var(--gray-9)',
+              transform: `scale(${size === 'large' ? 1.4 : size === 'medium' ? 1.2 : 1})`,
+              opacity: isLoading ? 0.3 : isStale ? 0.6 : 1,
+              transition: 'opacity 0.2s ease',
+            }}
+          >
+            <SunIcon width={cardSize.iconSize} height={cardSize.iconSize} />
+          </Box>
+          {isLoading && (
+            <Box
+              style={{
+                position: 'absolute',
+                top: '50%',
+                left: '50%',
+                transform: 'translate(-50%, -50%)',
+              }}
+            >
+              <Spinner
+                size={cardSize.fontSize as '1' | '2' | '3'}
+                style={
+                  {
+                    '--spinner-track-color': 'var(--gray-a6)',
+                    '--spinner-fill-color': isOn ? 'var(--amber-9)' : 'var(--gray-9)',
+                  } as React.CSSProperties
+                }
+              />
+            </Box>
+          )}
+        </Box>
+
+        {/* Name */}
+        <Text
+          size={cardSize.fontSize as '1' | '2' | '3'}
+          weight={isOn ? 'medium' : 'regular'}
+          align="center"
+          style={{
+            color: isOn ? 'var(--amber-11)' : undefined,
+            maxWidth: '100%',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            opacity: isLoading ? 0.7 : 1,
+            transition: 'opacity 0.2s ease',
+          }}
+        >
+          {friendlyName}
+        </Text>
+
+        {/* Brightness slider */}
+        {isOn && supportsBrightness && !isEditMode && (
+          <Box style={{ width: '100%', paddingTop: '4px' }}>
+            <Flex align="center" gap="2">
+              <Text size="1" color="gray" style={{ minWidth: '35px' }}>
+                {displayBrightness}%
+              </Text>
+              <Slider.Root
+                className="SliderRoot"
+                value={[displayBrightness]}
+                onValueChange={handleBrightnessChange}
+                onValueCommit={handleBrightnessCommit}
+                onPointerDown={() => setIsDragging(true)}
+                onPointerUp={() => setIsDragging(false)}
+                max={100}
+                step={1}
+                aria-label="Brightness"
+                style={{ flex: 1 }}
+              >
+                <Slider.Track className="SliderTrack">
+                  <Slider.Range className="SliderRange" />
+                </Slider.Track>
+                <Slider.Thumb className="SliderThumb" />
+              </Slider.Root>
+            </Flex>
+          </Box>
+        )}
+
+        {/* Status */}
+        <Text
+          size="1"
+          color={error ? 'red' : isOn ? 'amber' : 'gray'}
+          weight="medium"
+          style={{
+            opacity: isLoading ? 0.5 : 1,
+            transition: 'opacity 0.2s ease',
+          }}
+        >
+          {error
+            ? 'ERROR'
+            : isOn && displayBrightness < 100 && supportsBrightness
+              ? `${displayBrightness}%`
+              : entity.state.toUpperCase()}
+        </Text>
+      </Flex>
+    </Card>
+  )
+}
+
+// Memoize the component to prevent unnecessary re-renders
+export const LightCard = memo(LightCardComponent, (prevProps, nextProps) => {
+  // Re-render if any of these props change
+  return (
+    prevProps.entityId === nextProps.entityId &&
+    prevProps.size === nextProps.size &&
+    prevProps.onDelete === nextProps.onDelete &&
+    prevProps.isSelected === nextProps.isSelected &&
+    prevProps.onSelect === nextProps.onSelect
+  )
+})

--- a/src/components/LightCard.tsx
+++ b/src/components/LightCard.tsx
@@ -75,13 +75,15 @@ function LightCardComponent({
   const supportsBrightness = useMemo(() => {
     // Modern Home Assistant uses supported_color_modes
     if (lightAttributes?.supported_color_modes) {
-      return lightAttributes.supported_color_modes.includes('brightness') ||
-             lightAttributes.supported_color_modes.includes('color_temp') ||
-             lightAttributes.supported_color_modes.includes('hs') ||
-             lightAttributes.supported_color_modes.includes('xy') ||
-             lightAttributes.supported_color_modes.includes('rgb') ||
-             lightAttributes.supported_color_modes.includes('rgbw') ||
-             lightAttributes.supported_color_modes.includes('rgbww')
+      return (
+        lightAttributes.supported_color_modes.includes('brightness') ||
+        lightAttributes.supported_color_modes.includes('color_temp') ||
+        lightAttributes.supported_color_modes.includes('hs') ||
+        lightAttributes.supported_color_modes.includes('xy') ||
+        lightAttributes.supported_color_modes.includes('rgb') ||
+        lightAttributes.supported_color_modes.includes('rgbw') ||
+        lightAttributes.supported_color_modes.includes('rgbww')
+      )
     }
     // Fallback to old supported_features check
     return (lightAttributes?.supported_features ?? 0) & SUPPORT_BRIGHTNESS

--- a/src/components/__tests__/LightCard.test.tsx
+++ b/src/components/__tests__/LightCard.test.tsx
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { LightCard } from '../LightCard'
+import * as hooks from '~/hooks'
+import { useDashboardStore } from '~/store'
+import { HassEntity } from '~/store/entityTypes'
+
+// Mock the hooks
+vi.mock('~/hooks', () => ({
+  useEntity: vi.fn(),
+  useServiceCall: vi.fn(),
+}))
+
+// Mock the store
+vi.mock('~/store', () => ({
+  useDashboardStore: vi.fn((selector) => selector({ mode: 'view' })),
+}))
+
+describe('LightCard', () => {
+  const mockEntity: HassEntity = {
+    entity_id: 'light.living_room',
+    state: 'on',
+    attributes: {
+      friendly_name: 'Living Room Light',
+      brightness: 255,
+      supported_features: 1, // SUPPORT_BRIGHTNESS
+    },
+    last_changed: '2023-01-01T00:00:00Z',
+    last_updated: '2023-01-01T00:00:00Z',
+    context: {
+      id: 'test-context',
+      parent_id: null,
+      user_id: null,
+    },
+  }
+
+  const mockServiceCallHandlers = {
+    loading: false,
+    error: null,
+    turnOn: vi.fn(),
+    turnOff: vi.fn(),
+    toggle: vi.fn(),
+    callService: vi.fn(),
+    setValue: vi.fn(),
+    clearError: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(hooks.useEntity as any).mockReturnValue({
+      entity: mockEntity,
+      isConnected: true,
+      isStale: false,
+    })
+    ;(hooks.useServiceCall as any).mockReturnValue(mockServiceCallHandlers)
+  })
+
+  it('renders light entity with brightness slider', () => {
+    render(<LightCard entityId="light.living_room" />)
+
+    expect(screen.getByText('Living Room Light')).toBeInTheDocument()
+    expect(screen.getByText('100%')).toBeInTheDocument() // Shows percentage when on
+    expect(screen.getByRole('slider')).toBeInTheDocument()
+  })
+
+  it('renders light entity without brightness slider when off', () => {
+    ;(hooks.useEntity as any).mockReturnValue({
+      entity: { ...mockEntity, state: 'off' },
+      isConnected: true,
+      isStale: false,
+    })
+
+    render(<LightCard entityId="light.living_room" />)
+
+    expect(screen.getByText('Living Room Light')).toBeInTheDocument()
+    expect(screen.getByText('OFF')).toBeInTheDocument()
+    expect(screen.queryByRole('slider')).not.toBeInTheDocument()
+  })
+
+  it('renders brightness slider for supported lights', () => {
+    render(<LightCard entityId="light.living_room" />)
+
+    const slider = screen.getByRole('slider')
+    expect(slider).toBeInTheDocument()
+    expect(slider).toHaveAttribute('aria-valuenow', '100')
+    expect(slider).toHaveAttribute('aria-valuemin', '0')
+    expect(slider).toHaveAttribute('aria-valuemax', '100')
+  })
+
+  it('shows different brightness levels', () => {
+    ;(hooks.useEntity as any).mockReturnValue({
+      entity: {
+        ...mockEntity,
+        attributes: { ...mockEntity.attributes, brightness: 128 }, // 50%
+      },
+      isConnected: true,
+      isStale: false,
+    })
+
+    render(<LightCard entityId="light.living_room" />)
+
+    // Status should show percentage (there are two 50% texts - one in slider, one in status)
+    const allPercentageTexts = screen.getAllByText('50%')
+    expect(allPercentageTexts).toHaveLength(2) // One in slider label, one in status
+    
+    // The status element is the one with weight-medium class
+    const statusElement = allPercentageTexts.find(el => el.classList.contains('rt-r-weight-medium'))
+    expect(statusElement).toBeInTheDocument()
+  })
+
+  it('hides brightness slider for lights without brightness support', () => {
+    ;(hooks.useEntity as any).mockReturnValue({
+      entity: {
+        ...mockEntity,
+        attributes: { ...mockEntity.attributes, supported_features: 0 }, // No brightness support
+      },
+      isConnected: true,
+      isStale: false,
+    })
+
+    render(<LightCard entityId="light.living_room" />)
+
+    expect(screen.queryByRole('slider')).not.toBeInTheDocument()
+  })
+
+  it('toggles light on click', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<LightCard entityId="light.living_room" />)
+
+    // Click on the icon area to toggle
+    const toggleArea = container.querySelector('.light-toggle-area')
+    expect(toggleArea).toBeInTheDocument()
+    
+    if (toggleArea) {
+      await user.click(toggleArea)
+    }
+
+    expect(mockServiceCallHandlers.turnOff).toHaveBeenCalledWith('light.living_room')
+  })
+
+  it('shows unavailable state', () => {
+    ;(hooks.useEntity as any).mockReturnValue({
+      entity: { ...mockEntity, state: 'unavailable' },
+      isConnected: true,
+      isStale: false,
+    })
+
+    render(<LightCard entityId="light.living_room" />)
+
+    expect(screen.getByText('UNAVAILABLE')).toBeInTheDocument()
+    expect(screen.queryByRole('slider')).not.toBeInTheDocument()
+  })
+
+  it('shows disconnected state', () => {
+    ;(hooks.useEntity as any).mockReturnValue({
+      entity: null,
+      isConnected: false,
+      isStale: false,
+    })
+
+    render(<LightCard entityId="light.living_room" />)
+
+    expect(screen.getByText('Disconnected')).toBeInTheDocument()
+  })
+
+  it('shows loading state', () => {
+    ;(hooks.useServiceCall as any).mockReturnValue({
+      ...mockServiceCallHandlers,
+      loading: true,
+    })
+
+    const { container } = render(<LightCard entityId="light.living_room" />)
+
+    // Check for spinner element
+    expect(container.querySelector('.rt-Spinner')).toBeInTheDocument()
+    
+    // Card should have loading cursor
+    const card = container.querySelector('.light-card')
+    expect(card).toHaveStyle('cursor: wait')
+  })
+
+  it('shows error state', () => {
+    ;(hooks.useServiceCall as any).mockReturnValue({
+      ...mockServiceCallHandlers,
+      error: 'Failed to toggle light',
+    })
+
+    render(<LightCard entityId="light.living_room" />)
+
+    expect(screen.getByText('ERROR')).toBeInTheDocument()
+  })
+
+  it('shows stale data indicator', () => {
+    ;(hooks.useEntity as any).mockReturnValue({
+      entity: mockEntity,
+      isConnected: true,
+      isStale: true,
+    })
+
+    const { container } = render(<LightCard entityId="light.living_room" />)
+
+    const card = container.querySelector('.light-card')
+    expect(card).toHaveStyle('border-style: dashed')
+  })
+
+  it('handles edit mode interactions', () => {
+    const onDelete = vi.fn()
+    const onSelect = vi.fn()
+
+    vi.mocked(useDashboardStore as any).mockImplementation(
+      (selector: any) => selector({ mode: 'edit' })
+    )
+
+    render(
+      <LightCard
+        entityId="light.living_room"
+        onDelete={onDelete}
+        onSelect={onSelect}
+        isSelected={false}
+      />
+    )
+
+    // Should show delete button
+    const deleteButton = screen.getByRole('button', { name: 'Delete entity' })
+    expect(deleteButton).toBeInTheDocument()
+
+    // Should show drag handle
+    expect(document.querySelector('.grid-item-drag-handle')).toBeInTheDocument()
+
+    // Clicking delete button
+    fireEvent.click(deleteButton)
+    expect(onDelete).toHaveBeenCalled()
+
+    // Clicking card should select it
+    const card = screen.getByText('Living Room Light').closest('.light-card')
+    if (card) {
+      fireEvent.click(card)
+      expect(onSelect).toHaveBeenCalledWith(true)
+    }
+  })
+
+  it('shows selected state', () => {
+    const { container } = render(<LightCard entityId="light.living_room" isSelected={true} />)
+
+    const card = container.querySelector('.light-card')
+    expect(card).toHaveStyle('background-color: var(--blue-3)')
+    expect(card).toHaveStyle('border-color: var(--blue-6)')
+  })
+
+  it('respects different sizes', () => {
+    const { rerender } = render(<LightCard entityId="light.living_room" size="small" />)
+    const nameElement = screen.getByText('Living Room Light')
+    expect(nameElement).toHaveClass('rt-r-size-1')
+
+    rerender(<LightCard entityId="light.living_room" size="medium" />)
+    expect(screen.getByText('Living Room Light')).toHaveClass('rt-r-size-2')
+
+    rerender(<LightCard entityId="light.living_room" size="large" />)
+    expect(screen.getByText('Living Room Light')).toHaveClass('rt-r-size-3')
+  })
+})


### PR DESCRIPTION
Closes #48

## Summary
- Created new LightCard component for light entities with advanced brightness control
- Integrated Radix UI Slider component for smooth, touch-friendly brightness adjustment
- Automatically uses LightCard for light entities while maintaining ButtonCard for other entity types

## Implementation Details
- **LightCard Component**: Extends the existing entity card pattern with brightness control
- **Smart Entity Detection**: GridView automatically selects the appropriate card type based on entity domain
- **Brightness Control**: 
  - Shows slider only when light is on and supports brightness
  - Converts between Home Assistant scale (0-255) and UI scale (0-100)
  - Dragging to 0% turns the light off
  - Real-time visual feedback during adjustment
- **Feature Detection**: Uses Home Assistant's supported_features bit flags to determine capabilities
- **Maintains All Existing Features**:
  - Edit mode with selection and deletion
  - Drag handle for repositioning
  - Loading states with spinner
  - Error handling
  - Stale data indication
  - Touch-optimized sizing

## Testing
- [x] Added comprehensive test suite for LightCard component (14 tests)
- [x] Tested with lights that support brightness
- [x] Tested with lights that don't support brightness
- [x] Tested toggle functionality
- [x] Tested edit mode features
- [x] All existing tests continue to pass
- [x] TypeScript checks pass
- [x] Linting passes

## Visual Changes
- Light entities now show a brightness slider when on
- Current brightness percentage displayed in slider and status
- Smooth transitions and animations
- Touch-friendly slider with appropriate sizing

## Next Steps
The infrastructure is now in place for additional light features:
- Color picker for RGB lights (issue #48 mentions this)
- Color temperature control
- Effect selection

These can be added incrementally to the existing LightCard component.