### PR TITLE
feat: implement input entity components

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@tanstack/react-store": "^0.7.1",
     "@types/js-yaml": "^4.0.9",
     "js-yaml": "^4.1.0",
+    "lucide-react": "^0.525.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-grid-layout": "^1.5.2",

--- a/src/components/GridView.tsx
+++ b/src/components/GridView.tsx
@@ -3,6 +3,11 @@ import { Box } from '@radix-ui/themes'
 import { ButtonCard } from './ButtonCard'
 import { LightCard } from './LightCard'
 import { SensorCard } from './SensorCard'
+import { InputBooleanCard } from './InputBooleanCard'
+import { InputNumberCard } from './InputNumberCard'
+import { InputSelectCard } from './InputSelectCard'
+import { InputTextCard } from './InputTextCard'
+import { InputDateTimeCard } from './InputDateTimeCard'
 import { Separator } from './Separator'
 import { DeleteConfirmDialog } from './DeleteConfirmDialog'
 import { GridLayoutSection } from './GridLayoutSection'
@@ -59,8 +64,58 @@ function EntityCard({
           onSelect={onSelect}
         />
       )
+    case 'input_boolean':
+      return (
+        <InputBooleanCard
+          entityId={entityId}
+          size={size}
+          onDelete={onDelete}
+          isSelected={isSelected}
+          onSelect={onSelect}
+        />
+      )
+    case 'input_number':
+      return (
+        <InputNumberCard
+          entityId={entityId}
+          size={size}
+          onDelete={onDelete}
+          isSelected={isSelected}
+          onSelect={onSelect}
+        />
+      )
+    case 'input_select':
+      return (
+        <InputSelectCard
+          entityId={entityId}
+          size={size}
+          onDelete={onDelete}
+          isSelected={isSelected}
+          onSelect={onSelect}
+        />
+      )
+    case 'input_text':
+      return (
+        <InputTextCard
+          entityId={entityId}
+          size={size}
+          onDelete={onDelete}
+          isSelected={isSelected}
+          onSelect={onSelect}
+        />
+      )
+    case 'input_datetime':
+      return (
+        <InputDateTimeCard
+          entityId={entityId}
+          size={size}
+          onDelete={onDelete}
+          isSelected={isSelected}
+          onSelect={onSelect}
+        />
+      )
     default:
-      // Default to ButtonCard for switches, input_booleans, and other entities
+      // Default to ButtonCard for switches and other entities
       return (
         <ButtonCard
           entityId={entityId}

--- a/src/components/InputBooleanCard.test.tsx
+++ b/src/components/InputBooleanCard.test.tsx
@@ -1,0 +1,295 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '../test/utils'
+import { InputBooleanCard } from './InputBooleanCard'
+import { useEntity } from '../hooks/useEntity'
+import { useServiceCall } from '../hooks/useServiceCall'
+import { useDashboardStore } from '../store'
+
+// Mock the hooks
+vi.mock('../hooks/useEntity')
+vi.mock('../hooks/useServiceCall')
+vi.mock('../store')
+
+describe('InputBooleanCard', () => {
+  const mockToggle = vi.fn()
+  const mockOnDelete = vi.fn()
+  const mockOnSelect = vi.fn()
+
+  const defaultEntity = {
+    entity_id: 'input_boolean.test_toggle',
+    state: 'off',
+    attributes: {
+      friendly_name: 'Test Toggle',
+    },
+    last_changed: '2024-01-01T00:00:00Z',
+    last_updated: '2024-01-01T00:00:00Z',
+    context: { id: 'test', parent_id: null, user_id: null },
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    cleanup()
+
+    // Default mock implementations
+    vi.mocked(useEntity).mockReturnValue({
+      entity: defaultEntity,
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    vi.mocked(useServiceCall).mockReturnValue({
+      callService: vi.fn(),
+      turnOn: vi.fn(),
+      turnOff: vi.fn(),
+      toggle: mockToggle,
+      setValue: vi.fn(),
+      loading: false,
+      error: null,
+      clearError: vi.fn(),
+    })
+
+    vi.mocked(useDashboardStore).mockReturnValue('view')
+  })
+
+  it('renders input boolean with friendly name', () => {
+    render(<InputBooleanCard entityId="input_boolean.test_toggle" />)
+
+    expect(screen.getByText('Test Toggle')).toBeInTheDocument()
+    expect(screen.getByRole('switch')).toBeInTheDocument()
+  })
+
+  it('shows entity id when no friendly name', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        attributes: {},
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputBooleanCard entityId="input_boolean.test_toggle" />)
+    expect(screen.getByText('test_toggle')).toBeInTheDocument()
+  })
+
+  it('shows on state with amber styling', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        state: 'on',
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    const { container } = render(<InputBooleanCard entityId="input_boolean.test_toggle" />)
+    const card = container.querySelector('.rt-Card')
+
+    expect(card).toHaveStyle({ backgroundColor: 'var(--amber-3)' })
+    expect(screen.getByRole('switch')).toBeChecked()
+  })
+
+  it('toggles on click in view mode', async () => {
+    render(<InputBooleanCard entityId="input_boolean.test_toggle" />)
+
+    const card = screen.getByText('Test Toggle').closest('.rt-Card')!
+    fireEvent.click(card)
+
+    await waitFor(() => {
+      expect(mockToggle).toHaveBeenCalledWith('input_boolean.test_toggle')
+    })
+  })
+
+  it('toggles on switch change', async () => {
+    render(<InputBooleanCard entityId="input_boolean.test_toggle" />)
+
+    const switchElement = screen.getByRole('switch')
+    fireEvent.click(switchElement)
+
+    await waitFor(() => {
+      expect(mockToggle).toHaveBeenCalledWith('input_boolean.test_toggle')
+    })
+  })
+
+  it('selects card in edit mode', async () => {
+    vi.mocked(useDashboardStore).mockReturnValue('edit')
+
+    render(
+      <InputBooleanCard
+        entityId="input_boolean.test_toggle"
+        onSelect={mockOnSelect}
+        isSelected={false}
+      />
+    )
+
+    // Switch should not be visible in edit mode
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+    expect(screen.getByText('OFF')).toBeInTheDocument()
+
+    const card = screen.getByText('Test Toggle').closest('.rt-Card')!
+    fireEvent.click(card)
+
+    await waitFor(() => {
+      expect(mockOnSelect).toHaveBeenCalledWith(true)
+      expect(mockToggle).not.toHaveBeenCalled()
+    })
+  })
+
+  it('shows selected state styling', () => {
+    const { container } = render(
+      <InputBooleanCard entityId="input_boolean.test_toggle" isSelected={true} />
+    )
+
+    const card = container.querySelector('.rt-Card')
+    expect(card).toHaveClass('ring-2', 'ring-blue-500')
+    expect(card).toHaveStyle({ backgroundColor: 'var(--blue-2)' })
+  })
+
+  it('shows delete button in edit mode', () => {
+    vi.mocked(useDashboardStore).mockReturnValue('edit')
+
+    render(<InputBooleanCard entityId="input_boolean.test_toggle" onDelete={mockOnDelete} />)
+
+    const deleteButton = screen.getByRole('button')
+    fireEvent.click(deleteButton)
+
+    expect(mockOnDelete).toHaveBeenCalled()
+  })
+
+  it('shows loading state', () => {
+    vi.mocked(useServiceCall).mockReturnValue({
+      callService: vi.fn(),
+      turnOn: vi.fn(),
+      turnOff: vi.fn(),
+      toggle: mockToggle,
+      setValue: vi.fn(),
+      loading: true,
+      error: null,
+      clearError: vi.fn(),
+    })
+
+    const { container } = render(<InputBooleanCard entityId="input_boolean.test_toggle" />)
+
+    // Check for spinner
+    const spinner = container.querySelector('[style*="animation: spin"]')
+    expect(spinner).toBeInTheDocument()
+
+    // Switch should be disabled during loading
+    expect(screen.getByRole('switch')).toBeDisabled()
+  })
+
+  it('shows error state', () => {
+    vi.mocked(useServiceCall).mockReturnValue({
+      callService: vi.fn(),
+      turnOn: vi.fn(),
+      turnOff: vi.fn(),
+      toggle: mockToggle,
+      setValue: vi.fn(),
+      loading: false,
+      error: 'Failed to toggle',
+      clearError: vi.fn(),
+    })
+
+    const { container } = render(<InputBooleanCard entityId="input_boolean.test_toggle" />)
+
+    const card = container.querySelector('.rt-Card')
+    expect(card).toHaveClass('border-2', 'border-red-500')
+    expect(screen.getByText('Failed to toggle')).toBeInTheDocument()
+  })
+
+  it('shows stale data indicator', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        attributes: {
+          ...defaultEntity.attributes,
+          _stale: true,
+        },
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: true,
+    })
+
+    const { container } = render(<InputBooleanCard entityId="input_boolean.test_toggle" />)
+
+    const card = container.querySelector('.rt-Card')
+    expect(card).toHaveClass('border-2', 'border-orange-400')
+    expect(card).toHaveStyle({ borderStyle: 'dashed' })
+  })
+
+  it('shows disconnected state', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: undefined,
+      isConnected: false,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputBooleanCard entityId="input_boolean.test_toggle" />)
+    expect(screen.getByText('Disconnected')).toBeInTheDocument()
+  })
+
+  it('shows entity not found state', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: undefined,
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputBooleanCard entityId="input_boolean.test_toggle" />)
+    expect(screen.getByText('Entity not found')).toBeInTheDocument()
+  })
+
+  it('shows unavailable state', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        state: 'unavailable',
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputBooleanCard entityId="input_boolean.test_toggle" />)
+    expect(screen.getByText('Unavailable')).toBeInTheDocument()
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+  })
+
+  describe('size variants', () => {
+    it('renders small size', () => {
+      render(<InputBooleanCard entityId="input_boolean.test_toggle" size="small" />)
+
+      const text = screen.getByText('Test Toggle')
+      expect(text).toHaveClass('rt-r-size-1')
+
+      const switchElement = screen.getByRole('switch')
+      expect(switchElement).toHaveClass('rt-r-size-1')
+    })
+
+    it('renders medium size', () => {
+      render(<InputBooleanCard entityId="input_boolean.test_toggle" size="medium" />)
+
+      const text = screen.getByText('Test Toggle')
+      expect(text).toHaveClass('rt-r-size-2')
+
+      const switchElement = screen.getByRole('switch')
+      expect(switchElement).toHaveClass('rt-r-size-2')
+    })
+
+    it('renders large size', () => {
+      render(<InputBooleanCard entityId="input_boolean.test_toggle" size="large" />)
+
+      const text = screen.getByText('Test Toggle')
+      expect(text).toHaveClass('rt-r-size-3')
+
+      const switchElement = screen.getByRole('switch')
+      expect(switchElement).toHaveClass('rt-r-size-3')
+    })
+  })
+})

