### PR TITLE
feat: add text capability to separator cards with configurable options

### DIFF
--- a/src/components/CardConfig.tsx
+++ b/src/components/CardConfig.tsx
@@ -237,7 +237,7 @@ function Component({ title, description, configDefinition, config, onChange }: C
 }
 
 function Content({ config = {}, onChange = () => {}, item }: ContentProps) {
-  const cardType = item ? getCardType(item) : undefined
+  const cardType = item?.type === 'separator' ? 'separator' : item ? getCardType(item) : undefined
 
   if (!item || !cardType || !cardConfigurations[cardType]) {
     return (
@@ -303,14 +303,37 @@ function Content({ config = {}, onChange = () => {}, item }: ContentProps) {
 }
 
 function Modal({ open, onOpenChange, item, onSave }: ModalProps) {
-  const [localConfig, setLocalConfig] = React.useState<Record<string, unknown>>(item.config || {})
+  // Initialize config based on item type
+  const getInitialConfig = () => {
+    if (item.type === 'separator') {
+      // For separator, use the direct properties as config
+      return {
+        title: item.title || '',
+        separatorOrientation: item.separatorOrientation || 'horizontal',
+        separatorTextColor: item.separatorTextColor || 'gray',
+      }
+    }
+    return item.config || {}
+  }
+
+  const [localConfig, setLocalConfig] = React.useState<Record<string, unknown>>(getInitialConfig())
 
   React.useEffect(() => {
-    setLocalConfig(item.config || {})
-  }, [item.config])
+    setLocalConfig(getInitialConfig())
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [item])
 
   const handleSave = () => {
-    onSave({ config: localConfig })
+    // For separator, we need to save the config as direct properties
+    if (item.type === 'separator') {
+      onSave({
+        title: localConfig.title as string,
+        separatorOrientation: localConfig.separatorOrientation as 'horizontal' | 'vertical',
+        separatorTextColor: localConfig.separatorTextColor as string,
+      })
+    } else {
+      onSave({ config: localConfig })
+    }
     onOpenChange(false)
   }
 

--- a/src/components/GridView.tsx
+++ b/src/components/GridView.tsx
@@ -311,6 +311,7 @@ export function GridView({ screenId, items, resolution }: GridViewProps) {
                 onDelete={isEditMode ? () => handleDeleteItem(item.id) : undefined}
                 onConfigure={isEditMode ? () => handleConfigureItem(item) : undefined}
                 hasConfiguration={true}
+                transparent={true}
               >
                 <Separator
                   title={item.title}

--- a/src/components/GridView.tsx
+++ b/src/components/GridView.tsx
@@ -22,6 +22,7 @@ import { GridLayoutSection } from './GridLayoutSection'
 import { EntityErrorBoundary } from './ui'
 import { GridItem } from '../store/types'
 import { dashboardActions, useDashboardStore } from '../store'
+import { CardConfig } from './CardConfig'
 import './GridLayoutSection.css'
 
 interface GridViewProps {
@@ -209,6 +210,8 @@ export function GridView({ screenId, items, resolution }: GridViewProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [itemToDelete, setItemToDelete] = useState<string | null>(null)
   const [bulkDeletePending, setBulkDeletePending] = useState(false)
+  const [configModalOpen, setConfigModalOpen] = useState(false)
+  const [itemToConfig, setItemToConfig] = useState<GridItem | null>(null)
 
   const handleDeleteItem = (itemId: string) => {
     setItemToDelete(itemId)
@@ -245,6 +248,17 @@ export function GridView({ screenId, items, resolution }: GridViewProps) {
       }
       return next
     })
+  }
+
+  const handleConfigureItem = (item: GridItem) => {
+    setItemToConfig(item)
+    setConfigModalOpen(true)
+  }
+
+  const handleSaveConfig = (updates: Partial<GridItem>) => {
+    if (itemToConfig) {
+      dashboardActions.updateGridItem(screenId, itemToConfig.id, updates)
+    }
   }
 
   // Keyboard shortcuts
@@ -295,6 +309,8 @@ export function GridView({ screenId, items, resolution }: GridViewProps) {
                     : undefined
                 }
                 onDelete={isEditMode ? () => handleDeleteItem(item.id) : undefined}
+                onConfigure={isEditMode ? () => handleConfigureItem(item) : undefined}
+                hasConfiguration={true}
               >
                 <Separator
                   title={item.title}
@@ -364,6 +380,16 @@ export function GridView({ screenId, items, resolution }: GridViewProps) {
         onConfirm={confirmDelete}
         itemCount={bulkDeletePending ? selectedItems.size : 1}
       />
+
+      {/* Configuration Modal */}
+      {itemToConfig && (
+        <CardConfig.Modal
+          open={configModalOpen}
+          onOpenChange={setConfigModalOpen}
+          item={itemToConfig}
+          onSave={handleSaveConfig}
+        />
+      )}
     </Box>
   )
 }

--- a/src/components/Separator.tsx
+++ b/src/components/Separator.tsx
@@ -94,7 +94,7 @@ export function Separator({
   return (
     <div
       style={{
-        backgroundColor: 'var(--gray-3)',
+        backgroundColor: isEditMode ? 'var(--gray-3)' : 'transparent',
         height: '100%',
         cursor: isEditMode ? 'pointer' : 'default',
       }}

--- a/src/components/configurations/cardConfigurations.ts
+++ b/src/components/configurations/cardConfigurations.ts
@@ -74,6 +74,43 @@ export const cardConfigurations: Record<
       },
     },
   },
+  separator: {
+    title: 'Separator',
+    description: 'Configure the separator appearance and text.',
+    definition: {
+      title: {
+        type: 'string',
+        default: '',
+        label: 'Label (optional)',
+        placeholder: 'Section title...',
+        description: 'Text to display on the separator line',
+      },
+      separatorOrientation: {
+        type: 'select',
+        default: 'horizontal',
+        label: 'Orientation',
+        description: 'Direction of the separator line',
+        options: [
+          { value: 'horizontal', label: 'Horizontal' },
+          { value: 'vertical', label: 'Vertical' },
+        ],
+      },
+      separatorTextColor: {
+        type: 'select',
+        default: 'gray',
+        label: 'Text Color',
+        description: 'Color of the separator text',
+        options: [
+          { value: 'gray', label: 'Gray' },
+          { value: 'blue', label: 'Blue' },
+          { value: 'green', label: 'Green' },
+          { value: 'red', label: 'Red' },
+          { value: 'orange', label: 'Orange' },
+          { value: 'purple', label: 'Purple' },
+        ],
+      },
+    },
+  },
 }
 
 // Get the entity domain from a GridItem

--- a/src/components/configurations/index.ts
+++ b/src/components/configurations/index.ts
@@ -1,1 +1,1 @@
-export { cardConfigurations } from './cardConfigurations'
+export { cardConfigurations, getCardType } from './cardConfigurations'


### PR DESCRIPTION
## Summary
- Added configuration support for separator cards using the generic configuration system
- Separator cards now support optional text labels with configurable colors
- Users can configure text, orientation, and color through the configuration modal in edit mode
- Configuration is properly persisted in YAML

## Related Issue
Closes #114

## Testing
- [x] All tests pass locally (`npm test`)
- [x] Linting passes (`npm run lint`)
- [x] TypeScript checks pass (`npm run typecheck`)
- [x] Tested separator configuration in edit mode
- [x] Configuration persists after save
- [x] Text displays correctly on both horizontal and vertical separators

## Test Evidence
All 440 tests passing:
```
Test Files  37 passed (37)
     Tests  440 passed  < /dev/null |  2 skipped (442)
```

Epic: #81