### PR TITLE
feat: remove screen title header and grid size display

### DIFF
--- a/app/utils/responsive.ts
+++ b/app/utils/responsive.ts
@@ -104,26 +104,26 @@ export const gridConfig = {
   mobile: {
     columns: 4,
     rows: 12,
-    margin: [8, 8] as [number, number],
-    containerPadding: [8, 8] as [number, number],
+    margin: [12, 12] as [number, number], // Consistent with Radix p="3" (12px)
+    containerPadding: [12, 12] as [number, number], // Consistent with sidebar padding
   },
   tablet: {
     columns: 8,
     rows: 10,
-    margin: [12, 12] as [number, number],
-    containerPadding: [12, 12] as [number, number],
+    margin: [16, 16] as [number, number], // Consistent with Radix p="4" (16px)
+    containerPadding: [16, 16] as [number, number], // Consistent with sidebar padding
   },
   desktop: {
     columns: 12,
     rows: 8,
-    margin: [16, 16] as [number, number],
-    containerPadding: [16, 16] as [number, number],
+    margin: [16, 16] as [number, number], // Consistent with Radix p="4" (16px)
+    containerPadding: [16, 16] as [number, number], // Consistent with sidebar padding
   },
   wide: {
     columns: 16,
     rows: 8,
-    margin: [16, 16] as [number, number],
-    containerPadding: [20, 20] as [number, number],
+    margin: [16, 16] as [number, number], // Consistent with Radix p="4" (16px)
+    containerPadding: [16, 16] as [number, number], // Consistent with sidebar padding
   },
 } as const
 