--- a/src/components/InputBooleanCard.tsx
+++ b/src/components/InputBooleanCard.tsx
@@ -1,0 +1,243 @@
+import React, { memo, useCallback } from 'react'
+import { Box, Card, Flex, IconButton, Switch, Text } from '@radix-ui/themes'
+import { Archive, ToggleLeft, ToggleRight, X } from 'lucide-react'
+import { useEntity } from '../hooks/useEntity'
+import { useServiceCall } from '../hooks/useServiceCall'
+import { useDashboardStore } from '../store'
+
+interface InputBooleanCardProps {
+  entityId: string
+  size?: 'small' | 'medium' | 'large'
+  onDelete?: () => void
+  isSelected?: boolean
+  onSelect?: (selected: boolean) => void
+}
+
+export const InputBooleanCard = memo(function InputBooleanCard({
+  entityId,
+  size = 'medium',
+  onDelete,
+  isSelected = false,
+  onSelect,
+}: InputBooleanCardProps) {
+  const { entity, isConnected } = useEntity(entityId)
+  const { toggle, loading, error } = useServiceCall()
+  const mode = useDashboardStore((state) => state.mode)
+  const isEditMode = mode === 'edit'
+
+  const handleClick = useCallback(() => {
+    if (isEditMode && onSelect) {
+      onSelect(!isSelected)
+    } else if (!isEditMode && entity) {
+      toggle(entity.entity_id)
+    }
+  }, [isEditMode, onSelect, isSelected, entity, toggle])
+
+  const handleSwitchChange = useCallback(
+    (_checked: boolean) => {
+      if (!isEditMode && entity) {
+        toggle(entity.entity_id)
+      }
+    },
+    [isEditMode, entity, toggle]
+  )
+
+  const handleDelete = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      onDelete?.()
+    },
+    [onDelete]
+  )
+
+  // Handle loading/error states
+  if (!isConnected || !entity) {
+    return (
+      <Card
+        className={`
+          relative flex items-center justify-center
+          ${isEditMode ? 'cursor-move' : 'cursor-pointer'}
+          border-2 border-dashed border-red-500
+          ${size === 'small' ? 'p-2' : size === 'large' ? 'p-4' : 'p-3'}
+        `}
+        style={{
+          borderStyle: 'dashed',
+          borderColor: 'var(--red-8)',
+          animation: 'pulse-border 2s ease-in-out infinite',
+        }}
+      >
+        <style>{`
+          @keyframes pulse-border {
+            0%,
+            100% {
+              opacity: 0.5;
+            }
+            50% {
+              opacity: 1;
+            }
+          }
+        `}</style>
+        <Text size="1" color="red">
+          {!isConnected ? 'Disconnected' : 'Entity not found'}
+        </Text>
+      </Card>
+    )
+  }
+
+  const cardSize = {
+    small: { p: '2', iconSize: '16', fontSize: '1' },
+    medium: { p: '3', iconSize: '20', fontSize: '2' },
+    large: { p: '4', iconSize: '24', fontSize: '3' },
+  }[size]
+
+  // Handle unavailable entities
+  if (entity.state === 'unavailable') {
+    return (
+      <Card
+        className={`
+          relative
+          ${isEditMode ? 'cursor-move' : 'cursor-not-allowed'}
+          ${isSelected ? 'ring-2 ring-blue-500' : ''}
+        `}
+        style={{
+          borderStyle: 'dotted',
+          borderColor: 'var(--gray-7)',
+          backgroundColor: isSelected ? 'var(--blue-2)' : undefined,
+          padding: `var(--space-${cardSize.p})`,
+        }}
+        onClick={handleClick}
+      >
+        {isEditMode && (
+          <>
+            <Box
+              className="absolute inset-x-0 top-0 h-6 cursor-move"
+              style={{
+                background: 'linear-gradient(to bottom, rgba(0,0,0,0.1), transparent)',
+              }}
+            />
+            <IconButton
+              size="1"
+              variant="ghost"
+              className="absolute top-1 right-1"
+              onClick={handleDelete}
+              style={{ cursor: 'pointer' }}
+            >
+              <X size={12} />
+            </IconButton>
+          </>
+        )}
+        <Flex direction="column" align="center" gap="2">
+          <Archive size={cardSize.iconSize} style={{ color: 'var(--gray-9)' }} />
+          <Text size={cardSize.fontSize as '1' | '2' | '3'} color="gray">
+            {entity.attributes.friendly_name || entity.entity_id.split('.')[1]}
+          </Text>
+          <Text size="1" color="gray">
+            Unavailable
+          </Text>
+        </Flex>
+      </Card>
+    )
+  }
+
+  const isOn = entity.state === 'on'
+  const Icon = isOn ? ToggleRight : ToggleLeft
+  const iconColor = isOn ? 'var(--amber-9)' : 'var(--gray-9)'
+
+  const isStale = entity.attributes._stale === true
+
+  return (
+    <Card
+      className={`
+        relative transition-all duration-200
+        ${isEditMode ? 'cursor-move' : 'cursor-pointer'}
+        ${isSelected ? 'ring-2 ring-blue-500' : ''}
+        ${isStale ? 'border-2 border-orange-400' : ''}
+        ${error ? 'border-2 border-red-500' : ''}
+      `}
+      style={{
+        backgroundColor: isSelected ? 'var(--blue-2)' : isOn ? 'var(--amber-3)' : undefined,
+        borderStyle: isStale ? 'dashed' : error ? 'solid' : undefined,
+        borderColor: isStale ? 'var(--orange-8)' : error ? 'var(--red-8)' : undefined,
+        padding: `var(--space-${cardSize.p})`,
+        animation: error ? 'pulse-border 2s ease-in-out infinite' : undefined,
+      }}
+      onClick={handleClick}
+    >
+      {isEditMode && (
+        <>
+          <Box
+            className="absolute inset-x-0 top-0 h-6 cursor-move"
+            style={{
+              background: 'linear-gradient(to bottom, rgba(0,0,0,0.1), transparent)',
+            }}
+          />
+          <IconButton
+            size="1"
+            variant="ghost"
+            className="absolute top-1 right-1"
+            onClick={handleDelete}
+            style={{ cursor: 'pointer' }}
+          >
+            <X size={12} />
+          </IconButton>
+        </>
+      )}
+
+      {loading && (
+        <Box
+          className="absolute inset-0 flex items-center justify-center bg-black/10"
+          style={{ borderRadius: 'var(--radius-2)' }}
+        >
+          <Box
+            className="h-4 w-4 rounded-full border-2 border-gray-600 border-t-transparent"
+            style={{ animation: 'spin 1s linear infinite' }}
+          />
+        </Box>
+      )}
+
+      <style>{`
+        @keyframes spin {
+          to {
+            transform: rotate(360deg);
+          }
+        }
+        @keyframes pulse-border {
+          0%,
+          100% {
+            opacity: 0.5;
+          }
+          50% {
+            opacity: 1;
+          }
+        }
+      `}</style>
+
+      <Flex direction="column" align="center" gap="2">
+        <Icon size={cardSize.iconSize} style={{ color: iconColor }} />
+        <Text size={cardSize.fontSize as '1' | '2' | '3'} weight="medium">
+          {entity.attributes.friendly_name || entity.entity_id.split('.')[1]}
+        </Text>
+        {!isEditMode && (
+          <Switch
+            size={size === 'small' ? '1' : size === 'large' ? '3' : '2'}
+            checked={isOn}
+            onCheckedChange={handleSwitchChange}
+            disabled={loading}
+            style={{ cursor: 'pointer' }}
+          />
+        )}
+        {isEditMode && (
+          <Text size="1" color={isOn ? 'amber' : 'gray'}>
+            {isOn ? 'ON' : 'OFF'}
+          </Text>
+        )}
+      </Flex>
+
+      {error && (
+        <Text size="1" color="red" className="absolute bottom-1 left-1 right-1 text-center">
+          {error}
+        </Text>
+      )}
+    </Card>
+  )
+})

--- a/src/components/InputDateTimeCard.test.tsx
+++ b/src/components/InputDateTimeCard.test.tsx
@@ -1,0 +1,407 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '../test/utils'
+import { InputDateTimeCard } from './InputDateTimeCard'
+import { useEntity } from '../hooks/useEntity'
+import { useServiceCall } from '../hooks/useServiceCall'
+import { useDashboardStore } from '../store'
+
+// Mock the hooks
+vi.mock('../hooks/useEntity')
+vi.mock('../hooks/useServiceCall')
+vi.mock('../store')
+
+describe('InputDateTimeCard', () => {
+  const mockSetValue = vi.fn()
+  const mockOnSelect = vi.fn()
+
+  const defaultEntity = {
+    entity_id: 'input_datetime.test_datetime',
+    state: '2024-01-15T14:30:00',
+    attributes: {
+      friendly_name: 'Test DateTime',
+      has_date: true,
+      has_time: true,
+    },
+    last_changed: '2024-01-01T00:00:00Z',
+    last_updated: '2024-01-01T00:00:00Z',
+    context: { id: 'test', parent_id: null, user_id: null },
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    cleanup()
+
+    // Default mock implementations
+    vi.mocked(useEntity).mockReturnValue({
+      entity: defaultEntity,
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    vi.mocked(useServiceCall).mockReturnValue({
+      callService: vi.fn(),
+      turnOn: vi.fn(),
+      turnOff: vi.fn(),
+      toggle: vi.fn(),
+      setValue: mockSetValue,
+      loading: false,
+      error: null,
+      clearError: vi.fn(),
+    })
+
+    vi.mocked(useDashboardStore).mockReturnValue('view')
+  })
+
+  it('renders input datetime with friendly name and formatted value', () => {
+    render(<InputDateTimeCard entityId="input_datetime.test_datetime" />)
+
+    expect(screen.getByText('Test DateTime')).toBeInTheDocument()
+    // The exact format will depend on locale, just check that a formatted date is displayed
+    // The component shows the date in a Box element
+    const dateDisplay = screen
+      .getByText('Test DateTime')
+      .parentElement?.querySelector('.rt-Box span')
+    expect(dateDisplay).toBeInTheDocument()
+    // The text content should include some part of the date
+    expect(dateDisplay?.textContent).toMatch(/2024|15|30|PM|AM/)
+  })
+
+  it('shows entity id when no friendly name', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        attributes: {
+          ...defaultEntity.attributes,
+          friendly_name: undefined,
+        },
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputDateTimeCard entityId="input_datetime.test_datetime" />)
+    expect(screen.getByText('test_datetime')).toBeInTheDocument()
+  })
+
+  it('shows date and time indicator', () => {
+    render(<InputDateTimeCard entityId="input_datetime.test_datetime" />)
+    expect(screen.getByText('Date & Time')).toBeInTheDocument()
+  })
+
+  it('shows date only indicator when has_time is false', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        state: '2024-01-15',
+        attributes: {
+          ...defaultEntity.attributes,
+          has_date: true,
+          has_time: false,
+        },
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputDateTimeCard entityId="input_datetime.test_datetime" />)
+    expect(screen.getByText('Date Only')).toBeInTheDocument()
+  })
+
+  it('shows time only indicator when has_date is false', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        state: '14:30:00',
+        attributes: {
+          ...defaultEntity.attributes,
+          has_date: false,
+          has_time: true,
+        },
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputDateTimeCard entityId="input_datetime.test_datetime" />)
+    expect(screen.getByText('Time Only')).toBeInTheDocument()
+  })
+
+  it('enters edit mode on click in view mode', async () => {
+    const { container } = render(<InputDateTimeCard entityId="input_datetime.test_datetime" />)
+
+    // Initially should show the formatted date, not input
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+
+    // Click the edit button to enter edit mode
+    const buttons = container.querySelectorAll('.rt-IconButton')
+    expect(buttons.length).toBeGreaterThan(0)
+    fireEvent.click(buttons[0])
+
+    // Wait for the input to appear
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toBeInTheDocument()
+    })
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    expect(input.type).toBe('datetime-local')
+    expect(input.value).toBe('2024-01-15T14:30:00')
+  })
+
+  it('uses date input type for date only', async () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        state: '2024-01-15',
+        attributes: {
+          ...defaultEntity.attributes,
+          has_date: true,
+          has_time: false,
+        },
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputDateTimeCard entityId="input_datetime.test_datetime" />)
+
+    const card = screen.getByText('Test DateTime').closest('.rt-Card')!
+    fireEvent.click(card)
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toBeInTheDocument()
+    })
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    expect(input.type).toBe('date')
+  })
+
+  it('uses time input type for time only', async () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        state: '14:30:00',
+        attributes: {
+          ...defaultEntity.attributes,
+          has_date: false,
+          has_time: true,
+        },
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputDateTimeCard entityId="input_datetime.test_datetime" />)
+
+    const card = screen.getByText('Test DateTime').closest('.rt-Card')!
+    fireEvent.click(card)
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toBeInTheDocument()
+    })
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    expect(input.type).toBe('time')
+  })
+
+  it('submits new value on form submit', async () => {
+    render(<InputDateTimeCard entityId="input_datetime.test_datetime" />)
+
+    // Enter edit mode by clicking the edit button
+    const buttons = screen.getAllByRole('button')
+    const editButton = buttons.find((btn) => btn.querySelector('.lucide-pen'))
+    expect(editButton).toBeDefined()
+    fireEvent.click(editButton!)
+
+    // Wait for edit mode to activate
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toBeInTheDocument()
+    })
+
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: '2024-02-20T16:45:00' } })
+
+    const submitButtons = screen.getAllByRole('button')
+    const submitButton = submitButtons[0] // Submit button is first
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockSetValue).toHaveBeenCalledWith(
+        'input_datetime.test_datetime',
+        '2024-02-20T16:45:00'
+      )
+    })
+  })
+
+  it('cancels edit on cancel button click', async () => {
+    render(<InputDateTimeCard entityId="input_datetime.test_datetime" />)
+
+    // Enter edit mode by clicking the edit button
+    const buttons = screen.getAllByRole('button')
+    const editButton = buttons.find((btn) => btn.querySelector('.lucide-pen'))
+    expect(editButton).toBeDefined()
+    fireEvent.click(editButton!)
+
+    // Wait for edit mode to activate
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toBeInTheDocument()
+    })
+
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: '2024-02-20T16:45:00' } })
+
+    const cancelButtons = screen.getAllByRole('button')
+    const cancelButton = cancelButtons[cancelButtons.length - 1] // Cancel button is last
+    fireEvent.click(cancelButton)
+
+    await waitFor(() => {
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+      expect(mockSetValue).not.toHaveBeenCalled()
+    })
+  })
+
+  it('shows not set for unknown value', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        state: 'unknown',
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputDateTimeCard entityId="input_datetime.test_datetime" />)
+    expect(screen.getByText('(not set)')).toBeInTheDocument()
+  })
+
+  it('shows not set for empty value', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        state: '',
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputDateTimeCard entityId="input_datetime.test_datetime" />)
+    expect(screen.getByText('(not set)')).toBeInTheDocument()
+  })
+
+  it('handles invalid date format gracefully', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        state: 'invalid-date',
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputDateTimeCard entityId="input_datetime.test_datetime" />)
+    expect(screen.getByText('invalid-date')).toBeInTheDocument()
+  })
+
+  it('shows edit button that enters edit mode', async () => {
+    render(<InputDateTimeCard entityId="input_datetime.test_datetime" />)
+
+    const editButton = screen.getAllByRole('button')[0]
+    fireEvent.click(editButton)
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toBeInTheDocument()
+    })
+  })
+
+  it('selects card in edit mode', async () => {
+    vi.mocked(useDashboardStore).mockReturnValue('edit')
+
+    render(
+      <InputDateTimeCard
+        entityId="input_datetime.test_datetime"
+        onSelect={mockOnSelect}
+        isSelected={false}
+      />
+    )
+
+    // Input field should not be visible in edit mode
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+
+    const card = screen.getByText('Test DateTime').closest('.rt-Card')!
+    fireEvent.click(card)
+
+    await waitFor(() => {
+      expect(mockOnSelect).toHaveBeenCalledWith(true)
+      expect(mockSetValue).not.toHaveBeenCalled()
+    })
+  })
+
+  it('shows loading state', () => {
+    vi.mocked(useServiceCall).mockReturnValue({
+      callService: vi.fn(),
+      turnOn: vi.fn(),
+      turnOff: vi.fn(),
+      toggle: vi.fn(),
+      setValue: mockSetValue,
+      loading: true,
+      error: null,
+      clearError: vi.fn(),
+    })
+
+    const { container } = render(<InputDateTimeCard entityId="input_datetime.test_datetime" />)
+
+    // Check for spinner
+    const spinner = container.querySelector('[style*="animation: spin"]')
+    expect(spinner).toBeInTheDocument()
+  })
+
+  it('shows error state', () => {
+    vi.mocked(useServiceCall).mockReturnValue({
+      callService: vi.fn(),
+      turnOn: vi.fn(),
+      turnOff: vi.fn(),
+      toggle: vi.fn(),
+      setValue: mockSetValue,
+      loading: false,
+      error: 'Failed to set value',
+      clearError: vi.fn(),
+    })
+
+    const { container } = render(<InputDateTimeCard entityId="input_datetime.test_datetime" />)
+
+    const card = container.querySelector('.rt-Card')
+    expect(card).toHaveClass('border-2', 'border-red-500')
+    expect(screen.getByText('Failed to set value')).toBeInTheDocument()
+  })
+
+  describe('size variants', () => {
+    it('renders small size', () => {
+      render(<InputDateTimeCard entityId="input_datetime.test_datetime" size="small" />)
+
+      const text = screen.getByText('Test DateTime')
+      expect(text).toHaveClass('rt-r-size-1')
+    })
+
+    it('renders medium size', () => {
+      render(<InputDateTimeCard entityId="input_datetime.test_datetime" size="medium" />)
+
+      const text = screen.getByText('Test DateTime')
+      expect(text).toHaveClass('rt-r-size-2')
+    })
+
+    it('renders large size', () => {
+      render(<InputDateTimeCard entityId="input_datetime.test_datetime" size="large" />)
+
+      const text = screen.getByText('Test DateTime')
+      expect(text).toHaveClass('rt-r-size-3')
+    })
+  })
+})

