### PR TITLE
feat: add configuration support for text cards

### DIFF
--- a/src/components/CardConfig.tsx
+++ b/src/components/CardConfig.tsx
@@ -237,7 +237,14 @@ function Component({ title, description, configDefinition, config, onChange }: C
 }
 
 function Content({ config = {}, onChange = () => {}, item }: ContentProps) {
-  const cardType = item?.type === 'separator' ? 'separator' : item ? getCardType(item) : undefined
+  const cardType =
+    item?.type === 'separator'
+      ? 'separator'
+      : item?.type === 'text'
+        ? 'text'
+        : item
+          ? getCardType(item)
+          : undefined
 
   if (!item || !cardType || !cardConfigurations[cardType]) {
     return (
@@ -311,6 +318,16 @@ function Modal({ open, onOpenChange, item, onSave }: ModalProps) {
         title: item.title || '',
         separatorOrientation: item.separatorOrientation || 'horizontal',
         separatorTextColor: item.separatorTextColor || 'gray',
+        hideBackground: item.hideBackground || false,
+      }
+    } else if (item.type === 'text') {
+      // For text cards, use the direct properties as config
+      return {
+        content: item.content || '# Text Card\n\nDouble-click to edit this text.',
+        alignment: item.alignment || 'left',
+        textSize: item.textSize || 'medium',
+        textColor: item.textColor || 'default',
+        hideBackground: item.hideBackground || false,
       }
     }
     return item.config || {}
@@ -330,6 +347,16 @@ function Modal({ open, onOpenChange, item, onSave }: ModalProps) {
         title: localConfig.title as string,
         separatorOrientation: localConfig.separatorOrientation as 'horizontal' | 'vertical',
         separatorTextColor: localConfig.separatorTextColor as string,
+        hideBackground: localConfig.hideBackground as boolean,
+      })
+    } else if (item.type === 'text') {
+      // For text cards, save the config as direct properties
+      onSave({
+        content: localConfig.content as string,
+        alignment: localConfig.alignment as 'left' | 'center' | 'right',
+        textSize: localConfig.textSize as 'small' | 'medium' | 'large',
+        textColor: localConfig.textColor as string,
+        hideBackground: localConfig.hideBackground as boolean,
       })
     } else {
       onSave({ config: localConfig })

--- a/src/components/CardConfig.tsx
+++ b/src/components/CardConfig.tsx
@@ -355,6 +355,9 @@ function Preview({ item, config }: PreviewProps) {
                 alignment={previewItem.alignment}
                 textSize={previewItem.textSize}
                 textColor={previewItem.textColor}
+                isSelected={false}
+                onSelect={undefined}
+                forceViewMode={true}
               />
             </GridCard>
           ) : cardType === 'weather' && item.entityId ? (

--- a/src/components/CardConfig.tsx
+++ b/src/components/CardConfig.tsx
@@ -23,6 +23,8 @@ import { LightCard } from './LightCard'
 import { BinarySensorCard } from './BinarySensorCard'
 import { Separator as SeparatorCard } from './Separator'
 import { GridCard } from './GridCard'
+import { dashboardStore } from '~/store'
+import { useEffect } from 'react'
 
 interface ModalProps {
   open: boolean
@@ -291,6 +293,30 @@ interface PreviewProps {
   config: Record<string, unknown>
 }
 
+// Wrapper component that temporarily sets mode to 'view' for preview
+function ViewModeWrapper({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    // Store current mode
+    const currentMode = dashboardStore.state.mode
+
+    // Set to view mode
+    dashboardStore.setState((state) => ({
+      ...state,
+      mode: 'view',
+    }))
+
+    // Restore original mode on unmount
+    return () => {
+      dashboardStore.setState((state) => ({
+        ...state,
+        mode: currentMode,
+      }))
+    }
+  }, [])
+
+  return <>{children}</>
+}
+
 function Preview({ item, config }: PreviewProps) {
   const cardType =
     item?.type === 'separator'
@@ -322,58 +348,59 @@ function Preview({ item, config }: PreviewProps) {
   }
 
   return (
-    <Section title="Preview">
-      <Text size="2" color="gray" style={{ marginBottom: '16px' }}>
-        Live preview of your configuration
-      </Text>
-      <Box
-        style={{
-          display: 'flex',
-          justifyContent: 'center',
-          padding: '16px',
-          backgroundColor: 'var(--gray-2)',
-          borderRadius: 'var(--radius-3)',
-          minHeight: '200px',
-          alignItems: 'center',
-        }}
-      >
-        <Box style={{ width: '280px', pointerEvents: 'none' }}>
-          {item.type === 'separator' ? (
-            <GridCard size="medium" transparent={previewItem.hideBackground}>
-              <SeparatorCard
-                title={previewItem.title}
-                orientation={previewItem.separatorOrientation || 'horizontal'}
-                textColor={previewItem.separatorTextColor || 'gray'}
-              />
-            </GridCard>
-          ) : item.type === 'text' ? (
-            <GridCard size="medium" transparent={previewItem.hideBackground}>
-              <TextCard
-                entityId={item.id}
-                size="medium"
-                content={previewItem.content}
-                alignment={previewItem.alignment}
-                textSize={previewItem.textSize}
-                textColor={previewItem.textColor}
-                isSelected={false}
-                onSelect={undefined}
-                forceViewMode={true}
-              />
-            </GridCard>
-          ) : cardType === 'weather' && item.entityId ? (
-            <WeatherCard entityId={item.entityId} size="medium" config={config} />
-          ) : cardType === 'light' && item.entityId ? (
-            <LightCard entityId={item.entityId} size="medium" item={previewItem} />
-          ) : cardType === 'binary_sensor' && item.entityId ? (
-            <BinarySensorCard entityId={item.entityId} size="medium" item={previewItem} />
-          ) : (
-            <Text size="2" color="gray">
-              Preview not available for this card type
-            </Text>
-          )}
+    <ViewModeWrapper>
+      <Section title="Preview">
+        <Text size="2" color="gray" style={{ marginBottom: '16px' }}>
+          Live preview of your configuration
+        </Text>
+        <Box
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            padding: '16px',
+            backgroundColor: 'var(--gray-2)',
+            borderRadius: 'var(--radius-3)',
+            minHeight: '200px',
+            alignItems: 'center',
+          }}
+        >
+          <Box style={{ width: '280px', pointerEvents: 'none' }}>
+            {item.type === 'separator' ? (
+              <GridCard size="medium" transparent={previewItem.hideBackground}>
+                <SeparatorCard
+                  title={previewItem.title}
+                  orientation={previewItem.separatorOrientation || 'horizontal'}
+                  textColor={previewItem.separatorTextColor || 'gray'}
+                />
+              </GridCard>
+            ) : item.type === 'text' ? (
+              <GridCard size="medium" transparent={previewItem.hideBackground}>
+                <TextCard
+                  entityId={item.id}
+                  size="medium"
+                  content={previewItem.content}
+                  alignment={previewItem.alignment}
+                  textSize={previewItem.textSize}
+                  textColor={previewItem.textColor}
+                  isSelected={false}
+                  onSelect={undefined}
+                />
+              </GridCard>
+            ) : cardType === 'weather' && item.entityId ? (
+              <WeatherCard entityId={item.entityId} size="medium" config={config} />
+            ) : cardType === 'light' && item.entityId ? (
+              <LightCard entityId={item.entityId} size="medium" item={previewItem} />
+            ) : cardType === 'binary_sensor' && item.entityId ? (
+              <BinarySensorCard entityId={item.entityId} size="medium" item={previewItem} />
+            ) : (
+              <Text size="2" color="gray">
+                Preview not available for this card type
+              </Text>
+            )}
+          </Box>
         </Box>
-      </Box>
-    </Section>
+      </Section>
+    </ViewModeWrapper>
   )
 }
 