--- a/src/components/AppTaskbar.tsx
+++ b/src/components/AppTaskbar.tsx
@@ -102,28 +102,36 @@ export function AppTaskbar() {
         {/* Bottom controls */}
         {mode === 'edit' && currentScreenId && (
           <>
-            <TaskbarButton
-              icon={<CardStackPlusIcon />}
-              label="Add Screen"
-              variant="soft"
-              onClick={() => window.dispatchEvent(new CustomEvent('addScreen'))}
-              showText={false}
-              ariaLabel="Add Screen"
-              title="Add Screen"
-            />
-            <TaskbarButton
-              icon={<PlusCircledIcon />}
-              label="Add Item"
-              variant="soft"
-              onClick={() =>
-                window.dispatchEvent(
-                  new CustomEvent('addItem', { detail: { screenId: currentScreenId } })
-                )
-              }
-              showText={false}
-              ariaLabel="Add Item"
-              title="Add Item"
-            />
+            <Flex 
+              gap="2" 
+              direction={tabsExpanded ? "row" : "column"}
+              style={{ width: '100%' }}
+            >
+              <TaskbarButton
+                icon={<CardStackPlusIcon />}
+                label="Add Screen"
+                variant="soft"
+                onClick={() => window.dispatchEvent(new CustomEvent('addScreen'))}
+                showText={false}
+                ariaLabel="Add Screen"
+                title="Add Screen"
+                style={tabsExpanded ? { flex: 1 } : undefined}
+              />
+              <TaskbarButton
+                icon={<PlusCircledIcon />}
+                label="Add Item"
+                variant="soft"
+                onClick={() =>
+                  window.dispatchEvent(
+                    new CustomEvent('addItem', { detail: { screenId: currentScreenId } })
+                  )
+                }
+                showText={false}
+                ariaLabel="Add Item"
+                title="Add Item"
+                style={tabsExpanded ? { flex: 1 } : undefined}
+              />
+            </Flex>
             <Separator size="4" />
           </>
         )}

--- a/src/components/AppTaskbar.tsx
+++ b/src/components/AppTaskbar.tsx
@@ -3,12 +3,12 @@ import { Box, IconButton, Separator, Flex } from '@radix-ui/themes'
 import {
   HeartFilledIcon,
   HeartIcon,
-  PlusIcon,
   HomeIcon,
   ViewGridIcon,
   ChevronRightIcon,
   ChevronLeftIcon,
-  ComponentPlaceholderIcon,
+  CardStackPlusIcon,
+  PlusCircledIcon,
 } from '@radix-ui/react-icons'
 import { useStore } from '@tanstack/react-store'
 import { dashboardStore, dashboardActions } from '../store/dashboardStore'
@@ -103,7 +103,7 @@ export function AppTaskbar() {
         {mode === 'edit' && currentScreenId && (
           <>
             <TaskbarButton
-              icon={<PlusIcon />}
+              icon={<CardStackPlusIcon />}
               label="Add Screen"
               variant="soft"
               onClick={() => window.dispatchEvent(new CustomEvent('addScreen'))}
@@ -112,7 +112,7 @@ export function AppTaskbar() {
               title="Add Screen"
             />
             <TaskbarButton
-              icon={<ComponentPlaceholderIcon />}
+              icon={<PlusCircledIcon />}
               label="Add Item"
               variant="soft"
               onClick={() =>

--- a/src/components/AppTaskbar.tsx
+++ b/src/components/AppTaskbar.tsx
@@ -9,7 +9,6 @@ import {
   ChevronRightIcon,
   ChevronLeftIcon,
   FileIcon,
-  GridIcon,
 } from '@radix-ui/react-icons'
 import { useStore } from '@tanstack/react-store'
 import { dashboardStore, dashboardActions } from '../store/dashboardStore'

--- a/src/components/AppTaskbar.tsx
+++ b/src/components/AppTaskbar.tsx
@@ -8,6 +8,8 @@ import {
   ViewGridIcon,
   ChevronRightIcon,
   ChevronLeftIcon,
+  FileIcon,
+  GridIcon,
 } from '@radix-ui/react-icons'
 import { useStore } from '@tanstack/react-store'
 import { dashboardStore, dashboardActions } from '../store/dashboardStore'
@@ -95,39 +97,64 @@ export function AppTaskbar() {
           />
         ))}
 
-        {/* Add Screen button in edit mode */}
-        {mode === 'edit' && (
-          <>
-            <TaskbarButton
-              icon={<PlusIcon />}
-              label="Add Screen"
-              variant="ghost"
-              onClick={() => window.dispatchEvent(new CustomEvent('addScreen'))}
-              showText={tabsExpanded}
-              ariaLabel="Add Screen"
-            />
-            {currentScreenId && (
-              <TaskbarButton
-                icon={<PlusIcon />}
-                label="Add Item"
-                variant="ghost"
-                onClick={() =>
-                  window.dispatchEvent(
-                    new CustomEvent('addItem', { detail: { screenId: currentScreenId } })
-                  )
-                }
-                showText={tabsExpanded}
-                ariaLabel="Add Item"
-              />
-            )}
-          </>
-        )}
-
         {/* Spacer */}
         <Box style={{ flex: '1 1 auto' }} />
 
         {/* Bottom controls */}
-        <Separator size="4" />
+        {mode === 'edit' && currentScreenId && (
+          <>
+            {tabsExpanded ? (
+              <Flex gap="2" style={{ width: '100%' }}>
+                <TaskbarButton
+                  icon={<FileIcon />}
+                  label="Add Screen"
+                  variant="soft"
+                  onClick={() => window.dispatchEvent(new CustomEvent('addScreen'))}
+                  showText={true}
+                  ariaLabel="Add Screen"
+                  style={{ flex: 1 }}
+                />
+                <TaskbarButton
+                  icon={<PlusIcon />}
+                  label="Add Item"
+                  variant="soft"
+                  onClick={() =>
+                    window.dispatchEvent(
+                      new CustomEvent('addItem', { detail: { screenId: currentScreenId } })
+                    )
+                  }
+                  showText={true}
+                  ariaLabel="Add Item"
+                  style={{ flex: 1 }}
+                />
+              </Flex>
+            ) : (
+              <>
+                <TaskbarButton
+                  icon={<FileIcon />}
+                  label="Add Screen"
+                  variant="soft"
+                  onClick={() => window.dispatchEvent(new CustomEvent('addScreen'))}
+                  showText={false}
+                  ariaLabel="Add Screen"
+                />
+                <TaskbarButton
+                  icon={<PlusIcon />}
+                  label="Add Item"
+                  variant="soft"
+                  onClick={() =>
+                    window.dispatchEvent(
+                      new CustomEvent('addItem', { detail: { screenId: currentScreenId } })
+                    )
+                  }
+                  showText={false}
+                  ariaLabel="Add Item"
+                />
+              </>
+            )}
+            <Separator size="4" />
+          </>
+        )}
         <ConnectionStatus showText={tabsExpanded} />
         <ModeToggle showText={tabsExpanded} />
         <ConfigurationMenu showText={tabsExpanded} />

--- a/src/components/AppTaskbar.tsx
+++ b/src/components/AppTaskbar.tsx
@@ -8,7 +8,7 @@ import {
   ViewGridIcon,
   ChevronRightIcon,
   ChevronLeftIcon,
-  FileIcon,
+  ComponentPlaceholderIcon,
 } from '@radix-ui/react-icons'
 import { useStore } from '@tanstack/react-store'
 import { dashboardStore, dashboardActions } from '../store/dashboardStore'
@@ -102,55 +102,28 @@ export function AppTaskbar() {
         {/* Bottom controls */}
         {mode === 'edit' && currentScreenId && (
           <>
-            {tabsExpanded ? (
-              <Flex gap="2" style={{ width: '100%' }}>
-                <TaskbarButton
-                  icon={<FileIcon />}
-                  label="Add Screen"
-                  variant="soft"
-                  onClick={() => window.dispatchEvent(new CustomEvent('addScreen'))}
-                  showText={true}
-                  ariaLabel="Add Screen"
-                  style={{ flex: 1 }}
-                />
-                <TaskbarButton
-                  icon={<PlusIcon />}
-                  label="Add Item"
-                  variant="soft"
-                  onClick={() =>
-                    window.dispatchEvent(
-                      new CustomEvent('addItem', { detail: { screenId: currentScreenId } })
-                    )
-                  }
-                  showText={true}
-                  ariaLabel="Add Item"
-                  style={{ flex: 1 }}
-                />
-              </Flex>
-            ) : (
-              <>
-                <TaskbarButton
-                  icon={<FileIcon />}
-                  label="Add Screen"
-                  variant="soft"
-                  onClick={() => window.dispatchEvent(new CustomEvent('addScreen'))}
-                  showText={false}
-                  ariaLabel="Add Screen"
-                />
-                <TaskbarButton
-                  icon={<PlusIcon />}
-                  label="Add Item"
-                  variant="soft"
-                  onClick={() =>
-                    window.dispatchEvent(
-                      new CustomEvent('addItem', { detail: { screenId: currentScreenId } })
-                    )
-                  }
-                  showText={false}
-                  ariaLabel="Add Item"
-                />
-              </>
-            )}
+            <TaskbarButton
+              icon={<PlusIcon />}
+              label="Add Screen"
+              variant="soft"
+              onClick={() => window.dispatchEvent(new CustomEvent('addScreen'))}
+              showText={false}
+              ariaLabel="Add Screen"
+              title="Add Screen"
+            />
+            <TaskbarButton
+              icon={<ComponentPlaceholderIcon />}
+              label="Add Item"
+              variant="soft"
+              onClick={() =>
+                window.dispatchEvent(
+                  new CustomEvent('addItem', { detail: { screenId: currentScreenId } })
+                )
+              }
+              showText={false}
+              ariaLabel="Add Item"
+              title="Add Item"
+            />
             <Separator size="4" />
           </>
         )}

--- a/src/components/AppTaskbar.tsx
+++ b/src/components/AppTaskbar.tsx
@@ -97,14 +97,30 @@ export function AppTaskbar() {
 
         {/* Add Screen button in edit mode */}
         {mode === 'edit' && (
-          <TaskbarButton
-            icon={<PlusIcon />}
-            label="Add Screen"
-            variant="ghost"
-            onClick={() => window.dispatchEvent(new CustomEvent('addScreen'))}
-            showText={tabsExpanded}
-            ariaLabel="Add Screen"
-          />
+          <>
+            <TaskbarButton
+              icon={<PlusIcon />}
+              label="Add Screen"
+              variant="ghost"
+              onClick={() => window.dispatchEvent(new CustomEvent('addScreen'))}
+              showText={tabsExpanded}
+              ariaLabel="Add Screen"
+            />
+            {currentScreenId && (
+              <TaskbarButton
+                icon={<PlusIcon />}
+                label="Add Item"
+                variant="ghost"
+                onClick={() =>
+                  window.dispatchEvent(
+                    new CustomEvent('addItem', { detail: { screenId: currentScreenId } })
+                  )
+                }
+                showText={tabsExpanded}
+                ariaLabel="Add Item"
+              />
+            )}
+          </>
         )}
 
         {/* Spacer */}

--- a/src/components/AppTaskbar.tsx
+++ b/src/components/AppTaskbar.tsx
@@ -102,11 +102,7 @@ export function AppTaskbar() {
         {/* Bottom controls */}
         {mode === 'edit' && currentScreenId && (
           <>
-            <Flex 
-              gap="2" 
-              direction={tabsExpanded ? "row" : "column"}
-              style={{ width: '100%' }}
-            >
+            <Flex gap="2" direction={tabsExpanded ? 'row' : 'column'} style={{ width: '100%' }}>
               <TaskbarButton
                 icon={<CardStackPlusIcon />}
                 label="Add Screen"

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -76,7 +76,6 @@ export function Dashboard() {
         style={{
           flex: 1,
           overflow: 'auto',
-          padding: 'var(--container-padding)',
         }}
       >
         {currentScreen ? (
@@ -90,19 +89,21 @@ export function Dashboard() {
                   resolution={currentScreen.grid.resolution}
                 />
               ) : (
-                <Card>
-                  <Flex align="center" justify="center" p="6">
-                    <Text color="gray" size="2">
-                      No items added yet.{' '}
-                      {mode === 'edit' && 'Click "Add Item" to start building your dashboard.'}
-                    </Text>
-                  </Flex>
-                </Card>
+                <Box p="4">
+                  <Card>
+                    <Flex align="center" justify="center" p="6">
+                      <Text color="gray" size="2">
+                        No items added yet.{' '}
+                        {mode === 'edit' && 'Click "Add Item" to start building your dashboard.'}
+                      </Text>
+                    </Flex>
+                  </Card>
+                </Box>
               )}
             </ErrorBoundary>
           </>
         ) : (
-          <Flex align="center" justify="center" style={{ height: '100%' }}>
+          <Flex align="center" justify="center" style={{ height: '100%' }} p="4">
             <Card>
               <Flex direction="column" align="center" gap="3" p="4">
                 <Text size="3" color="gray">

--- a/src/components/GridLayoutSection.css
+++ b/src/components/GridLayoutSection.css
@@ -6,12 +6,11 @@
 }
 
 .react-grid-item {
-  transition: all 200ms ease;
-  transition-property: left, top, width, height;
+  transition: none;
 }
 
 .react-grid-item.cssTransforms {
-  transition-property: transform, width, height;
+  transition: none;
 }
 
 .react-grid-item.resizing {
@@ -33,7 +32,7 @@
 .react-grid-item.react-grid-placeholder {
   background: var(--accent-3);
   opacity: 0.5;
-  transition-duration: 100ms;
+  transition: none;
   z-index: 2;
   border-radius: var(--radius-3);
   border: 2px dashed var(--accent-7);
@@ -62,7 +61,7 @@
   border: 2px solid var(--accent-9);
   background: var(--color-background);
   opacity: 0;
-  transition: opacity 0.2s;
+  transition: none;
 }
 
 .react-grid-item:hover .react-resizable-handle::after {
@@ -202,7 +201,6 @@
   bottom: 6px;
 }
 
-/* Touch-friendly drag handle */
 .grid-item-drag-handle {
   position: absolute;
   top: 8px;
@@ -216,7 +214,7 @@
   border-radius: var(--radius-2);
   cursor: move;
   opacity: 0;
-  transition: opacity 0.2s;
+  transition: none;
   z-index: 10;
 }
 

--- a/src/components/TaskbarButton.tsx
+++ b/src/components/TaskbarButton.tsx
@@ -12,7 +12,10 @@ interface TaskbarButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 }
 
 export const TaskbarButton = React.forwardRef<HTMLButtonElement, TaskbarButtonProps>(
-  ({ icon, label, onClick, variant = 'soft', color, showText, ariaLabel, title, ...props }, ref) => {
+  (
+    { icon, label, onClick, variant = 'soft', color, showText, ariaLabel, title, ...props },
+    ref
+  ) => {
     if (showText && label) {
       return (
         <Button

--- a/src/components/TaskbarButton.tsx
+++ b/src/components/TaskbarButton.tsx
@@ -21,13 +21,13 @@ export const TaskbarButton = React.forwardRef<HTMLButtonElement, TaskbarButtonPr
           color={color}
           onClick={onClick}
           aria-label={ariaLabel}
-          style={{ 
-            width: '100%', 
+          style={{
+            width: '100%',
             justifyContent: 'flex-start',
             whiteSpace: 'nowrap',
             textOverflow: 'ellipsis',
             overflow: 'hidden',
-            ...props.style
+            ...props.style,
           }}
           {...props}
         >

--- a/src/components/TaskbarButton.tsx
+++ b/src/components/TaskbarButton.tsx
@@ -8,10 +8,11 @@ interface TaskbarButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   color?: 'gray' | 'green' | 'red'
   showText?: boolean
   ariaLabel: string
+  title?: string
 }
 
 export const TaskbarButton = React.forwardRef<HTMLButtonElement, TaskbarButtonProps>(
-  ({ icon, label, onClick, variant = 'soft', color, showText, ariaLabel, ...props }, ref) => {
+  ({ icon, label, onClick, variant = 'soft', color, showText, ariaLabel, title, ...props }, ref) => {
     if (showText && label) {
       return (
         <Button
@@ -21,6 +22,7 @@ export const TaskbarButton = React.forwardRef<HTMLButtonElement, TaskbarButtonPr
           color={color}
           onClick={onClick}
           aria-label={ariaLabel}
+          title={title}
           style={{
             width: '100%',
             justifyContent: 'flex-start',
@@ -45,6 +47,7 @@ export const TaskbarButton = React.forwardRef<HTMLButtonElement, TaskbarButtonPr
         color={color}
         onClick={onClick}
         aria-label={ariaLabel}
+        title={title}
         {...props}
       >
         {icon}

--- a/src/components/TaskbarButton.tsx
+++ b/src/components/TaskbarButton.tsx
@@ -21,7 +21,14 @@ export const TaskbarButton = React.forwardRef<HTMLButtonElement, TaskbarButtonPr
           color={color}
           onClick={onClick}
           aria-label={ariaLabel}
-          style={{ width: '100%', justifyContent: 'flex-start' }}
+          style={{ 
+            width: '100%', 
+            justifyContent: 'flex-start',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+            overflow: 'hidden',
+            ...props.style
+          }}
           {...props}
         >
           {icon}

--- a/src/components/__tests__/Dashboard.nested.test.tsx
+++ b/src/components/__tests__/Dashboard.nested.test.tsx
@@ -55,9 +55,9 @@ describe('Dashboard - Nested Views', () => {
     expect(screen.queryByText('No views created yet')).not.toBeInTheDocument()
     expect(screen.queryByText('Create Your First View')).not.toBeInTheDocument()
 
-    // Should show the nested view information
-    expect(screen.getAllByText('Living Room').length).toBeGreaterThanOrEqual(1)
-    expect(screen.getByText('Grid: 12 × 8')).toBeInTheDocument()
+    // Should show the parent view in taskbar (nested views aren't shown as buttons)
+    expect(screen.getByRole('button', { name: 'Main Floor' })).toBeInTheDocument()
+    // Should show content for the nested view
     expect(screen.getByText(/No items added yet/)).toBeInTheDocument()
   })
 
@@ -94,9 +94,10 @@ describe('Dashboard - Nested Views', () => {
 
     renderWithTheme(<Dashboard />)
 
-    // Should show the grandchild view content
-    expect(screen.getAllByText('TV Room').length).toBeGreaterThanOrEqual(1)
-    expect(screen.getByText('Grid: 10 × 6')).toBeInTheDocument()
+    // Should show the top-level parent in taskbar (nested views aren't shown as buttons)
+    expect(screen.getByRole('button', { name: 'First Floor' })).toBeInTheDocument()
+    // Should show content for the deeply nested view
+    expect(screen.getByText(/No items added yet/)).toBeInTheDocument()
   })
 
   it('should handle switching between nested and top-level views', () => {
@@ -126,8 +127,10 @@ describe('Dashboard - Nested Views', () => {
         <Dashboard />
       </Theme>
     )
-    expect(screen.getAllByText('Kitchen').length).toBeGreaterThanOrEqual(1)
-    expect(screen.getByText('Grid: 8 × 6')).toBeInTheDocument()
+    // Parent button should be shown (nested views aren't shown as buttons)
+    expect(screen.getByRole('button', { name: 'Overview' })).toBeInTheDocument()
+    // Should show content for the nested view
+    expect(screen.getByText(/No items added yet/)).toBeInTheDocument()
 
     // Then switch to top-level view
     dashboardActions.setCurrentScreen('top-1')
@@ -136,7 +139,9 @@ describe('Dashboard - Nested Views', () => {
         <Dashboard />
       </Theme>
     )
-    expect(screen.getAllByText('Overview').length).toBeGreaterThanOrEqual(1)
-    expect(screen.getByText('Grid: 12 × 8')).toBeInTheDocument()
+    // Top-level view button should be shown
+    expect(screen.getByRole('button', { name: 'Overview' })).toBeInTheDocument()
+    // Should show content for the top-level view
+    expect(screen.getByText(/No items added yet/)).toBeInTheDocument()
   })
 })

--- a/src/components/__tests__/Dashboard.test.tsx
+++ b/src/components/__tests__/Dashboard.test.tsx
@@ -91,10 +91,23 @@ describe('Dashboard', () => {
 
     it('should open AddViewDialog when clicking + button in edit mode', async () => {
       const user = userEvent.setup()
+      
+      // Add a test screen first so there's a current screen
+      dashboardActions.addScreen(
+        createTestScreen({
+          id: 'test-screen',
+          name: 'Test Screen',
+        })
+      )
+      dashboardActions.setCurrentScreen('test-screen')
+      
       renderWithTheme(<Dashboard />)
 
       // Switch to edit mode
       await user.click(screen.getByRole('button', { name: 'View Mode' }))
+
+      // Expand the taskbar to see the button text
+      await user.click(screen.getByRole('button', { name: 'Expand' }))
 
       // There should be an "Add Screen" button in the tab strip
       const addButton = screen.getByRole('button', { name: 'Add Screen' })

--- a/src/components/__tests__/Dashboard.test.tsx
+++ b/src/components/__tests__/Dashboard.test.tsx
@@ -91,7 +91,7 @@ describe('Dashboard', () => {
 
     it('should open AddViewDialog when clicking + button in edit mode', async () => {
       const user = userEvent.setup()
-      
+
       // Add a test screen first so there's a current screen
       dashboardActions.addScreen(
         createTestScreen({
@@ -100,7 +100,7 @@ describe('Dashboard', () => {
         })
       )
       dashboardActions.setCurrentScreen('test-screen')
-      
+
       renderWithTheme(<Dashboard />)
 
       // Switch to edit mode

--- a/src/components/__tests__/Dashboard.test.tsx
+++ b/src/components/__tests__/Dashboard.test.tsx
@@ -141,7 +141,8 @@ describe('Dashboard', () => {
       await waitFor(() => {
         expect(screen.queryByText('No views created yet')).not.toBeInTheDocument()
       })
-      expect(screen.getAllByText('Test View').length).toBeGreaterThanOrEqual(1)
+      // The screen name should be visible in the taskbar button
+      expect(screen.getByRole('button', { name: 'Test View' })).toBeInTheDocument()
     })
 
     it('should not create a view with empty name', async () => {
@@ -172,8 +173,9 @@ describe('Dashboard', () => {
     it('should display current view information', () => {
       renderWithTheme(<Dashboard />)
 
-      expect(screen.getAllByText('Living Room').length).toBeGreaterThanOrEqual(1)
-      expect(screen.getByText('Grid: 12 × 8')).toBeInTheDocument()
+      // Screen name should be shown in taskbar button
+      expect(screen.getByRole('button', { name: 'Living Room' })).toBeInTheDocument()
+      // Grid size is no longer displayed
       expect(screen.getByText(/No items added yet/)).toBeInTheDocument()
     })
 


### PR DESCRIPTION
## Summary
- Removed screen title header and grid size display from Dashboard
- Fixed double spacing issue between container and grid items
- Removed grid animations for snappier interactions
- Updated Add Item and Add Screen buttons with consistent styling

## Related Issue
Closes #82

## Changes Made

### 1. Header Removal
- Removed the screen title header section (lines 72-84 in Dashboard.tsx)
- Screen names are now only shown in taskbar buttons
- Grid size display has been removed entirely

### 2. Spacing Fixes
- Removed padding from Dashboard container to prevent double spacing
- Grid now handles all spacing uniformly
- Updated responsive grid config to use consistent spacing (12px mobile, 16px desktop)
- Added padding wrapper only for empty state cards

### 3. Animation Removal
- Removed all CSS transitions from grid items, placeholders, and resize handles
- Grid interactions now feel instant and snappy

### 4. Button Styling Updates
- Moved Add Item and Add Screen buttons to bottom of taskbar in edit mode
- Buttons are always icon-only with tooltips for clarity
- Use different icons:
  - Add Screen: CardStackPlusIcon (suggests adding to stack of screens)
  - Add Item: PlusCircledIcon (clear add action for widgets)
- Buttons layout side-by-side when taskbar is expanded, stack when collapsed
- Apply consistent soft variant styling to match other taskbar buttons

### 5. Test Updates
- Updated Dashboard tests to look for screen names in taskbar buttons
- Fixed nested view tests to check for parent screen buttons
- Updated Add Screen button test to work with new button placement

## Testing
- [x] Tested in development
- [x] TypeScript checks pass
- [x] Linting passes
- [x] All tests pass
- [x] Visual inspection confirms proper spacing and button styling