--- a/src/components/InputDateTimeCard.test.tsx
+++ b/src/components/InputDateTimeCard.test.tsx
@@ -136,7 +136,7 @@ describe('InputDateTimeCard', () => {
     // Should not have an input field initially
     expect(container.querySelector('input')).not.toBeInTheDocument()
     expect(container.querySelector('form')).not.toBeInTheDocument()
-    
+
     // Click the card to enter edit mode
     const card = screen.getByText('Test DateTime').closest('.rt-Card')!
     fireEvent.click(card)
@@ -145,7 +145,7 @@ describe('InputDateTimeCard', () => {
     await waitFor(() => {
       const form = container.querySelector('form')
       expect(form).toBeInTheDocument()
-      
+
       const input = container.querySelector('input[type="datetime-local"]')
       expect(input).toBeInTheDocument()
       // datetime-local inputs truncate seconds when zero
@@ -225,9 +225,7 @@ describe('InputDateTimeCard', () => {
 
     // Find the submit button (green check)
     const buttons = container.querySelectorAll('button')
-    const submitButton = Array.from(buttons).find(btn => 
-      btn.querySelector('svg.lucide-check')
-    )
+    const submitButton = Array.from(buttons).find((btn) => btn.querySelector('svg.lucide-check'))
     expect(submitButton).toBeDefined()
     fireEvent.click(submitButton!)
 
@@ -258,10 +256,13 @@ describe('InputDateTimeCard', () => {
 
     // Find the cancel button (red X) - not the close button in edit mode
     const buttons = container.querySelectorAll('form button')
-    const cancelButton = Array.from(buttons).find(btn => {
+    const cancelButton = Array.from(buttons).find((btn) => {
       const svg = btn.querySelector('svg')
-      return btn.getAttribute('type') === 'button' && 
-             svg && svg.querySelector('path[d*="18 6"]') !== null // X icon path
+      return (
+        btn.getAttribute('type') === 'button' &&
+        svg &&
+        svg.querySelector('path[d*="18 6"]') !== null
+      ) // X icon path
     })
     expect(cancelButton).toBeDefined()
     fireEvent.click(cancelButton!)
@@ -322,14 +323,14 @@ describe('InputDateTimeCard', () => {
 
     // Should not be in edit mode initially
     expect(container.querySelector('input')).not.toBeInTheDocument()
-    
+
     // Find the edit button
     const editButton = container.querySelector('button svg.lucide-pen')?.parentElement
     expect(editButton).toBeInTheDocument()
-    
+
     // Click the edit button
     fireEvent.click(editButton!)
-    
+
     await waitFor(() => {
       const input = container.querySelector('input')
       expect(input).toBeInTheDocument()

--- a/src/components/InputDateTimeCard.tsx
+++ b/src/components/InputDateTimeCard.tsx
@@ -1,0 +1,385 @@
+import React, { memo, useCallback, useState, useEffect } from 'react'
+import { Box, Card, Flex, IconButton, Text, TextField } from '@radix-ui/themes'
+import { Archive, Calendar, Check, Clock, Edit2, X } from 'lucide-react'
+import { useEntity } from '../hooks/useEntity'
+import { useServiceCall } from '../hooks/useServiceCall'
+import { useDashboardStore } from '../store'
+
+interface InputDateTimeCardProps {
+  entityId: string
+  size?: 'small' | 'medium' | 'large'
+  onDelete?: () => void
+  isSelected?: boolean
+  onSelect?: (selected: boolean) => void
+}
+
+interface InputDateTimeAttributes {
+  friendly_name?: string
+  has_date?: boolean
+  has_time?: boolean
+  _stale?: boolean
+}
+
+export const InputDateTimeCard = memo(function InputDateTimeCard({
+  entityId,
+  size = 'medium',
+  onDelete,
+  isSelected = false,
+  onSelect,
+}: InputDateTimeCardProps) {
+  const { entity, isConnected } = useEntity(entityId)
+  const { setValue, loading, error } = useServiceCall()
+  const mode = useDashboardStore((state) => state.mode)
+  const isEditMode = mode === 'edit'
+
+  const [localValue, setLocalValue] = useState<string>('')
+  const [isEditing, setIsEditing] = useState(false)
+
+  // Update local value when entity changes
+  useEffect(() => {
+    if (entity && !isEditing) {
+      setLocalValue(entity.state)
+    }
+  }, [entity, isEditing])
+
+  const handleClick = useCallback(() => {
+    if (isEditMode && onSelect) {
+      onSelect(!isSelected)
+    } else if (!isEditMode && !isEditing) {
+      setIsEditing(true)
+    }
+  }, [isEditMode, onSelect, isSelected, isEditing])
+
+  const handleDelete = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      onDelete?.()
+    },
+    [onDelete]
+  )
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault()
+      if (!entity || isEditMode) return
+
+      // Validate the datetime format
+      if (!localValue) {
+        setLocalValue(entity.state)
+        setIsEditing(false)
+        return
+      }
+
+      setValue(entity.entity_id, localValue)
+      setIsEditing(false)
+    },
+    [entity, isEditMode, localValue, setValue]
+  )
+
+  const handleCancel = useCallback(() => {
+    if (entity) {
+      setLocalValue(entity.state)
+      setIsEditing(false)
+    }
+  }, [entity])
+
+  const handleFieldClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+  }, [])
+
+  // Format display value
+  const formatDisplayValue = (value: string, attributes: InputDateTimeAttributes) => {
+    if (!value || value === 'unknown') return '(not set)'
+
+    try {
+      const date = new Date(value)
+      if (isNaN(date.getTime())) return value
+
+      const hasDate = attributes.has_date !== false
+      const hasTime = attributes.has_time !== false
+
+      if (hasDate && hasTime) {
+        return date.toLocaleString()
+      } else if (hasDate) {
+        return date.toLocaleDateString()
+      } else if (hasTime) {
+        return date.toLocaleTimeString()
+      }
+      return value
+    } catch {
+      return value
+    }
+  }
+
+  // Get input type based on entity attributes
+  const getInputType = (attributes: InputDateTimeAttributes) => {
+    const hasDate = attributes.has_date !== false
+    const hasTime = attributes.has_time !== false
+
+    if (hasDate && hasTime) return 'datetime-local'
+    if (hasDate) return 'date'
+    if (hasTime) return 'time'
+    return 'datetime-local'
+  }
+
+  // Handle loading/error states
+  if (!isConnected || !entity) {
+    return (
+      <Card
+        className={`
+          relative flex items-center justify-center
+          ${isEditMode ? 'cursor-move' : 'cursor-pointer'}
+          border-2 border-dashed border-red-500
+          ${size === 'small' ? 'p-2' : size === 'large' ? 'p-4' : 'p-3'}
+        `}
+        style={{
+          borderStyle: 'dashed',
+          borderColor: 'var(--red-8)',
+          animation: 'pulse-border 2s ease-in-out infinite',
+        }}
+      >
+        <style>{`
+          @keyframes pulse-border {
+            0%,
+            100% {
+              opacity: 0.5;
+            }
+            50% {
+              opacity: 1;
+            }
+          }
+        `}</style>
+        <Text size="1" color="red">
+          {!isConnected ? 'Disconnected' : 'Entity not found'}
+        </Text>
+      </Card>
+    )
+  }
+
+  const cardSize = {
+    small: { p: '2', iconSize: '16', fontSize: '1', buttonSize: '1' },
+    medium: { p: '3', iconSize: '20', fontSize: '2', buttonSize: '2' },
+    large: { p: '4', iconSize: '24', fontSize: '3', buttonSize: '3' },
+  }[size]
+
+  // Handle unavailable entities
+  if (entity.state === 'unavailable') {
+    return (
+      <Card
+        className={`
+          relative
+          ${isEditMode ? 'cursor-move' : 'cursor-not-allowed'}
+          ${isSelected ? 'ring-2 ring-blue-500' : ''}
+        `}
+        style={{
+          borderStyle: 'dotted',
+          borderColor: 'var(--gray-7)',
+          backgroundColor: isSelected ? 'var(--blue-2)' : undefined,
+          padding: `var(--space-${cardSize.p})`,
+        }}
+        onClick={handleClick}
+      >
+        {isEditMode && (
+          <>
+            <Box
+              className="absolute inset-x-0 top-0 h-6 cursor-move"
+              style={{
+                background: 'linear-gradient(to bottom, rgba(0,0,0,0.1), transparent)',
+              }}
+            />
+            <IconButton
+              size="1"
+              variant="ghost"
+              className="absolute top-1 right-1"
+              onClick={handleDelete}
+              style={{ cursor: 'pointer' }}
+            >
+              <X size={12} />
+            </IconButton>
+          </>
+        )}
+        <Flex direction="column" align="center" gap="2">
+          <Archive size={cardSize.iconSize} style={{ color: 'var(--gray-9)' }} />
+          <Text size={cardSize.fontSize as '1' | '2' | '3'} color="gray">
+            {entity.attributes.friendly_name || entity.entity_id.split('.')[1]}
+          </Text>
+          <Text size="1" color="gray">
+            Unavailable
+          </Text>
+        </Flex>
+      </Card>
+    )
+  }
+
+  const attributes = entity.attributes as InputDateTimeAttributes
+  const isStale = attributes._stale === true
+  const hasDate = attributes.has_date !== false
+  const hasTime = attributes.has_time !== false
+  const Icon = hasDate ? Calendar : Clock
+
+  const displayValue = formatDisplayValue(entity.state, attributes)
+  const inputType = getInputType(attributes)
+
+  return (
+    <Card
+      className={`
+        relative transition-all duration-200
+        ${isEditMode ? 'cursor-move' : 'cursor-pointer'}
+        ${isSelected ? 'ring-2 ring-blue-500' : ''}
+        ${isStale ? 'border-2 border-orange-400' : ''}
+        ${error ? 'border-2 border-red-500' : ''}
+      `}
+      style={{
+        backgroundColor: isSelected ? 'var(--blue-2)' : undefined,
+        borderStyle: isStale ? 'dashed' : error ? 'solid' : undefined,
+        borderColor: isStale ? 'var(--orange-8)' : error ? 'var(--red-8)' : undefined,
+        padding: `var(--space-${cardSize.p})`,
+        animation: error ? 'pulse-border 2s ease-in-out infinite' : undefined,
+      }}
+      onClick={handleClick}
+    >
+      {isEditMode && (
+        <>
+          <Box
+            className="absolute inset-x-0 top-0 h-6 cursor-move"
+            style={{
+              background: 'linear-gradient(to bottom, rgba(0,0,0,0.1), transparent)',
+            }}
+          />
+          <IconButton
+            size="1"
+            variant="ghost"
+            className="absolute top-1 right-1"
+            onClick={handleDelete}
+            style={{ cursor: 'pointer' }}
+          >
+            <X size={12} />
+          </IconButton>
+        </>
+      )}
+
+      {loading && (
+        <Box
+          className="absolute inset-0 flex items-center justify-center bg-black/10"
+          style={{ borderRadius: 'var(--radius-2)' }}
+        >
+          <Box
+            className="h-4 w-4 rounded-full border-2 border-gray-600 border-t-transparent"
+            style={{ animation: 'spin 1s linear infinite' }}
+          />
+        </Box>
+      )}
+
+      <style>{`
+        @keyframes spin {
+          to {
+            transform: rotate(360deg);
+          }
+        }
+        @keyframes pulse-border {
+          0%,
+          100% {
+            opacity: 0.5;
+          }
+          50% {
+            opacity: 1;
+          }
+        }
+      `}</style>
+
+      <Flex direction="column" align="center" gap="2">
+        <Icon size={cardSize.iconSize} style={{ color: 'var(--gray-9)' }} />
+        <Text size={cardSize.fontSize as '1' | '2' | '3'} weight="medium">
+          {attributes.friendly_name || entity.entity_id.split('.')[1]}
+        </Text>
+
+        {!isEditMode ? (
+          <>
+            {isEditing ? (
+              <form onSubmit={handleSubmit} onClick={handleFieldClick}>
+                <Flex align="center" gap="2">
+                  <TextField.Root
+                    size={cardSize.buttonSize as '1' | '2' | '3'}
+                    type={inputType}
+                    value={localValue}
+                    onChange={(e) => setLocalValue(e.target.value)}
+                    autoFocus
+                    style={{ minWidth: '200px' }}
+                  />
+                  <IconButton
+                    size={cardSize.buttonSize as '1' | '2' | '3'}
+                    type="submit"
+                    variant="soft"
+                    color="green"
+                    disabled={loading}
+                  >
+                    <Check size={parseInt(cardSize.iconSize) - 4} />
+                  </IconButton>
+                  <IconButton
+                    size={cardSize.buttonSize as '1' | '2' | '3'}
+                    type="button"
+                    variant="soft"
+                    color="red"
+                    onClick={handleCancel}
+                  >
+                    <X size={parseInt(cardSize.iconSize) - 4} />
+                  </IconButton>
+                </Flex>
+              </form>
+            ) : (
+              <Flex align="center" gap="2">
+                <Box
+                  style={{
+                    padding: '4px 12px',
+                    borderRadius: 'var(--radius-2)',
+                    backgroundColor: 'var(--gray-2)',
+                    minWidth: '120px',
+                    textAlign: 'center',
+                  }}
+                >
+                  <Text size={cardSize.fontSize as '1' | '2' | '3'}>{displayValue}</Text>
+                </Box>
+                <IconButton
+                  size={cardSize.buttonSize as '1' | '2' | '3'}
+                  variant="ghost"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setIsEditing(true)
+                  }}
+                >
+                  <Edit2 size={parseInt(cardSize.iconSize) - 4} />
+                </IconButton>
+              </Flex>
+            )}
+          </>
+        ) : (
+          <Text size={cardSize.fontSize as '1' | '2' | '3'} color="gray">
+            {displayValue}
+          </Text>
+        )}
+
+        {hasDate && hasTime && (
+          <Text size="1" color="gray">
+            Date & Time
+          </Text>
+        )}
+        {hasDate && !hasTime && (
+          <Text size="1" color="gray">
+            Date Only
+          </Text>
+        )}
+        {!hasDate && hasTime && (
+          <Text size="1" color="gray">
+            Time Only
+          </Text>
+        )}
+      </Flex>
+
+      {error && (
+        <Text size="1" color="red" className="absolute bottom-1 left-1 right-1 text-center">
+          {error}
+        </Text>
+      )}
+    </Card>
+  )
+})

--- a/src/components/InputNumberCard.test.tsx
+++ b/src/components/InputNumberCard.test.tsx
@@ -1,0 +1,356 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '../test/utils'
+import { InputNumberCard } from './InputNumberCard'
+import { useEntity } from '../hooks/useEntity'
+import { useServiceCall } from '../hooks/useServiceCall'
+import { useDashboardStore } from '../store'
+
+// Mock the hooks
+vi.mock('../hooks/useEntity')
+vi.mock('../hooks/useServiceCall')
+vi.mock('../store')
+
+describe('InputNumberCard', () => {
+  const mockSetValue = vi.fn()
+  const mockOnSelect = vi.fn()
+
+  const defaultEntity = {
+    entity_id: 'input_number.test_number',
+    state: '50',
+    attributes: {
+      friendly_name: 'Test Number',
+      min: 0,
+      max: 100,
+      step: 1,
+      unit_of_measurement: '%',
+    },
+    last_changed: '2024-01-01T00:00:00Z',
+    last_updated: '2024-01-01T00:00:00Z',
+    context: { id: 'test', parent_id: null, user_id: null },
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    cleanup()
+
+    // Default mock implementations
+    vi.mocked(useEntity).mockReturnValue({
+      entity: defaultEntity,
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    vi.mocked(useServiceCall).mockReturnValue({
+      callService: vi.fn(),
+      turnOn: vi.fn(),
+      turnOff: vi.fn(),
+      toggle: vi.fn(),
+      setValue: mockSetValue,
+      loading: false,
+      error: null,
+      clearError: vi.fn(),
+    })
+
+    vi.mocked(useDashboardStore).mockReturnValue('view')
+  })
+
+  it('renders input number with friendly name and value', () => {
+    render(<InputNumberCard entityId="input_number.test_number" />)
+
+    expect(screen.getByText('Test Number')).toBeInTheDocument()
+    expect(screen.getByText('50 %')).toBeInTheDocument()
+  })
+
+  it('shows entity id when no friendly name', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        attributes: {
+          ...defaultEntity.attributes,
+          friendly_name: undefined,
+        },
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputNumberCard entityId="input_number.test_number" />)
+    expect(screen.getByText('test_number')).toBeInTheDocument()
+  })
+
+  it('shows min and max range', () => {
+    render(<InputNumberCard entityId="input_number.test_number" />)
+    expect(screen.getByText('0 - 100')).toBeInTheDocument()
+  })
+
+  it('increments value on plus button click', async () => {
+    render(<InputNumberCard entityId="input_number.test_number" />)
+
+    const buttons = screen.getAllByRole('button')
+    const plusButton = buttons[buttons.length - 1] // Plus button is last
+    fireEvent.click(plusButton)
+
+    await waitFor(() => {
+      expect(mockSetValue).toHaveBeenCalledWith('input_number.test_number', 51)
+    })
+  })
+
+  it('decrements value on minus button click', async () => {
+    render(<InputNumberCard entityId="input_number.test_number" />)
+
+    const buttons = screen.getAllByRole('button')
+    const minusButton = buttons[buttons.length - 2] // Minus button is second to last
+    fireEvent.click(minusButton)
+
+    await waitFor(() => {
+      expect(mockSetValue).toHaveBeenCalledWith('input_number.test_number', 49)
+    })
+  })
+
+  it('respects max value limit', async () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        state: '100',
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputNumberCard entityId="input_number.test_number" />)
+
+    const buttons = screen.getAllByRole('button')
+    const plusButton = buttons[buttons.length - 1] // Plus button is last
+    expect(plusButton).toBeDisabled()
+  })
+
+  it('respects min value limit', async () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        state: '0',
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputNumberCard entityId="input_number.test_number" />)
+
+    const buttons = screen.getAllByRole('button')
+    const minusButton = buttons[buttons.length - 2] // Minus button is second to last
+    expect(minusButton).toBeDisabled()
+  })
+
+  it('uses step value for increment/decrement', async () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        state: '50',
+        attributes: {
+          ...defaultEntity.attributes,
+          step: 5,
+        },
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputNumberCard entityId="input_number.test_number" />)
+
+    const buttons = screen.getAllByRole('button')
+    const plusButton = buttons[buttons.length - 1] // Plus button is last
+    fireEvent.click(plusButton)
+
+    await waitFor(() => {
+      expect(mockSetValue).toHaveBeenCalledWith('input_number.test_number', 55)
+    })
+  })
+
+  it('allows direct value editing', async () => {
+    render(<InputNumberCard entityId="input_number.test_number" />)
+
+    // Click on the value display to edit
+    const valueDisplay = screen.getByText('50 %')
+    fireEvent.click(valueDisplay)
+
+    // Should show input field
+    const input = screen.getByRole('textbox')
+    expect(input).toHaveValue('50')
+
+    // Change value and submit
+    fireEvent.change(input, { target: { value: '75' } })
+    fireEvent.submit(input.closest('form')!)
+
+    await waitFor(() => {
+      expect(mockSetValue).toHaveBeenCalledWith('input_number.test_number', 75)
+    })
+  })
+
+  it('validates input within min/max range', async () => {
+    render(<InputNumberCard entityId="input_number.test_number" />)
+
+    const valueDisplay = screen.getByText('50 %')
+    fireEvent.click(valueDisplay)
+
+    const input = screen.getByRole('textbox')
+
+    // Try to set value above max
+    fireEvent.change(input, { target: { value: '150' } })
+    fireEvent.submit(input.closest('form')!)
+
+    await waitFor(() => {
+      expect(mockSetValue).toHaveBeenCalledWith('input_number.test_number', 100) // Clamped to max
+    })
+  })
+
+  it('handles invalid input', async () => {
+    render(<InputNumberCard entityId="input_number.test_number" />)
+
+    const valueDisplay = screen.getByText('50 %')
+    fireEvent.click(valueDisplay)
+
+    const input = screen.getByRole('textbox')
+
+    // Enter invalid value
+    fireEvent.change(input, { target: { value: 'abc' } })
+    fireEvent.submit(input.closest('form')!)
+
+    await waitFor(() => {
+      expect(mockSetValue).not.toHaveBeenCalled()
+      // Value should revert to original
+      expect(screen.getByText('50 %')).toBeInTheDocument()
+    })
+  })
+
+  it('selects card in edit mode', async () => {
+    vi.mocked(useDashboardStore).mockReturnValue('edit')
+
+    render(
+      <InputNumberCard
+        entityId="input_number.test_number"
+        onSelect={mockOnSelect}
+        isSelected={false}
+      />
+    )
+
+    // Controls should not be visible in edit mode
+    expect(screen.queryByRole('button', { name: /plus/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /minus/i })).not.toBeInTheDocument()
+
+    const card = screen.getByText('Test Number').closest('.rt-Card')!
+    fireEvent.click(card)
+
+    await waitFor(() => {
+      expect(mockOnSelect).toHaveBeenCalledWith(true)
+      expect(mockSetValue).not.toHaveBeenCalled()
+    })
+  })
+
+  it('shows loading state', () => {
+    vi.mocked(useServiceCall).mockReturnValue({
+      callService: vi.fn(),
+      turnOn: vi.fn(),
+      turnOff: vi.fn(),
+      toggle: vi.fn(),
+      setValue: mockSetValue,
+      loading: true,
+      error: null,
+      clearError: vi.fn(),
+    })
+
+    const { container } = render(<InputNumberCard entityId="input_number.test_number" />)
+
+    // Check for spinner
+    const spinner = container.querySelector('[style*="animation: spin"]')
+    expect(spinner).toBeInTheDocument()
+
+    // Buttons should be disabled during loading
+    const buttons = screen.getAllByRole('button')
+    expect(buttons[buttons.length - 2]).toBeDisabled() // Minus button
+    expect(buttons[buttons.length - 1]).toBeDisabled() // Plus button
+  })
+
+  it('shows error state', () => {
+    vi.mocked(useServiceCall).mockReturnValue({
+      callService: vi.fn(),
+      turnOn: vi.fn(),
+      turnOff: vi.fn(),
+      toggle: vi.fn(),
+      setValue: mockSetValue,
+      loading: false,
+      error: 'Failed to set value',
+      clearError: vi.fn(),
+    })
+
+    const { container } = render(<InputNumberCard entityId="input_number.test_number" />)
+
+    const card = container.querySelector('.rt-Card')
+    expect(card).toHaveClass('border-2', 'border-red-500')
+    expect(screen.getByText('Failed to set value')).toBeInTheDocument()
+  })
+
+  it('handles no unit of measurement', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        attributes: {
+          ...defaultEntity.attributes,
+          unit_of_measurement: undefined,
+        },
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputNumberCard entityId="input_number.test_number" />)
+    expect(screen.getByText('50')).toBeInTheDocument() // No unit shown
+  })
+
+  it('formats decimal values based on step', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        state: '50.5',
+        attributes: {
+          ...defaultEntity.attributes,
+          step: 0.1,
+        },
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputNumberCard entityId="input_number.test_number" />)
+    expect(screen.getByText('50.5 %')).toBeInTheDocument()
+  })
+
+  describe('size variants', () => {
+    it('renders small size', () => {
+      render(<InputNumberCard entityId="input_number.test_number" size="small" />)
+
+      const text = screen.getByText('Test Number')
+      expect(text).toHaveClass('rt-r-size-1')
+    })
+
+    it('renders medium size', () => {
+      render(<InputNumberCard entityId="input_number.test_number" size="medium" />)
+
+      const text = screen.getByText('Test Number')
+      expect(text).toHaveClass('rt-r-size-2')
+    })
+
+    it('renders large size', () => {
+      render(<InputNumberCard entityId="input_number.test_number" size="large" />)
+
+      const text = screen.getByText('Test Number')
+      expect(text).toHaveClass('rt-r-size-3')
+    })
+  })
+})