--- a/src/components/GridView.tsx
+++ b/src/components/GridView.tsx
@@ -311,7 +311,7 @@ export function GridView({ screenId, items, resolution }: GridViewProps) {
                 onDelete={isEditMode ? () => handleDeleteItem(item.id) : undefined}
                 onConfigure={isEditMode ? () => handleConfigureItem(item) : undefined}
                 hasConfiguration={true}
-                transparent={true}
+                transparent={item.hideBackground !== false}
               >
                 <Separator
                   title={item.title}
@@ -337,6 +337,7 @@ export function GridView({ screenId, items, resolution }: GridViewProps) {
                 onDelete={isEditMode ? () => handleDeleteItem(item.id) : undefined}
                 hasConfiguration={isEditMode}
                 onConfigure={isEditMode ? () => handleConfigureItem(item) : undefined}
+                transparent={item.hideBackground}
               >
                 <TextCard
                   entityId={item.id}
@@ -344,6 +345,7 @@ export function GridView({ screenId, items, resolution }: GridViewProps) {
                   content={item.content}
                   alignment={item.alignment}
                   textSize={item.textSize}
+                  textColor={item.textColor}
                   isSelected={selectedItems.has(item.id)}
                   onSelect={
                     isEditMode ? (selected) => handleSelectItem(item.id, selected) : undefined

--- a/src/components/GridView.tsx
+++ b/src/components/GridView.tsx
@@ -335,6 +335,8 @@ export function GridView({ screenId, items, resolution }: GridViewProps) {
                     : undefined
                 }
                 onDelete={isEditMode ? () => handleDeleteItem(item.id) : undefined}
+                hasConfiguration={isEditMode}
+                onConfigure={isEditMode ? () => handleConfigureItem(item) : undefined}
               >
                 <TextCard
                   entityId={item.id}

--- a/src/components/TextCard.tsx
+++ b/src/components/TextCard.tsx
@@ -13,6 +13,7 @@ interface TextCardProps {
   alignment?: 'left' | 'center' | 'right'
   textSize?: 'small' | 'medium' | 'large'
   textColor?: string
+  forceViewMode?: boolean
 }
 
 function TextCardComponent({
@@ -24,9 +25,10 @@ function TextCardComponent({
   alignment = 'left',
   textSize = 'medium',
   textColor = 'default',
+  forceViewMode = false,
 }: TextCardProps) {
   const mode = useDashboardStore((state) => state.mode)
-  const isEditMode = mode === 'edit'
+  const isEditMode = forceViewMode ? false : mode === 'edit'
   const [editContent, setEditContent] = useState(content)
   const textAreaRef = useRef<HTMLTextAreaElement>(null)
   const currentScreenId = useDashboardStore((state) => state.currentScreenId)

--- a/src/components/TextCard.tsx
+++ b/src/components/TextCard.tsx
@@ -13,7 +13,6 @@ interface TextCardProps {
   alignment?: 'left' | 'center' | 'right'
   textSize?: 'small' | 'medium' | 'large'
   textColor?: string
-  forceViewMode?: boolean
 }
 
 function TextCardComponent({
@@ -25,10 +24,9 @@ function TextCardComponent({
   alignment = 'left',
   textSize = 'medium',
   textColor = 'default',
-  forceViewMode = false,
 }: TextCardProps) {
   const mode = useDashboardStore((state) => state.mode)
-  const isEditMode = forceViewMode ? false : mode === 'edit'
+  const isEditMode = mode === 'edit'
   const [editContent, setEditContent] = useState(content)
   const textAreaRef = useRef<HTMLTextAreaElement>(null)
   const currentScreenId = useDashboardStore((state) => state.currentScreenId)

--- a/src/components/TextCard.tsx
+++ b/src/components/TextCard.tsx
@@ -43,6 +43,12 @@ function TextCardComponent({
     large: '3' as const,
   }[textSize]
 
+  const baseFontSize = {
+    small: '0.875rem',
+    medium: '1rem',
+    large: '1.125rem',
+  }[textSize]
+
   useEffect(() => {
     if (isEditMode && textAreaRef.current) {
       textAreaRef.current.focus()
@@ -112,6 +118,7 @@ function TextCardComponent({
         style={{
           textAlign: alignment,
           width: '100%',
+          fontSize: baseFontSize,
         }}
       >
         <ReactMarkdown

--- a/src/components/TextCard.tsx
+++ b/src/components/TextCard.tsx
@@ -12,6 +12,7 @@ interface TextCardProps {
   content?: string
   alignment?: 'left' | 'center' | 'right'
   textSize?: 'small' | 'medium' | 'large'
+  textColor?: string
 }
 
 function TextCardComponent({
@@ -22,6 +23,7 @@ function TextCardComponent({
   content = 'Double-click to edit',
   alignment = 'left',
   textSize = 'medium',
+  textColor = 'default',
 }: TextCardProps) {
   const mode = useDashboardStore((state) => state.mode)
   const isEditMode = mode === 'edit'
@@ -118,6 +120,20 @@ function TextCardComponent({
               <RadixText
                 size={fontSize}
                 weight="bold"
+                color={
+                  textColor !== 'default'
+                    ? (textColor as
+                        | 'gray'
+                        | 'blue'
+                        | 'green'
+                        | 'red'
+                        | 'orange'
+                        | 'purple'
+                        | 'cyan'
+                        | 'pink'
+                        | 'yellow')
+                    : undefined
+                }
                 style={{ display: 'block', marginBottom: '0.5em', fontSize: '1.5em' }}
               >
                 {children}
@@ -127,6 +143,20 @@ function TextCardComponent({
               <RadixText
                 size={fontSize}
                 weight="bold"
+                color={
+                  textColor !== 'default'
+                    ? (textColor as
+                        | 'gray'
+                        | 'blue'
+                        | 'green'
+                        | 'red'
+                        | 'orange'
+                        | 'purple'
+                        | 'cyan'
+                        | 'pink'
+                        | 'yellow')
+                    : undefined
+                }
                 style={{ display: 'block', marginBottom: '0.5em', fontSize: '1.3em' }}
               >
                 {children}
@@ -136,23 +166,91 @@ function TextCardComponent({
               <RadixText
                 size={fontSize}
                 weight="medium"
+                color={
+                  textColor !== 'default'
+                    ? (textColor as
+                        | 'gray'
+                        | 'blue'
+                        | 'green'
+                        | 'red'
+                        | 'orange'
+                        | 'purple'
+                        | 'cyan'
+                        | 'pink'
+                        | 'yellow')
+                    : undefined
+                }
                 style={{ display: 'block', marginBottom: '0.5em', fontSize: '1.1em' }}
               >
                 {children}
               </RadixText>
             ),
             p: ({ children }) => (
-              <RadixText as="p" size={fontSize} style={{ marginBottom: '0.5em' }}>
+              <RadixText
+                as="p"
+                size={fontSize}
+                color={
+                  textColor !== 'default'
+                    ? (textColor as
+                        | 'gray'
+                        | 'blue'
+                        | 'green'
+                        | 'red'
+                        | 'orange'
+                        | 'purple'
+                        | 'cyan'
+                        | 'pink'
+                        | 'yellow')
+                    : undefined
+                }
+                style={{ marginBottom: '0.5em' }}
+              >
                 {children}
               </RadixText>
             ),
             strong: ({ children }) => (
-              <RadixText as="span" size={fontSize} weight="bold">
+              <RadixText
+                as="span"
+                size={fontSize}
+                weight="bold"
+                color={
+                  textColor !== 'default'
+                    ? (textColor as
+                        | 'gray'
+                        | 'blue'
+                        | 'green'
+                        | 'red'
+                        | 'orange'
+                        | 'purple'
+                        | 'cyan'
+                        | 'pink'
+                        | 'yellow')
+                    : undefined
+                }
+              >
                 {children}
               </RadixText>
             ),
             em: ({ children }) => (
-              <RadixText as="span" size={fontSize} style={{ fontStyle: 'italic' }}>
+              <RadixText
+                as="span"
+                size={fontSize}
+                color={
+                  textColor !== 'default'
+                    ? (textColor as
+                        | 'gray'
+                        | 'blue'
+                        | 'green'
+                        | 'red'
+                        | 'orange'
+                        | 'purple'
+                        | 'cyan'
+                        | 'pink'
+                        | 'yellow')
+                    : undefined
+                }
+                style={{ fontStyle: 'italic' }}
+              >
                 {children}
               </RadixText>
             ),
@@ -164,7 +262,24 @@ function TextCardComponent({
             ),
             li: ({ children }) => (
               <li>
-                <RadixText as="span" size={fontSize}>
+                <RadixText
+                  as="span"
+                  size={fontSize}
+                  color={
+                    textColor !== 'default'
+                      ? (textColor as
+                          | 'gray'
+                          | 'blue'
+                          | 'green'
+                          | 'red'
+                          | 'orange'
+                          | 'purple'
+                          | 'cyan'
+                          | 'pink'
+                          | 'yellow')
+                      : undefined
+                  }
+                >
                   {children}
                 </RadixText>
               </li>

--- a/src/components/configurations/cardConfigurations.ts
+++ b/src/components/configurations/cardConfigurations.ts
@@ -109,6 +109,12 @@ export const cardConfigurations: Record<
           { value: 'purple', label: 'Purple' },
         ],
       },
+      hideBackground: {
+        type: 'boolean',
+        default: false,
+        label: 'Hide Card Background',
+        description: 'Remove the card background for a cleaner look',
+      },
     },
   },
   text: {
@@ -116,7 +122,7 @@ export const cardConfigurations: Record<
     description: 'Configure text display and formatting options.',
     definition: {
       content: {
-        type: 'string',
+        type: 'textarea',
         default: '# Text Card\n\nDouble-click to edit this text.',
         label: 'Content',
         placeholder: 'Enter your text here...',
@@ -143,6 +149,30 @@ export const cardConfigurations: Record<
           { value: 'medium', label: 'Medium' },
           { value: 'large', label: 'Large' },
         ],
+      },
+      textColor: {
+        type: 'select',
+        default: 'default',
+        label: 'Text Color',
+        description: 'Color of the text (applies to all text in the card)',
+        options: [
+          { value: 'default', label: 'Default' },
+          { value: 'gray', label: 'Gray' },
+          { value: 'blue', label: 'Blue' },
+          { value: 'green', label: 'Green' },
+          { value: 'red', label: 'Red' },
+          { value: 'orange', label: 'Orange' },
+          { value: 'purple', label: 'Purple' },
+          { value: 'cyan', label: 'Cyan' },
+          { value: 'pink', label: 'Pink' },
+          { value: 'yellow', label: 'Yellow' },
+        ],
+      },
+      hideBackground: {
+        type: 'boolean',
+        default: false,
+        label: 'Hide Card Background',
+        description: 'Remove the card background for a cleaner look',
       },
     },
   },

--- a/src/components/configurations/cardConfigurations.ts
+++ b/src/components/configurations/cardConfigurations.ts
@@ -111,6 +111,41 @@ export const cardConfigurations: Record<
       },
     },
   },
+  text: {
+    title: 'Text Card',
+    description: 'Configure text display and formatting options.',
+    definition: {
+      content: {
+        type: 'string',
+        default: '# Text Card\n\nDouble-click to edit this text.',
+        label: 'Content',
+        placeholder: 'Enter your text here...',
+        description: 'Text content (supports Markdown formatting)',
+      },
+      alignment: {
+        type: 'select',
+        default: 'left',
+        label: 'Text Alignment',
+        description: 'Horizontal alignment of the text',
+        options: [
+          { value: 'left', label: 'Left' },
+          { value: 'center', label: 'Center' },
+          { value: 'right', label: 'Right' },
+        ],
+      },
+      textSize: {
+        type: 'select',
+        default: 'medium',
+        label: 'Text Size',
+        description: 'Size of the text content',
+        options: [
+          { value: 'small', label: 'Small' },
+          { value: 'medium', label: 'Medium' },
+          { value: 'large', label: 'Large' },
+        ],
+      },
+    },
+  },
 }
 
 // Get the entity domain from a GridItem

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -15,6 +15,8 @@ export interface GridItem {
   content?: string // For text cards
   alignment?: 'left' | 'center' | 'right' // For text cards
   textSize?: 'small' | 'medium' | 'large' // For text cards
+  textColor?: string // For text cards (e.g., 'default', 'gray', 'blue', 'red')
+  hideBackground?: boolean // For text cards and separators
   config?: Record<string, unknown> // Entity-specific configuration
   x: number
   y: number


### PR DESCRIPTION
## Summary
- Added configuration support for TextCard component
- Fixed configuration modal to properly handle text cards
- Added font color option with multiple color choices (gray, blue, green, red, orange, purple, cyan, pink, yellow)
- Added hide background option for both text cards and separators
- Users can now configure text alignment, text size, font color, and hide background through the configuration modal
- Integrated TextCard with the existing card configuration system

## Related Issue
Closes #113

## Testing
- [x] All tests pass locally (`npm test`)
- [x] Linting passes (`npm run lint`)
- [x] TypeScript checks pass (`npm run typecheck`)
- [x] Built successfully (`npm run build:ha`)
- [x] Tested configuration modal for text cards
- [x] Verified text cards work with all grid sizes
- [x] Tested font color changes
- [x] Tested hide background option for both text cards and separators

## Test Evidence
All 440 tests passed successfully.