### PR TITLE
feat: add theme support with light/dark/system modes

### DIFF
--- a/src/components/ConfigurationMenu.tsx
+++ b/src/components/ConfigurationMenu.tsx
@@ -181,7 +181,10 @@ export function ConfigurationMenu() {
           <DropdownMenu.Separator />
 
           <DropdownMenu.Label>Theme</DropdownMenu.Label>
-          <DropdownMenu.RadioGroup value={theme} onValueChange={(value) => dashboardActions.setTheme(value as 'light' | 'dark' | 'auto')}>
+          <DropdownMenu.RadioGroup
+            value={theme}
+            onValueChange={(value) => dashboardActions.setTheme(value as 'light' | 'dark' | 'auto')}
+          >
             <DropdownMenu.RadioItem value="light">
               <SunIcon />
               Light

--- a/src/components/ConfigurationMenu.tsx
+++ b/src/components/ConfigurationMenu.tsx
@@ -8,6 +8,9 @@ import {
   ExclamationTriangleIcon,
   CopyIcon,
   DownloadIcon,
+  SunIcon,
+  MoonIcon,
+  DesktopIcon,
 } from '@radix-ui/react-icons'
 import {
   exportConfigurationToFile,
@@ -21,8 +24,10 @@ import {
 } from '../store/persistence'
 import { ImportPreviewDialog } from './ImportPreviewDialog'
 import type { DashboardConfig } from '../store/types'
+import { useDashboardStore, dashboardActions } from '../store/dashboardStore'
 
 export function ConfigurationMenu() {
+  const theme = useDashboardStore((state) => state.theme)
   const [resetDialogOpen, setResetDialogOpen] = useState(false)
   const [importError, setImportError] = useState<string | null>(null)
   const [importSuccess, setImportSuccess] = useState<string | null>(null)
@@ -172,6 +177,24 @@ export function ConfigurationMenu() {
               {(storageInfo.used / 1024).toFixed(1)} KB used ({storageInfo.percentage.toFixed(1)}%)
             </Text>
           </DropdownMenu.Item>
+
+          <DropdownMenu.Separator />
+
+          <DropdownMenu.Label>Theme</DropdownMenu.Label>
+          <DropdownMenu.RadioGroup value={theme} onValueChange={(value) => dashboardActions.setTheme(value as 'light' | 'dark' | 'auto')}>
+            <DropdownMenu.RadioItem value="light">
+              <SunIcon />
+              Light
+            </DropdownMenu.RadioItem>
+            <DropdownMenu.RadioItem value="dark">
+              <MoonIcon />
+              Dark
+            </DropdownMenu.RadioItem>
+            <DropdownMenu.RadioItem value="auto">
+              <DesktopIcon />
+              System
+            </DropdownMenu.RadioItem>
+          </DropdownMenu.RadioGroup>
 
           <DropdownMenu.Separator />
 

--- a/src/components/__tests__/ThemeToggle.test.tsx
+++ b/src/components/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ConfigurationMenu } from '../ConfigurationMenu'
+import { dashboardStore, dashboardActions } from '~/store/dashboardStore'
+import { Theme } from '@radix-ui/themes'
+
+describe('Theme Toggle', () => {
+  beforeEach(() => {
+    // Reset theme to default
+    dashboardStore.setState((state) => ({ ...state, theme: 'auto' }))
+  })
+
+  it('should display current theme in menu', async () => {
+    const user = userEvent.setup()
+    
+    render(
+      <Theme>
+        <ConfigurationMenu />
+      </Theme>
+    )
+
+    // Open the menu
+    const configButton = screen.getByText('Configuration')
+    await user.click(configButton)
+
+    // Check that theme label is displayed
+    await waitFor(() => {
+      expect(screen.getByText('Theme')).toBeInTheDocument()
+    })
+  })
+
+  it('should change theme when selecting light mode', async () => {
+    const user = userEvent.setup()
+    
+    render(
+      <Theme>
+        <ConfigurationMenu />
+      </Theme>
+    )
+
+    // Open the menu
+    const configButton = screen.getByText('Configuration')
+    await user.click(configButton)
+
+    // Wait for menu to open and click on Light theme
+    await waitFor(() => {
+      const lightOption = screen.getByText('Light')
+      expect(lightOption).toBeInTheDocument()
+    })
+    
+    const lightOption = screen.getByText('Light')
+    await user.click(lightOption)
+
+    // Verify theme was updated in store
+    expect(dashboardStore.state.theme).toBe('light')
+  })
+
+  it('should change theme when selecting dark mode', async () => {
+    const user = userEvent.setup()
+    
+    render(
+      <Theme>
+        <ConfigurationMenu />
+      </Theme>
+    )
+
+    // Open the menu
+    const configButton = screen.getByText('Configuration')
+    await user.click(configButton)
+
+    // Wait for menu to open and click on Dark theme
+    await waitFor(() => {
+      const darkOption = screen.getByText('Dark')
+      expect(darkOption).toBeInTheDocument()
+    })
+    
+    const darkOption = screen.getByText('Dark')
+    await user.click(darkOption)
+
+    // Verify theme was updated in store
+    expect(dashboardStore.state.theme).toBe('dark')
+  })
+
+  it('should change theme when selecting system mode', async () => {
+    const user = userEvent.setup()
+    
+    // Set to light first
+    dashboardActions.setTheme('light')
+    
+    render(
+      <Theme>
+        <ConfigurationMenu />
+      </Theme>
+    )
+
+    // Open the menu
+    const configButton = screen.getByText('Configuration')
+    await user.click(configButton)
+
+    // Wait for menu to open and click on System theme
+    await waitFor(() => {
+      const systemOption = screen.getByText('System')
+      expect(systemOption).toBeInTheDocument()
+    })
+    
+    const systemOption = screen.getByText('System')
+    await user.click(systemOption)
+
+    // Verify theme was updated in store
+    expect(dashboardStore.state.theme).toBe('auto')
+  })
+})

--- a/src/components/__tests__/ThemeToggle.test.tsx
+++ b/src/components/__tests__/ThemeToggle.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ConfigurationMenu } from '../ConfigurationMenu'
@@ -13,7 +13,7 @@ describe('Theme Toggle', () => {
 
   it('should display current theme in menu', async () => {
     const user = userEvent.setup()
-    
+
     render(
       <Theme>
         <ConfigurationMenu />
@@ -32,7 +32,7 @@ describe('Theme Toggle', () => {
 
   it('should change theme when selecting light mode', async () => {
     const user = userEvent.setup()
-    
+
     render(
       <Theme>
         <ConfigurationMenu />
@@ -48,7 +48,7 @@ describe('Theme Toggle', () => {
       const lightOption = screen.getByText('Light')
       expect(lightOption).toBeInTheDocument()
     })
-    
+
     const lightOption = screen.getByText('Light')
     await user.click(lightOption)
 
@@ -58,7 +58,7 @@ describe('Theme Toggle', () => {
 
   it('should change theme when selecting dark mode', async () => {
     const user = userEvent.setup()
-    
+
     render(
       <Theme>
         <ConfigurationMenu />
@@ -74,7 +74,7 @@ describe('Theme Toggle', () => {
       const darkOption = screen.getByText('Dark')
       expect(darkOption).toBeInTheDocument()
     })
-    
+
     const darkOption = screen.getByText('Dark')
     await user.click(darkOption)
 
@@ -84,10 +84,10 @@ describe('Theme Toggle', () => {
 
   it('should change theme when selecting system mode', async () => {
     const user = userEvent.setup()
-    
+
     // Set to light first
     dashboardActions.setTheme('light')
-    
+
     render(
       <Theme>
         <ConfigurationMenu />
@@ -103,7 +103,7 @@ describe('Theme Toggle', () => {
       const systemOption = screen.getByText('System')
       expect(systemOption).toBeInTheDocument()
     })
-    
+
     const systemOption = screen.getByText('System')
     await user.click(systemOption)
 


### PR DESCRIPTION
## Summary
- Add theme selector to configuration menu with light, dark, and system (auto) options
- Implement automatic theme switching based on system preferences
- Ensure theme persists across sessions

## Related Issue
Closes #60

## Testing
- [x] Theme can be changed from Configuration menu
- [x] Light mode displays correctly
- [x] Dark mode displays correctly  
- [x] System mode follows OS preference
- [x] System mode updates dynamically when OS preference changes
- [x] Theme persists after page reload
- [x] All tests pass

## Screenshots
The theme selector is available in the Configuration dropdown menu with three options:
- ☀️ Light
- 🌙 Dark
- 🖥️ System

## Implementation Details
- Theme state is stored in the dashboard store and persists via localStorage
- Root component applies the theme to Radix UI Theme component
- System preference detection uses `matchMedia` API with event listeners for dynamic updates
- All existing components automatically adapt to the theme through Radix UI's CSS variables