--- a/src/components/InputNumberCard.tsx
+++ b/src/components/InputNumberCard.tsx
@@ -1,0 +1,392 @@
+import React, { memo, useCallback, useState, useEffect } from 'react'
+import { Box, Card, Flex, IconButton, Text, TextField } from '@radix-ui/themes'
+import { Archive, Hash, Minus, Plus, X } from 'lucide-react'
+import { useEntity } from '../hooks/useEntity'
+import { useServiceCall } from '../hooks/useServiceCall'
+import { useDashboardStore } from '../store'
+
+interface InputNumberCardProps {
+  entityId: string
+  size?: 'small' | 'medium' | 'large'
+  onDelete?: () => void
+  isSelected?: boolean
+  onSelect?: (selected: boolean) => void
+}
+
+interface InputNumberAttributes {
+  friendly_name?: string
+  min?: number
+  max?: number
+  step?: number
+  unit_of_measurement?: string
+  mode?: 'slider' | 'box'
+  _stale?: boolean
+}
+
+export const InputNumberCard = memo(function InputNumberCard({
+  entityId,
+  size = 'medium',
+  onDelete,
+  isSelected = false,
+  onSelect,
+}: InputNumberCardProps) {
+  const { entity, isConnected } = useEntity(entityId)
+  const { setValue, loading, error } = useServiceCall()
+  const mode = useDashboardStore((state) => state.mode)
+  const isEditMode = mode === 'edit'
+
+  const [localValue, setLocalValue] = useState<string>('')
+  const [isEditing, setIsEditing] = useState(false)
+
+  // Update local value when entity changes
+  useEffect(() => {
+    if (entity && !isEditing) {
+      setLocalValue(entity.state)
+    }
+  }, [entity, isEditing])
+
+  const handleClick = useCallback(() => {
+    if (isEditMode && onSelect) {
+      onSelect(!isSelected)
+    }
+  }, [isEditMode, onSelect, isSelected])
+
+  const handleDelete = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      onDelete?.()
+    },
+    [onDelete]
+  )
+
+  const handleIncrement = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      if (!entity || isEditMode) return
+
+      const attributes = entity.attributes as InputNumberAttributes
+      const currentValue = parseFloat(entity.state)
+      const step = attributes.step || 1
+      const max = attributes.max
+
+      const newValue = currentValue + step
+      const finalValue = max !== undefined ? Math.min(newValue, max) : newValue
+
+      setValue(entity.entity_id, finalValue)
+    },
+    [entity, isEditMode, setValue]
+  )
+
+  const handleDecrement = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      if (!entity || isEditMode) return
+
+      const attributes = entity.attributes as InputNumberAttributes
+      const currentValue = parseFloat(entity.state)
+      const step = attributes.step || 1
+      const min = attributes.min
+
+      const newValue = currentValue - step
+      const finalValue = min !== undefined ? Math.max(newValue, min) : newValue
+
+      setValue(entity.entity_id, finalValue)
+    },
+    [entity, isEditMode, setValue]
+  )
+
+  const handleValueSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault()
+      if (!entity || isEditMode) return
+
+      const attributes = entity.attributes as InputNumberAttributes
+      const value = parseFloat(localValue)
+
+      if (isNaN(value)) {
+        setLocalValue(entity.state)
+        setIsEditing(false)
+        return
+      }
+
+      const min = attributes.min
+      const max = attributes.max
+
+      let finalValue = value
+      if (min !== undefined) finalValue = Math.max(finalValue, min)
+      if (max !== undefined) finalValue = Math.min(finalValue, max)
+
+      setValue(entity.entity_id, finalValue)
+      setIsEditing(false)
+    },
+    [entity, isEditMode, localValue, setValue]
+  )
+
+  const handleFieldClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      if (!isEditMode) {
+        setIsEditing(true)
+      }
+    },
+    [isEditMode]
+  )
+
+  const handleFieldBlur = useCallback(() => {
+    if (entity) {
+      setLocalValue(entity.state)
+      setIsEditing(false)
+    }
+  }, [entity])
+
+  // Handle loading/error states
+  if (!isConnected || !entity) {
+    return (
+      <Card
+        className={`
+          relative flex items-center justify-center
+          ${isEditMode ? 'cursor-move' : 'cursor-pointer'}
+          border-2 border-dashed border-red-500
+          ${size === 'small' ? 'p-2' : size === 'large' ? 'p-4' : 'p-3'}
+        `}
+        style={{
+          borderStyle: 'dashed',
+          borderColor: 'var(--red-8)',
+          animation: 'pulse-border 2s ease-in-out infinite',
+        }}
+      >
+        <style>{`
+          @keyframes pulse-border {
+            0%,
+            100% {
+              opacity: 0.5;
+            }
+            50% {
+              opacity: 1;
+            }
+          }
+        `}</style>
+        <Text size="1" color="red">
+          {!isConnected ? 'Disconnected' : 'Entity not found'}
+        </Text>
+      </Card>
+    )
+  }
+
+  const cardSize = {
+    small: { p: '2', iconSize: '16', fontSize: '1', buttonSize: '1' },
+    medium: { p: '3', iconSize: '20', fontSize: '2', buttonSize: '2' },
+    large: { p: '4', iconSize: '24', fontSize: '3', buttonSize: '3' },
+  }[size]
+
+  // Handle unavailable entities
+  if (entity.state === 'unavailable') {
+    return (
+      <Card
+        className={`
+          relative
+          ${isEditMode ? 'cursor-move' : 'cursor-not-allowed'}
+          ${isSelected ? 'ring-2 ring-blue-500' : ''}
+        `}
+        style={{
+          borderStyle: 'dotted',
+          borderColor: 'var(--gray-7)',
+          backgroundColor: isSelected ? 'var(--blue-2)' : undefined,
+          padding: `var(--space-${cardSize.p})`,
+        }}
+        onClick={handleClick}
+      >
+        {isEditMode && (
+          <>
+            <Box
+              className="absolute inset-x-0 top-0 h-6 cursor-move"
+              style={{
+                background: 'linear-gradient(to bottom, rgba(0,0,0,0.1), transparent)',
+              }}
+            />
+            <IconButton
+              size="1"
+              variant="ghost"
+              className="absolute top-1 right-1"
+              onClick={handleDelete}
+              style={{ cursor: 'pointer' }}
+            >
+              <X size={12} />
+            </IconButton>
+          </>
+        )}
+        <Flex direction="column" align="center" gap="2">
+          <Archive size={cardSize.iconSize} style={{ color: 'var(--gray-9)' }} />
+          <Text size={cardSize.fontSize as '1' | '2' | '3'} color="gray">
+            {entity.attributes.friendly_name || entity.entity_id.split('.')[1]}
+          </Text>
+          <Text size="1" color="gray">
+            Unavailable
+          </Text>
+        </Flex>
+      </Card>
+    )
+  }
+
+  const attributes = entity.attributes as InputNumberAttributes
+  const isStale = attributes._stale === true
+  const unit = attributes.unit_of_measurement || ''
+
+  // Format display value
+  const displayValue = parseFloat(entity.state).toFixed(
+    attributes.step && attributes.step < 1 ? 1 : 0
+  )
+
+  return (
+    <Card
+      className={`
+        relative transition-all duration-200
+        ${isEditMode ? 'cursor-move' : 'cursor-pointer'}
+        ${isSelected ? 'ring-2 ring-blue-500' : ''}
+        ${isStale ? 'border-2 border-orange-400' : ''}
+        ${error ? 'border-2 border-red-500' : ''}
+      `}
+      style={{
+        backgroundColor: isSelected ? 'var(--blue-2)' : undefined,
+        borderStyle: isStale ? 'dashed' : error ? 'solid' : undefined,
+        borderColor: isStale ? 'var(--orange-8)' : error ? 'var(--red-8)' : undefined,
+        padding: `var(--space-${cardSize.p})`,
+        animation: error ? 'pulse-border 2s ease-in-out infinite' : undefined,
+      }}
+      onClick={handleClick}
+    >
+      {isEditMode && (
+        <>
+          <Box
+            className="absolute inset-x-0 top-0 h-6 cursor-move"
+            style={{
+              background: 'linear-gradient(to bottom, rgba(0,0,0,0.1), transparent)',
+            }}
+          />
+          <IconButton
+            size="1"
+            variant="ghost"
+            className="absolute top-1 right-1"
+            onClick={handleDelete}
+            style={{ cursor: 'pointer' }}
+          >
+            <X size={12} />
+          </IconButton>
+        </>
+      )}
+
+      {loading && (
+        <Box
+          className="absolute inset-0 flex items-center justify-center bg-black/10"
+          style={{ borderRadius: 'var(--radius-2)' }}
+        >
+          <Box
+            className="h-4 w-4 rounded-full border-2 border-gray-600 border-t-transparent"
+            style={{ animation: 'spin 1s linear infinite' }}
+          />
+        </Box>
+      )}
+
+      <style>{`
+        @keyframes spin {
+          to {
+            transform: rotate(360deg);
+          }
+        }
+        @keyframes pulse-border {
+          0%,
+          100% {
+            opacity: 0.5;
+          }
+          50% {
+            opacity: 1;
+          }
+        }
+      `}</style>
+
+      <Flex direction="column" align="center" gap="2">
+        <Hash size={cardSize.iconSize} style={{ color: 'var(--gray-9)' }} />
+        <Text size={cardSize.fontSize as '1' | '2' | '3'} weight="medium">
+          {attributes.friendly_name || entity.entity_id.split('.')[1]}
+        </Text>
+
+        {!isEditMode ? (
+          <Flex align="center" gap="2">
+            <IconButton
+              size={cardSize.buttonSize as '1' | '2' | '3'}
+              variant="soft"
+              onClick={handleDecrement}
+              disabled={
+                loading ||
+                (attributes.min !== undefined && parseFloat(entity.state) <= attributes.min)
+              }
+              style={{ cursor: 'pointer' }}
+            >
+              <Minus size={parseInt(cardSize.iconSize) - 4} />
+            </IconButton>
+
+            {isEditing ? (
+              <form onSubmit={handleValueSubmit}>
+                <TextField.Root
+                  size={cardSize.buttonSize as '1' | '2' | '3'}
+                  value={localValue}
+                  onChange={(e) => setLocalValue(e.target.value)}
+                  onBlur={handleFieldBlur}
+                  autoFocus
+                  style={{ width: '80px', textAlign: 'center' }}
+                />
+              </form>
+            ) : (
+              <Box
+                onClick={handleFieldClick}
+                style={{
+                  cursor: 'text',
+                  padding: '4px 8px',
+                  borderRadius: 'var(--radius-2)',
+                  backgroundColor: 'var(--gray-2)',
+                  minWidth: '60px',
+                  textAlign: 'center',
+                }}
+              >
+                <Text size={cardSize.fontSize as '1' | '2' | '3'} weight="bold">
+                  {displayValue}
+                  {unit && ` ${unit}`}
+                </Text>
+              </Box>
+            )}
+
+            <IconButton
+              size={cardSize.buttonSize as '1' | '2' | '3'}
+              variant="soft"
+              onClick={handleIncrement}
+              disabled={
+                loading ||
+                (attributes.max !== undefined && parseFloat(entity.state) >= attributes.max)
+              }
+              style={{ cursor: 'pointer' }}
+            >
+              <Plus size={parseInt(cardSize.iconSize) - 4} />
+            </IconButton>
+          </Flex>
+        ) : (
+          <Text size={cardSize.fontSize as '1' | '2' | '3'} color="gray">
+            {displayValue}
+            {unit && ` ${unit}`}
+          </Text>
+        )}
+
+        {attributes.min !== undefined && attributes.max !== undefined && !isEditMode && (
+          <Text size="1" color="gray">
+            {attributes.min} - {attributes.max}
+          </Text>
+        )}
+      </Flex>
+
+      {error && (
+        <Text size="1" color="red" className="absolute bottom-1 left-1 right-1 text-center">
+          {error}
+        </Text>
+      )}
+    </Card>
+  )
+})

