### PR TITLE
feat: implement persistent sidebar state management

### DIFF
--- a/src/components/TabSidebar.tsx
+++ b/src/components/TabSidebar.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Box, Flex, IconButton, ScrollArea } from '@radix-ui/themes'
 import { Cross2Icon, HeartFilledIcon, HeartIcon } from '@radix-ui/react-icons'
 import { useStore } from '@tanstack/react-store'
-import { dashboardStore } from '../store/dashboardStore'
+import { dashboardStore, dashboardActions } from '../store/dashboardStore'
 import { useIsMobile } from '../../app/utils/responsive'
 import './TabSidebar.css'
 
@@ -17,12 +17,12 @@ export function TabSidebar({ children }: TabSidebarProps) {
 
   const handleClose = () => {
     if (!sidebarPinned) {
-      dashboardStore.setState((state) => ({ ...state, sidebarOpen: false }))
+      dashboardActions.toggleSidebar(false)
     }
   }
 
   const handleTogglePin = () => {
-    dashboardStore.setState((state) => ({ ...state, sidebarPinned: !state.sidebarPinned }))
+    dashboardActions.toggleSidebarPin()
   }
 
   return (
@@ -33,7 +33,7 @@ export function TabSidebar({ children }: TabSidebarProps) {
           <IconButton
             size="3"
             variant="soft"
-            onClick={() => dashboardStore.setState((state) => ({ ...state, sidebarOpen: true }))}
+            onClick={() => dashboardActions.toggleSidebar(true)}
             aria-label="Open sidebar"
             className="tab-trigger-button"
           >

--- a/src/store/__tests__/sidebar-persistence.test.ts
+++ b/src/store/__tests__/sidebar-persistence.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { dashboardStore, dashboardActions } from '../dashboardStore'
-import { saveDashboardConfig, loadDashboardConfig } from '../persistence'
+import { saveDashboardConfig } from '../persistence'
 import type { DashboardConfig } from '../types'
 
 // Mock localStorage

--- a/src/store/__tests__/sidebar-persistence.test.ts
+++ b/src/store/__tests__/sidebar-persistence.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { dashboardStore, dashboardActions } from '../dashboardStore'
+import { saveDashboardConfig, loadDashboardConfig } from '../persistence'
+import type { DashboardConfig } from '../types'
+
+// Mock localStorage
+const localStorageMock = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+}
+Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+
+describe('Sidebar State Persistence', () => {
+  beforeEach(() => {
+    // Reset store to initial state
+    dashboardActions.resetState()
+    // Clear localStorage mock
+    localStorageMock.getItem.mockClear()
+    localStorageMock.setItem.mockClear()
+  })
+
+  it('should include sidebar state in exported configuration', () => {
+    // Set sidebar state
+    dashboardActions.toggleSidebar(true)
+    dashboardActions.toggleSidebarPin()
+
+    // Export configuration
+    const config = dashboardActions.exportConfiguration()
+
+    // Check that sidebar state is included
+    expect(config.sidebarOpen).toBe(true)
+    expect(config.sidebarPinned).toBe(true)
+  })
+
+  it('should restore sidebar state from configuration', () => {
+    // Create a configuration with sidebar state
+    const config: DashboardConfig = {
+      version: '1.0.0',
+      screens: [],
+      theme: 'auto',
+      sidebarOpen: true,
+      sidebarPinned: true,
+    }
+
+    // Load the configuration
+    dashboardActions.loadConfiguration(config)
+
+    // Check that sidebar state was restored
+    const state = dashboardStore.state
+    expect(state.sidebarOpen).toBe(true)
+    expect(state.sidebarPinned).toBe(true)
+  })
+
+  it('should persist sidebar state changes to localStorage', () => {
+    // Mock the export configuration
+    const mockConfig: DashboardConfig = {
+      version: '1.0.0',
+      screens: [],
+      theme: 'auto',
+      sidebarOpen: true,
+      sidebarPinned: false,
+    }
+
+    // Save configuration
+    saveDashboardConfig(mockConfig)
+
+    // Check localStorage was called
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      'liebe-config',
+      JSON.stringify(mockConfig)
+    )
+  })
+
+  it('should mark state as dirty when sidebar state changes', () => {
+    // Initial state should not be dirty
+    expect(dashboardStore.state.isDirty).toBe(false)
+
+    // Toggle sidebar
+    dashboardActions.toggleSidebar(true)
+    expect(dashboardStore.state.isDirty).toBe(true)
+
+    // Mark clean
+    dashboardActions.markClean()
+    expect(dashboardStore.state.isDirty).toBe(false)
+
+    // Toggle pin
+    dashboardActions.toggleSidebarPin()
+    expect(dashboardStore.state.isDirty).toBe(true)
+  })
+
+  it('should preserve sidebar state when not specified in config', () => {
+    // Set initial sidebar state
+    dashboardActions.toggleSidebar(true)
+    dashboardActions.toggleSidebarPin()
+    dashboardActions.markClean()
+
+    // Load config without sidebar state
+    const config: DashboardConfig = {
+      version: '1.0.0',
+      screens: [],
+      theme: 'dark',
+    }
+    dashboardActions.loadConfiguration(config)
+
+    // Sidebar state should be preserved
+    const state = dashboardStore.state
+    expect(state.sidebarOpen).toBe(true)
+    expect(state.sidebarPinned).toBe(true)
+    expect(state.theme).toBe('dark') // Theme should be updated
+  })
+})

--- a/src/store/dashboardStore.ts
+++ b/src/store/dashboardStore.ts
@@ -296,6 +296,8 @@ export const dashboardActions = {
       configuration: config,
       gridResolution: DEFAULT_GRID_RESOLUTION,
       theme: config.theme || 'auto',
+      sidebarOpen: config.sidebarOpen ?? state.sidebarOpen,
+      sidebarPinned: config.sidebarPinned ?? state.sidebarPinned,
       isDirty: false,
     }))
   },