--- a/src/components/InputSelectCard.test.tsx
+++ b/src/components/InputSelectCard.test.tsx
@@ -1,0 +1,314 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '../test/utils'
+import { InputSelectCard } from './InputSelectCard'
+import { useEntity } from '../hooks/useEntity'
+import { useServiceCall } from '../hooks/useServiceCall'
+import { useDashboardStore } from '../store'
+
+// Mock the hooks
+vi.mock('../hooks/useEntity')
+vi.mock('../hooks/useServiceCall')
+vi.mock('../store')
+
+describe('InputSelectCard', () => {
+  const mockSetValue = vi.fn()
+  const mockOnDelete = vi.fn()
+  const mockOnSelect = vi.fn()
+
+  const defaultEntity = {
+    entity_id: 'input_select.test_select',
+    state: 'Option 1',
+    attributes: {
+      friendly_name: 'Test Select',
+      options: ['Option 1', 'Option 2', 'Option 3'],
+    },
+    last_changed: '2024-01-01T00:00:00Z',
+    last_updated: '2024-01-01T00:00:00Z',
+    context: { id: 'test', parent_id: null, user_id: null },
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    cleanup()
+
+    // Default mock implementations
+    vi.mocked(useEntity).mockReturnValue({
+      entity: defaultEntity,
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    vi.mocked(useServiceCall).mockReturnValue({
+      callService: vi.fn(),
+      turnOn: vi.fn(),
+      turnOff: vi.fn(),
+      toggle: vi.fn(),
+      setValue: mockSetValue,
+      loading: false,
+      error: null,
+      clearError: vi.fn(),
+    })
+
+    vi.mocked(useDashboardStore).mockReturnValue('view')
+  })
+
+  it('renders input select with friendly name and current value', () => {
+    render(<InputSelectCard entityId="input_select.test_select" />)
+
+    expect(screen.getByText('Test Select')).toBeInTheDocument()
+    expect(screen.getByText('Option 1')).toBeInTheDocument()
+  })
+
+  it('shows entity id when no friendly name', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        attributes: {
+          ...defaultEntity.attributes,
+          friendly_name: undefined,
+        },
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputSelectCard entityId="input_select.test_select" />)
+    expect(screen.getByText('test_select')).toBeInTheDocument()
+  })
+
+  it('opens dropdown and shows all options', async () => {
+    render(<InputSelectCard entityId="input_select.test_select" />)
+
+    // Click the select trigger
+    const trigger = screen.getByRole('combobox')
+    fireEvent.click(trigger)
+
+    await waitFor(() => {
+      expect(screen.getByText('Option 2')).toBeInTheDocument()
+      expect(screen.getByText('Option 3')).toBeInTheDocument()
+    })
+  })
+
+  it('changes value when selecting an option', async () => {
+    render(<InputSelectCard entityId="input_select.test_select" />)
+
+    // Open dropdown
+    const trigger = screen.getByRole('combobox')
+    fireEvent.click(trigger)
+
+    // Select Option 2
+    await waitFor(() => {
+      const option2 = screen.getByText('Option 2')
+      fireEvent.click(option2)
+    })
+
+    await waitFor(() => {
+      expect(mockSetValue).toHaveBeenCalledWith('input_select.test_select', 'Option 2')
+    })
+  })
+
+  it('prevents propagation when clicking select', async () => {
+    const mockCardClick = vi.fn()
+    const { container } = render(
+      <div onClick={mockCardClick}>
+        <InputSelectCard entityId="input_select.test_select" />
+      </div>
+    )
+
+    // Click the select container element
+    const selectBox = container.querySelector('.rt-Box')!
+    if (selectBox) {
+      fireEvent.click(selectBox)
+    }
+
+    expect(mockCardClick).not.toHaveBeenCalled()
+  })
+
+  it('selects card in edit mode', async () => {
+    vi.mocked(useDashboardStore).mockReturnValue('edit')
+
+    render(
+      <InputSelectCard
+        entityId="input_select.test_select"
+        onSelect={mockOnSelect}
+        isSelected={false}
+      />
+    )
+
+    // Select should not be visible in edit mode
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+    expect(screen.getByText('3 options')).toBeInTheDocument()
+
+    const card = screen.getByText('Test Select').closest('.rt-Card')!
+    fireEvent.click(card)
+
+    await waitFor(() => {
+      expect(mockOnSelect).toHaveBeenCalledWith(true)
+      expect(mockSetValue).not.toHaveBeenCalled()
+    })
+  })
+
+  it('shows selected state styling', () => {
+    const { container } = render(
+      <InputSelectCard entityId="input_select.test_select" isSelected={true} />
+    )
+
+    const card = container.querySelector('.rt-Card')
+    expect(card).toHaveClass('ring-2', 'ring-blue-500')
+    expect(card).toHaveStyle({ backgroundColor: 'var(--blue-2)' })
+  })
+
+  it('shows delete button in edit mode', () => {
+    vi.mocked(useDashboardStore).mockReturnValue('edit')
+
+    render(<InputSelectCard entityId="input_select.test_select" onDelete={mockOnDelete} />)
+
+    const deleteButton = screen.getByRole('button')
+    fireEvent.click(deleteButton)
+
+    expect(mockOnDelete).toHaveBeenCalled()
+  })
+
+  it('shows loading state', () => {
+    vi.mocked(useServiceCall).mockReturnValue({
+      callService: vi.fn(),
+      turnOn: vi.fn(),
+      turnOff: vi.fn(),
+      toggle: vi.fn(),
+      setValue: mockSetValue,
+      loading: true,
+      error: null,
+      clearError: vi.fn(),
+    })
+
+    const { container } = render(<InputSelectCard entityId="input_select.test_select" />)
+
+    // Check for spinner
+    const spinner = container.querySelector('[style*="animation: spin"]')
+    expect(spinner).toBeInTheDocument()
+
+    // Select should be disabled during loading
+    expect(screen.getByRole('combobox')).toBeDisabled()
+  })
+
+  it('shows error state', () => {
+    vi.mocked(useServiceCall).mockReturnValue({
+      callService: vi.fn(),
+      turnOn: vi.fn(),
+      turnOff: vi.fn(),
+      toggle: vi.fn(),
+      setValue: mockSetValue,
+      loading: false,
+      error: 'Failed to set value',
+      clearError: vi.fn(),
+    })
+
+    const { container } = render(<InputSelectCard entityId="input_select.test_select" />)
+
+    const card = container.querySelector('.rt-Card')
+    expect(card).toHaveClass('border-2', 'border-red-500')
+    expect(screen.getByText('Failed to set value')).toBeInTheDocument()
+  })
+
+  it('shows stale data indicator', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        attributes: {
+          ...defaultEntity.attributes,
+          _stale: true,
+        },
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    const { container } = render(<InputSelectCard entityId="input_select.test_select" />)
+
+    const card = container.querySelector('.rt-Card')
+    expect(card).toHaveClass('border-2', 'border-orange-400')
+    expect(card).toHaveStyle({ borderStyle: 'dashed' })
+  })
+
+  it('handles entity with no options', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        attributes: {
+          ...defaultEntity.attributes,
+          options: [],
+        },
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputSelectCard entityId="input_select.test_select" />)
+
+    expect(screen.getByRole('combobox')).toBeDisabled()
+  })
+
+  it('handles entity with missing options attribute', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        attributes: {
+          friendly_name: 'Test Select',
+        },
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputSelectCard entityId="input_select.test_select" />)
+
+    expect(screen.getByRole('combobox')).toBeDisabled()
+  })
+
+  it('shows singular option count in edit mode', () => {
+    vi.mocked(useDashboardStore).mockReturnValue('edit')
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        attributes: {
+          ...defaultEntity.attributes,
+          options: ['Single Option'],
+        },
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputSelectCard entityId="input_select.test_select" />)
+    expect(screen.getByText('1 option')).toBeInTheDocument() // Singular
+  })
+
+  describe('size variants', () => {
+    it('renders small size', () => {
+      render(<InputSelectCard entityId="input_select.test_select" size="small" />)
+
+      const text = screen.getByText('Test Select')
+      expect(text).toHaveClass('rt-r-size-1')
+    })
+
+    it('renders medium size', () => {
+      render(<InputSelectCard entityId="input_select.test_select" size="medium" />)
+
+      const text = screen.getByText('Test Select')
+      expect(text).toHaveClass('rt-r-size-2')
+    })
+
+    it('renders large size', () => {
+      render(<InputSelectCard entityId="input_select.test_select" size="large" />)
+
+      const text = screen.getByText('Test Select')
+      expect(text).toHaveClass('rt-r-size-3')
+    })
+  })
+})

--- a/src/components/InputSelectCard.tsx
+++ b/src/components/InputSelectCard.tsx
@@ -1,0 +1,266 @@
+import React, { memo, useCallback } from 'react'
+import { Box, Card, Flex, IconButton, Select, Text } from '@radix-ui/themes'
+import { Archive, ChevronDown, List, X } from 'lucide-react'
+import { useEntity } from '../hooks/useEntity'
+import { useServiceCall } from '../hooks/useServiceCall'
+import { useDashboardStore } from '../store'
+
+interface InputSelectCardProps {
+  entityId: string
+  size?: 'small' | 'medium' | 'large'
+  onDelete?: () => void
+  isSelected?: boolean
+  onSelect?: (selected: boolean) => void
+}
+
+interface InputSelectAttributes {
+  friendly_name?: string
+  options?: string[]
+  _stale?: boolean
+}
+
+export const InputSelectCard = memo(function InputSelectCard({
+  entityId,
+  size = 'medium',
+  onDelete,
+  isSelected = false,
+  onSelect,
+}: InputSelectCardProps) {
+  const { entity, isConnected } = useEntity(entityId)
+  const { setValue, loading, error } = useServiceCall()
+  const mode = useDashboardStore((state) => state.mode)
+  const isEditMode = mode === 'edit'
+
+  const handleClick = useCallback(() => {
+    if (isEditMode && onSelect) {
+      onSelect(!isSelected)
+    }
+  }, [isEditMode, onSelect, isSelected])
+
+  const handleDelete = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      onDelete?.()
+    },
+    [onDelete]
+  )
+
+  const handleValueChange = useCallback(
+    (value: string) => {
+      if (!entity || isEditMode) return
+      setValue(entity.entity_id, value)
+    },
+    [entity, isEditMode, setValue]
+  )
+
+  // Handle loading/error states
+  if (!isConnected || !entity) {
+    return (
+      <Card
+        className={`
+          relative flex items-center justify-center
+          ${isEditMode ? 'cursor-move' : 'cursor-pointer'}
+          border-2 border-dashed border-red-500
+          ${size === 'small' ? 'p-2' : size === 'large' ? 'p-4' : 'p-3'}
+        `}
+        style={{
+          borderStyle: 'dashed',
+          borderColor: 'var(--red-8)',
+          animation: 'pulse-border 2s ease-in-out infinite',
+        }}
+      >
+        <style>{`
+          @keyframes pulse-border {
+            0%,
+            100% {
+              opacity: 0.5;
+            }
+            50% {
+              opacity: 1;
+            }
+          }
+        `}</style>
+        <Text size="1" color="red">
+          {!isConnected ? 'Disconnected' : 'Entity not found'}
+        </Text>
+      </Card>
+    )
+  }
+
+  const cardSize = {
+    small: { p: '2', iconSize: '16', fontSize: '1' },
+    medium: { p: '3', iconSize: '20', fontSize: '2' },
+    large: { p: '4', iconSize: '24', fontSize: '3' },
+  }[size]
+
+  // Handle unavailable entities
+  if (entity.state === 'unavailable') {
+    return (
+      <Card
+        className={`
+          relative
+          ${isEditMode ? 'cursor-move' : 'cursor-not-allowed'}
+          ${isSelected ? 'ring-2 ring-blue-500' : ''}
+        `}
+        style={{
+          borderStyle: 'dotted',
+          borderColor: 'var(--gray-7)',
+          backgroundColor: isSelected ? 'var(--blue-2)' : undefined,
+          padding: `var(--space-${cardSize.p})`,
+        }}
+        onClick={handleClick}
+      >
+        {isEditMode && (
+          <>
+            <Box
+              className="absolute inset-x-0 top-0 h-6 cursor-move"
+              style={{
+                background: 'linear-gradient(to bottom, rgba(0,0,0,0.1), transparent)',
+              }}
+            />
+            <IconButton
+              size="1"
+              variant="ghost"
+              className="absolute top-1 right-1"
+              onClick={handleDelete}
+              style={{ cursor: 'pointer' }}
+            >
+              <X size={12} />
+            </IconButton>
+          </>
+        )}
+        <Flex direction="column" align="center" gap="2">
+          <Archive size={cardSize.iconSize} style={{ color: 'var(--gray-9)' }} />
+          <Text size={cardSize.fontSize as '1' | '2' | '3'} color="gray">
+            {entity.attributes.friendly_name || entity.entity_id.split('.')[1]}
+          </Text>
+          <Text size="1" color="gray">
+            Unavailable
+          </Text>
+        </Flex>
+      </Card>
+    )
+  }
+
+  const attributes = entity.attributes as InputSelectAttributes
+  const isStale = attributes._stale === true
+  const options = attributes.options || []
+  const currentValue = entity.state
+
+  return (
+    <Card
+      className={`
+        relative transition-all duration-200
+        ${isEditMode ? 'cursor-move' : 'cursor-pointer'}
+        ${isSelected ? 'ring-2 ring-blue-500' : ''}
+        ${isStale ? 'border-2 border-orange-400' : ''}
+        ${error ? 'border-2 border-red-500' : ''}
+      `}
+      style={{
+        backgroundColor: isSelected ? 'var(--blue-2)' : undefined,
+        borderStyle: isStale ? 'dashed' : error ? 'solid' : undefined,
+        borderColor: isStale ? 'var(--orange-8)' : error ? 'var(--red-8)' : undefined,
+        padding: `var(--space-${cardSize.p})`,
+        animation: error ? 'pulse-border 2s ease-in-out infinite' : undefined,
+      }}
+      onClick={handleClick}
+    >
+      {isEditMode && (
+        <>
+          <Box
+            className="absolute inset-x-0 top-0 h-6 cursor-move"
+            style={{
+              background: 'linear-gradient(to bottom, rgba(0,0,0,0.1), transparent)',
+            }}
+          />
+          <IconButton
+            size="1"
+            variant="ghost"
+            className="absolute top-1 right-1"
+            onClick={handleDelete}
+            style={{ cursor: 'pointer' }}
+          >
+            <X size={12} />
+          </IconButton>
+        </>
+      )}
+
+      {loading && (
+        <Box
+          className="absolute inset-0 flex items-center justify-center bg-black/10"
+          style={{ borderRadius: 'var(--radius-2)' }}
+        >
+          <Box
+            className="h-4 w-4 rounded-full border-2 border-gray-600 border-t-transparent"
+            style={{ animation: 'spin 1s linear infinite' }}
+          />
+        </Box>
+      )}
+
+      <style>{`
+        @keyframes spin {
+          to {
+            transform: rotate(360deg);
+          }
+        }
+        @keyframes pulse-border {
+          0%,
+          100% {
+            opacity: 0.5;
+          }
+          50% {
+            opacity: 1;
+          }
+        }
+      `}</style>
+
+      <Flex direction="column" align="center" gap="2">
+        <List size={cardSize.iconSize} style={{ color: 'var(--gray-9)' }} />
+        <Text size={cardSize.fontSize as '1' | '2' | '3'} weight="medium">
+          {attributes.friendly_name || entity.entity_id.split('.')[1]}
+        </Text>
+
+        {!isEditMode ? (
+          <Box onClick={(e) => e.stopPropagation()} style={{ minWidth: '120px' }}>
+            <Select.Root
+              value={currentValue}
+              onValueChange={handleValueChange}
+              disabled={loading || options.length === 0}
+            >
+              <Select.Trigger variant="soft" style={{ width: '100%' }}>
+                <Flex align="center" justify="between" style={{ width: '100%' }}>
+                  <Text size={cardSize.fontSize as '1' | '2' | '3'}>{currentValue}</Text>
+                  <ChevronDown size={parseInt(cardSize.iconSize) - 4} />
+                </Flex>
+              </Select.Trigger>
+              <Select.Content>
+                {options.map((option) => (
+                  <Select.Item key={option} value={option}>
+                    {option}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select.Root>
+          </Box>
+        ) : (
+          <Flex direction="column" align="center" gap="1">
+            <Text size={cardSize.fontSize as '1' | '2' | '3'} weight="bold" color="gray">
+              {currentValue}
+            </Text>
+            {options.length > 0 && (
+              <Text size="1" color="gray">
+                {options.length} option{options.length !== 1 ? 's' : ''}
+              </Text>
+            )}
+          </Flex>
+        )}
+      </Flex>
+
+      {error && (
+        <Text size="1" color="red" className="absolute bottom-1 left-1 right-1 text-center">
+          {error}
+        </Text>
+      )}
+    </Card>
+  )
+})

--- a/src/components/InputTextCard.test.tsx
+++ b/src/components/InputTextCard.test.tsx
@@ -1,0 +1,337 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '../test/utils'
+import { InputTextCard } from './InputTextCard'
+import { useEntity } from '../hooks/useEntity'
+import { useServiceCall } from '../hooks/useServiceCall'
+import { useDashboardStore } from '../store'
+
+// Mock the hooks
+vi.mock('../hooks/useEntity')
+vi.mock('../hooks/useServiceCall')
+vi.mock('../store')
+
+describe('InputTextCard', () => {
+  const mockSetValue = vi.fn()
+  const mockOnSelect = vi.fn()
+
+  const defaultEntity = {
+    entity_id: 'input_text.test_text',
+    state: 'Hello World',
+    attributes: {
+      friendly_name: 'Test Text',
+      min: 3,
+      max: 20,
+    },
+    last_changed: '2024-01-01T00:00:00Z',
+    last_updated: '2024-01-01T00:00:00Z',
+    context: { id: 'test', parent_id: null, user_id: null },
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    cleanup()
+
+    // Default mock implementations
+    vi.mocked(useEntity).mockReturnValue({
+      entity: defaultEntity,
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    vi.mocked(useServiceCall).mockReturnValue({
+      callService: vi.fn(),
+      turnOn: vi.fn(),
+      turnOff: vi.fn(),
+      toggle: vi.fn(),
+      setValue: mockSetValue,
+      loading: false,
+      error: null,
+      clearError: vi.fn(),
+    })
+
+    vi.mocked(useDashboardStore).mockReturnValue('view')
+  })
+
+  it('renders input text with friendly name and value', () => {
+    render(<InputTextCard entityId="input_text.test_text" />)
+
+    expect(screen.getByText('Test Text')).toBeInTheDocument()
+    expect(screen.getByText('Hello World')).toBeInTheDocument()
+  })
+
+  it('shows entity id when no friendly name', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        attributes: {
+          ...defaultEntity.attributes,
+          friendly_name: undefined,
+        },
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputTextCard entityId="input_text.test_text" />)
+    expect(screen.getByText('test_text')).toBeInTheDocument()
+  })
+
+  it('shows character limits when min and max are defined', () => {
+    render(<InputTextCard entityId="input_text.test_text" />)
+    expect(screen.getByText('3 - 20 chars')).toBeInTheDocument()
+  })
+
+  it('enters edit mode on click in view mode', async () => {
+    render(<InputTextCard entityId="input_text.test_text" />)
+
+    const card = screen.getByText('Test Text').closest('.rt-Card')!
+    fireEvent.click(card)
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toBeInTheDocument()
+      expect(screen.getByRole('textbox')).toHaveValue('Hello World')
+    })
+  })
+
+  it('submits new value on form submit', async () => {
+    render(<InputTextCard entityId="input_text.test_text" />)
+
+    // Enter edit mode
+    const card = screen.getByText('Test Text').closest('.rt-Card')!
+    fireEvent.click(card)
+
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'New Value' } })
+
+    const buttons = screen.getAllByRole('button')
+    const submitButton = buttons[0] // Submit button is first
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockSetValue).toHaveBeenCalledWith('input_text.test_text', 'New Value')
+    })
+  })
+
+  it('cancels edit on cancel button click', async () => {
+    render(<InputTextCard entityId="input_text.test_text" />)
+
+    // Enter edit mode
+    const card = screen.getByText('Test Text').closest('.rt-Card')!
+    fireEvent.click(card)
+
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'Changed Value' } })
+
+    const buttons = screen.getAllByRole('button')
+    const cancelButton = buttons[1] // Cancel button is second
+    fireEvent.click(cancelButton)
+
+    await waitFor(() => {
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+      expect(screen.getByText('Hello World')).toBeInTheDocument()
+      expect(mockSetValue).not.toHaveBeenCalled()
+    })
+  })
+
+  it('validates min length constraint', async () => {
+    render(<InputTextCard entityId="input_text.test_text" />)
+
+    // Enter edit mode
+    const card = screen.getByText('Test Text').closest('.rt-Card')!
+    fireEvent.click(card)
+
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'Hi' } }) // Too short
+
+    const form = input.closest('form')!
+    fireEvent.submit(form)
+
+    await waitFor(() => {
+      expect(mockSetValue).not.toHaveBeenCalled()
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+    })
+  })
+
+  it('enforces max length in input field', () => {
+    render(<InputTextCard entityId="input_text.test_text" />)
+
+    // Enter edit mode
+    const card = screen.getByText('Test Text').closest('.rt-Card')!
+    fireEvent.click(card)
+
+    const input = screen.getByRole('textbox')
+    expect(input).toHaveAttribute('maxLength', '20')
+  })
+
+  it('validates pattern constraint', async () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        attributes: {
+          ...defaultEntity.attributes,
+          pattern: '^[A-Z]+$', // Only uppercase letters
+        },
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputTextCard entityId="input_text.test_text" />)
+
+    // Enter edit mode
+    const card = screen.getByText('Test Text').closest('.rt-Card')!
+    fireEvent.click(card)
+
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'lowercase' } })
+
+    const form = input.closest('form')!
+    fireEvent.submit(form)
+
+    await waitFor(() => {
+      expect(mockSetValue).not.toHaveBeenCalled()
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows password field for password mode', async () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        state: 'secret123',
+        attributes: {
+          ...defaultEntity.attributes,
+          mode: 'password',
+        },
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputTextCard entityId="input_text.test_text" />)
+
+    // Should show masked value
+    expect(screen.getByText('••••••••')).toBeInTheDocument()
+
+    // Click the edit button to enter edit mode
+    const editButton = screen.getByRole('button')
+    fireEvent.click(editButton)
+
+    // Wait for edit mode and check the password input
+    await waitFor(() => {
+      const input = screen.getByRole('textbox')
+      expect(input).toBeInTheDocument()
+      expect(input).toHaveAttribute('type', 'password')
+    })
+  })
+
+  it('shows empty state', () => {
+    vi.mocked(useEntity).mockReturnValue({
+      entity: {
+        ...defaultEntity,
+        state: '',
+      },
+      isConnected: true,
+      isLoading: false,
+      isStale: false,
+    })
+
+    render(<InputTextCard entityId="input_text.test_text" />)
+    expect(screen.getByText('(empty)')).toBeInTheDocument()
+  })
+
+  it('shows edit button that enters edit mode', async () => {
+    render(<InputTextCard entityId="input_text.test_text" />)
+
+    const editButton = screen.getAllByRole('button')[0]
+    fireEvent.click(editButton)
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toBeInTheDocument()
+    })
+  })
+
+  it('selects card in edit mode', async () => {
+    vi.mocked(useDashboardStore).mockReturnValue('edit')
+
+    render(
+      <InputTextCard entityId="input_text.test_text" onSelect={mockOnSelect} isSelected={false} />
+    )
+
+    // Input field should not be visible in edit mode
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+
+    const card = screen.getByText('Test Text').closest('.rt-Card')!
+    fireEvent.click(card)
+
+    await waitFor(() => {
+      expect(mockOnSelect).toHaveBeenCalledWith(true)
+      expect(mockSetValue).not.toHaveBeenCalled()
+    })
+  })
+
+  it('shows loading state', () => {
+    vi.mocked(useServiceCall).mockReturnValue({
+      callService: vi.fn(),
+      turnOn: vi.fn(),
+      turnOff: vi.fn(),
+      toggle: vi.fn(),
+      setValue: mockSetValue,
+      loading: true,
+      error: null,
+      clearError: vi.fn(),
+    })
+
+    const { container } = render(<InputTextCard entityId="input_text.test_text" />)
+
+    // Check for spinner
+    const spinner = container.querySelector('[style*="animation: spin"]')
+    expect(spinner).toBeInTheDocument()
+  })
+
+  it('shows error state', () => {
+    vi.mocked(useServiceCall).mockReturnValue({
+      callService: vi.fn(),
+      turnOn: vi.fn(),
+      turnOff: vi.fn(),
+      toggle: vi.fn(),
+      setValue: mockSetValue,
+      loading: false,
+      error: 'Failed to set value',
+      clearError: vi.fn(),
+    })
+
+    const { container } = render(<InputTextCard entityId="input_text.test_text" />)
+
+    const card = container.querySelector('.rt-Card')
+    expect(card).toHaveClass('border-2', 'border-red-500')
+    expect(screen.getByText('Failed to set value')).toBeInTheDocument()
+  })
+
+  describe('size variants', () => {
+    it('renders small size', () => {
+      render(<InputTextCard entityId="input_text.test_text" size="small" />)
+
+      const text = screen.getByText('Test Text')
+      expect(text).toHaveClass('rt-r-size-1')
+    })
+
+    it('renders medium size', () => {
+      render(<InputTextCard entityId="input_text.test_text" size="medium" />)
+
+      const text = screen.getByText('Test Text')
+      expect(text).toHaveClass('rt-r-size-2')
+    })
+
+    it('renders large size', () => {
+      render(<InputTextCard entityId="input_text.test_text" size="large" />)
+
+      const text = screen.getByText('Test Text')
+      expect(text).toHaveClass('rt-r-size-3')
+    })
+  })
+})