@@ -306,6 +308,8 @@ export const dashboardActions = {
       version: state.configuration.version,
       screens: state.screens,
       theme: state.theme,
+      sidebarOpen: state.sidebarOpen,
+      sidebarPinned: state.sidebarPinned,
     }
   },
 
@@ -324,6 +328,15 @@ export const dashboardActions = {
     dashboardStore.setState((state) => ({
       ...state,
       sidebarOpen: open !== undefined ? open : !state.sidebarOpen,
+      isDirty: true,
+    }))
+  },
+
+  toggleSidebarPin: () => {
+    dashboardStore.setState((state) => ({
+      ...state,
+      sidebarPinned: !state.sidebarPinned,
+      isDirty: true,
     }))
   },
 

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -271,6 +271,8 @@ export const exportConfigurationAsYAML = (): string => {
     '# Generated': new Date().toISOString(),
     version: config.version,
     theme: config.theme || 'auto',
+    sidebarOpen: config.sidebarOpen,
+    sidebarPinned: config.sidebarPinned,
     screens: config.screens,
   }
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -33,6 +33,8 @@ export interface DashboardConfig {
   version: string
   screens: ScreenConfig[]
   theme?: 'light' | 'dark' | 'auto'
+  sidebarOpen?: boolean
+  sidebarPinned?: boolean
 }
 
 export type DashboardMode = 'view' | 'edit'


### PR DESCRIPTION
Closes #74

## Summary
- Added sidebar state (sidebarOpen and sidebarPinned) to the dashboard configuration
- Implemented persistence of sidebar state to localStorage
- Updated export/import functionality to include sidebar state in both JSON and YAML formats
- Added proper actions for toggling sidebar state that mark the state as dirty
- Created comprehensive tests for sidebar state persistence

## Changes Made

### Configuration Updates
- Added `sidebarOpen` and `sidebarPinned` to `DashboardConfig` interface
- Updated `exportConfiguration` to include sidebar state
- Updated `loadConfiguration` to restore sidebar state (with fallback to current state)
- Updated YAML export to include sidebar properties

### Store Actions
- Modified `toggleSidebar` action to mark state as dirty
- Added new `toggleSidebarPin` action for pin state management
- Updated TabSidebar component to use proper actions instead of direct state updates

### Testing
- Created comprehensive test suite for sidebar persistence
- Tests cover export, import, localStorage persistence, and dirty state management
- All tests passing

## Testing
- [x] Tested sidebar state persists across page reloads
- [x] Verified state is included in JSON export
- [x] Verified state is included in YAML export
- [x] Confirmed import restores sidebar state correctly
- [x] All unit tests pass
- [x] TypeScript checks pass
- [x] Linting passes

Epic: #72