--- a/src/components/InputTextCard.test.tsx
+++ b/src/components/InputTextCard.test.tsx
@@ -223,7 +223,8 @@ describe('InputTextCard', () => {
 
     // Wait for edit mode and check the password input
     await waitFor(() => {
-      const input = screen.getByRole('textbox')
+      // Password inputs don't have role="textbox", find by type
+      const input = screen.getByDisplayValue('secret123')
       expect(input).toBeInTheDocument()
       expect(input).toHaveAttribute('type', 'password')
     })

--- a/src/components/InputTextCard.tsx
+++ b/src/components/InputTextCard.tsx
@@ -1,0 +1,367 @@
+import React, { memo, useCallback, useState, useEffect } from 'react'
+import { Box, Card, Flex, IconButton, Text, TextField } from '@radix-ui/themes'
+import { Archive, Check, Edit2, Type, X } from 'lucide-react'
+import { useEntity } from '../hooks/useEntity'
+import { useServiceCall } from '../hooks/useServiceCall'
+import { useDashboardStore } from '../store'
+
+interface InputTextCardProps {
+  entityId: string
+  size?: 'small' | 'medium' | 'large'
+  onDelete?: () => void
+  isSelected?: boolean
+  onSelect?: (selected: boolean) => void
+}
+
+interface InputTextAttributes {
+  friendly_name?: string
+  min?: number
+  max?: number
+  pattern?: string
+  mode?: 'text' | 'password'
+  _stale?: boolean
+}
+
+export const InputTextCard = memo(function InputTextCard({
+  entityId,
+  size = 'medium',
+  onDelete,
+  isSelected = false,
+  onSelect,
+}: InputTextCardProps) {
+  const { entity, isConnected } = useEntity(entityId)
+  const { setValue, loading, error } = useServiceCall()
+  const mode = useDashboardStore((state) => state.mode)
+  const isEditMode = mode === 'edit'
+
+  const [localValue, setLocalValue] = useState<string>('')
+  const [isEditing, setIsEditing] = useState(false)
+
+  // Update local value when entity changes
+  useEffect(() => {
+    if (entity && !isEditing) {
+      setLocalValue(entity.state)
+    }
+  }, [entity, isEditing])
+
+  const handleClick = useCallback(() => {
+    if (isEditMode && onSelect) {
+      onSelect(!isSelected)
+    } else if (!isEditMode && !isEditing) {
+      setIsEditing(true)
+    }
+  }, [isEditMode, onSelect, isSelected, isEditing])
+
+  const handleDelete = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      onDelete?.()
+    },
+    [onDelete]
+  )
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault()
+      if (!entity || isEditMode) return
+
+      const attributes = entity.attributes as InputTextAttributes
+
+      // Validate length constraints
+      if (attributes.min && localValue.length < attributes.min) {
+        setLocalValue(entity.state)
+        setIsEditing(false)
+        return
+      }
+
+      if (attributes.max && localValue.length > attributes.max) {
+        setLocalValue(localValue.substring(0, attributes.max))
+        return
+      }
+
+      // Validate pattern if provided
+      if (attributes.pattern) {
+        const regex = new RegExp(attributes.pattern)
+        if (!regex.test(localValue)) {
+          setLocalValue(entity.state)
+          setIsEditing(false)
+          return
+        }
+      }
+
+      setValue(entity.entity_id, localValue)
+      setIsEditing(false)
+    },
+    [entity, isEditMode, localValue, setValue]
+  )
+
+  const handleCancel = useCallback(() => {
+    if (entity) {
+      setLocalValue(entity.state)
+      setIsEditing(false)
+    }
+  }, [entity])
+
+  const handleFieldClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+  }, [])
+
+  // Handle loading/error states
+  if (!isConnected || !entity) {
+    return (
+      <Card
+        className={`
+          relative flex items-center justify-center
+          ${isEditMode ? 'cursor-move' : 'cursor-pointer'}
+          border-2 border-dashed border-red-500
+          ${size === 'small' ? 'p-2' : size === 'large' ? 'p-4' : 'p-3'}
+        `}
+        style={{
+          borderStyle: 'dashed',
+          borderColor: 'var(--red-8)',
+          animation: 'pulse-border 2s ease-in-out infinite',
+        }}
+      >
+        <style>{`
+          @keyframes pulse-border {
+            0%,
+            100% {
+              opacity: 0.5;
+            }
+            50% {
+              opacity: 1;
+            }
+          }
+        `}</style>
+        <Text size="1" color="red">
+          {!isConnected ? 'Disconnected' : 'Entity not found'}
+        </Text>
+      </Card>
+    )
+  }
+
+  const cardSize = {
+    small: { p: '2', iconSize: '16', fontSize: '1', buttonSize: '1' },
+    medium: { p: '3', iconSize: '20', fontSize: '2', buttonSize: '2' },
+    large: { p: '4', iconSize: '24', fontSize: '3', buttonSize: '3' },
+  }[size]
+
+  // Handle unavailable entities
+  if (entity.state === 'unavailable') {
+    return (
+      <Card
+        className={`
+          relative
+          ${isEditMode ? 'cursor-move' : 'cursor-not-allowed'}
+          ${isSelected ? 'ring-2 ring-blue-500' : ''}
+        `}
+        style={{
+          borderStyle: 'dotted',
+          borderColor: 'var(--gray-7)',
+          backgroundColor: isSelected ? 'var(--blue-2)' : undefined,
+          padding: `var(--space-${cardSize.p})`,
+        }}
+        onClick={handleClick}
+      >
+        {isEditMode && (
+          <>
+            <Box
+              className="absolute inset-x-0 top-0 h-6 cursor-move"
+              style={{
+                background: 'linear-gradient(to bottom, rgba(0,0,0,0.1), transparent)',
+              }}
+            />
+            <IconButton
+              size="1"
+              variant="ghost"
+              className="absolute top-1 right-1"
+              onClick={handleDelete}
+              style={{ cursor: 'pointer' }}
+            >
+              <X size={12} />
+            </IconButton>
+          </>
+        )}
+        <Flex direction="column" align="center" gap="2">
+          <Archive size={cardSize.iconSize} style={{ color: 'var(--gray-9)' }} />
+          <Text size={cardSize.fontSize as '1' | '2' | '3'} color="gray">
+            {entity.attributes.friendly_name || entity.entity_id.split('.')[1]}
+          </Text>
+          <Text size="1" color="gray">
+            Unavailable
+          </Text>
+        </Flex>
+      </Card>
+    )
+  }
+
+  const attributes = entity.attributes as InputTextAttributes
+  const isStale = attributes._stale === true
+  const isPassword = attributes.mode === 'password'
+
+  // Display value (mask if password and not editing)
+  const displayValue = isPassword && !isEditing ? '••••••••' : entity.state
+
+  return (
+    <Card
+      className={`
+        relative transition-all duration-200
+        ${isEditMode ? 'cursor-move' : 'cursor-pointer'}
+        ${isSelected ? 'ring-2 ring-blue-500' : ''}
+        ${isStale ? 'border-2 border-orange-400' : ''}
+        ${error ? 'border-2 border-red-500' : ''}
+      `}
+      style={{
+        backgroundColor: isSelected ? 'var(--blue-2)' : undefined,
+        borderStyle: isStale ? 'dashed' : error ? 'solid' : undefined,
+        borderColor: isStale ? 'var(--orange-8)' : error ? 'var(--red-8)' : undefined,
+        padding: `var(--space-${cardSize.p})`,
+        animation: error ? 'pulse-border 2s ease-in-out infinite' : undefined,
+      }}
+      onClick={handleClick}
+    >
+      {isEditMode && (
+        <>
+          <Box
+            className="absolute inset-x-0 top-0 h-6 cursor-move"
+            style={{
+              background: 'linear-gradient(to bottom, rgba(0,0,0,0.1), transparent)',
+            }}
+          />
+          <IconButton
+            size="1"
+            variant="ghost"
+            className="absolute top-1 right-1"
+            onClick={handleDelete}
+            style={{ cursor: 'pointer' }}
+          >
+            <X size={12} />
+          </IconButton>
+        </>
+      )}
+
+      {loading && (
+        <Box
+          className="absolute inset-0 flex items-center justify-center bg-black/10"
+          style={{ borderRadius: 'var(--radius-2)' }}
+        >
+          <Box
+            className="h-4 w-4 rounded-full border-2 border-gray-600 border-t-transparent"
+            style={{ animation: 'spin 1s linear infinite' }}
+          />
+        </Box>
+      )}
+
+      <style>{`
+        @keyframes spin {
+          to {
+            transform: rotate(360deg);
+          }
+        }
+        @keyframes pulse-border {
+          0%,
+          100% {
+            opacity: 0.5;
+          }
+          50% {
+            opacity: 1;
+          }
+        }
+      `}</style>
+
+      <Flex direction="column" align="center" gap="2">
+        <Type size={cardSize.iconSize} style={{ color: 'var(--gray-9)' }} />
+        <Text size={cardSize.fontSize as '1' | '2' | '3'} weight="medium">
+          {attributes.friendly_name || entity.entity_id.split('.')[1]}
+        </Text>
+
+        {!isEditMode ? (
+          <>
+            {isEditing ? (
+              <form onSubmit={handleSubmit} onClick={handleFieldClick}>
+                <Flex align="center" gap="2">
+                  <TextField.Root
+                    size={cardSize.buttonSize as '1' | '2' | '3'}
+                    type={isPassword ? 'password' : 'text'}
+                    value={localValue}
+                    onChange={(e) => setLocalValue(e.target.value)}
+                    autoFocus
+                    style={{ minWidth: '150px' }}
+                    maxLength={attributes.max}
+                  />
+                  <IconButton
+                    size={cardSize.buttonSize as '1' | '2' | '3'}
+                    type="submit"
+                    variant="soft"
+                    color="green"
+                    disabled={loading}
+                  >
+                    <Check size={parseInt(cardSize.iconSize) - 4} />
+                  </IconButton>
+                  <IconButton
+                    size={cardSize.buttonSize as '1' | '2' | '3'}
+                    type="button"
+                    variant="soft"
+                    color="red"
+                    onClick={handleCancel}
+                  >
+                    <X size={parseInt(cardSize.iconSize) - 4} />
+                  </IconButton>
+                </Flex>
+              </form>
+            ) : (
+              <Flex align="center" gap="2">
+                <Box
+                  style={{
+                    padding: '4px 12px',
+                    borderRadius: 'var(--radius-2)',
+                    backgroundColor: 'var(--gray-2)',
+                    minWidth: '100px',
+                    textAlign: 'center',
+                  }}
+                >
+                  <Text
+                    size={cardSize.fontSize as '1' | '2' | '3'}
+                    style={{ fontFamily: isPassword ? 'monospace' : undefined }}
+                  >
+                    {displayValue || '(empty)'}
+                  </Text>
+                </Box>
+                <IconButton
+                  size={cardSize.buttonSize as '1' | '2' | '3'}
+                  variant="ghost"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setIsEditing(true)
+                  }}
+                >
+                  <Edit2 size={parseInt(cardSize.iconSize) - 4} />
+                </IconButton>
+              </Flex>
+            )}
+          </>
+        ) : (
+          <Text
+            size={cardSize.fontSize as '1' | '2' | '3'}
+            color="gray"
+            style={{ fontFamily: isPassword ? 'monospace' : undefined }}
+          >
+            {displayValue || '(empty)'}
+          </Text>
+        )}
+
+        {attributes.min !== undefined && attributes.max !== undefined && (
+          <Text size="1" color="gray">
+            {attributes.min} - {attributes.max} chars
+          </Text>
+        )}
+      </Flex>
+
+      {error && (
+        <Text size="1" color="red" className="absolute bottom-1 left-1 right-1 text-center">
+          {error}
+        </Text>
+      )}
+    </Card>
+  )
+})

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -22,3 +22,6 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
   unobserve: vi.fn(),
   disconnect: vi.fn(),
 }))
+
+// Mock scrollIntoView
+Element.prototype.scrollIntoView = vi.fn()

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -1,0 +1,15 @@
+import { render, RenderOptions } from '@testing-library/react'
+import { Theme } from '@radix-ui/themes'
+import '@radix-ui/themes/styles.css'
+
+// Custom render function that includes providers
+export function renderWithTheme(ui: React.ReactElement, options?: RenderOptions) {
+  return render(ui, {
+    wrapper: ({ children }) => <Theme>{children}</Theme>,
+    ...options,
+  })
+}
+
+// Re-export everything from testing library
+export * from '@testing-library/react'
+export { renderWithTheme as render }


### PR DESCRIPTION
Closes #52

## Summary
- Created comprehensive input entity components for Home Assistant input helpers
- Implemented InputBooleanCard with toggle/switch functionality
- Implemented InputNumberCard with increment/decrement controls
- Implemented InputSelectCard with dropdown selection
- Implemented InputTextCard with inline text editing
- Implemented InputDateTimeCard with date/time picker support
- Updated GridView to automatically select the appropriate card type based on entity domain

## Implementation Details
- **InputBooleanCard**: Toggle switch with visual feedback, follows same pattern as LightCard
- **InputNumberCard**: Plus/minus buttons with inline editing, respects min/max constraints
- **InputSelectCard**: Dropdown with all available options, shows option count in edit mode
- **InputTextCard**: Click-to-edit with submit/cancel buttons, supports password mode
- **InputDateTimeCard**: Automatic input type selection based on has_date/has_time attributes
- **Touch-optimized**: All controls sized appropriately for touch interaction
- **Real-time sync**: All changes immediately update Home Assistant state
- **Edit mode support**: Full support for selection, deletion, and drag-and-drop

## Testing
- [x] Created comprehensive test suites for all input components (91 tests total)
- [x] Tested value validation and constraints
- [x] Tested edit mode functionality
- [x] Tested error and loading states
- [x] All tests pass
- [x] TypeScript checks pass
- [x] Linting passes