### PR TITLE
feat: add GitHub Pages deployment workflow

### DIFF
--- a/.github/pages-index.html
+++ b/.github/pages-index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Liebe - Home Assistant Dashboard</title>
+    <meta charset="utf-8" />
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        padding: 2rem;
+      }
+      .container {
+        max-width: 800px;
+        margin: 0 auto;
+      }
+      code {
+        background: #f4f4f4;
+        padding: 0.2rem 0.4rem;
+        border-radius: 3px;
+      }
+      pre {
+        background: #f4f4f4;
+        padding: 1rem;
+        border-radius: 5px;
+        overflow-x: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Liebe - Home Assistant Dashboard</h1>
+      <p>A modern, customizable dashboard for Home Assistant with a beautiful UI.</p>
+
+      <h2>Installation</h2>
+      <p>Add the following to your Home Assistant <code>configuration.yaml</code>:</p>
+      <pre><code>panel_custom:
+  - name: liebe-panel
+    sidebar_title: Liebe
+    sidebar_icon: mdi:heart
+    url_path: liebe
+    module_url: https://fx.github.io/liebe/panel.js</code></pre>
+
+      <p>Then restart Home Assistant and find "Liebe" in the sidebar.</p>
+
+      <h2>Resources</h2>
+      <ul>
+        <li><a href="https://github.com/fx/liebe">GitHub Repository</a></li>
+        <li><a href="panel.js">panel.js</a> - The Home Assistant panel module</li>
+      </ul>
+    </div>
+  </body>
+</html>

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,69 @@
+name: Deploy to GitHub Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ['main']
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Home Assistant panel
+        run: npm run build:ha:prod
+
+      - name: Create GitHub Pages directory structure
+        run: |
+          mkdir -p ./pages-dist
+          # Copy the panel.js file to the root
+          cp ./dist/panel.js ./pages-dist/
+          # Copy the index.html file
+          cp ./.github/pages-index.html ./pages-dist/index.html
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './pages-dist'
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -869,3 +869,57 @@ The `/workspace/screenshots/` directory should:
 - Contain a `.gitkeep` file to ensure it's tracked in version control
 - Be committed to the repository
 - Store all development and testing screenshots
+
+## GitHub Pages Deployment
+
+### Automatic Deployment
+
+The project is automatically deployed to GitHub Pages when changes are pushed to the `main` branch. The deployment workflow:
+
+1. Builds the Home Assistant panel in production mode
+2. Creates a GitHub Pages site with the panel.js file
+3. Deploys to https://fx.github.io/liebe/
+
+### Manual Deployment
+
+To manually trigger a deployment:
+
+1. Go to Actions tab in GitHub
+2. Select "Deploy to GitHub Pages" workflow
+3. Click "Run workflow"
+
+### GitHub Pages Configuration
+
+The deployment uses:
+
+- **Build script**: `npm run build:ha:prod`
+- **Source**: GitHub Actions
+- **Branch**: Automated deployment (no gh-pages branch)
+- **URL**: https://fx.github.io/liebe/
+
+### Files Created
+
+- `/panel.js` - The Home Assistant panel module
+- `/index.html` - Landing page with installation instructions
+
+### Deployment Workflow
+
+The `.github/workflows/deploy.yml` file handles:
+
+1. Building the production panel
+2. Creating GitHub Pages artifacts
+3. Deploying to GitHub Pages
+4. Setting proper permissions
+
+### Usage
+
+Users can use the GitHub Pages hosted version by adding to their Home Assistant configuration:
+
+```yaml
+panel_custom:
+  - name: liebe-panel
+    sidebar_title: Liebe
+    sidebar_icon: mdi:heart
+    url_path: liebe
+    module_url: https://fx.github.io/liebe/panel.js
+```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,31 @@ panel_custom:
 
 ## Production
 
-Host Liebe on any web server and add to your `configuration.yaml`:
+### Option 1: GitHub Pages (Recommended)
+
+The easiest way to use Liebe is through the GitHub Pages hosted version:
+
+```yaml
+panel_custom:
+  - name: liebe-panel
+    sidebar_title: Liebe
+    sidebar_icon: mdi:heart
+    url_path: liebe
+    module_url: https://fx.github.io/liebe/panel.js
+```
+
+### Option 2: Self-hosting
+
+You can also build and host Liebe on your own web server:
+
+```bash
+# Build for production
+npm run build:ha:prod
+
+# Upload dist/panel.js to your web server
+```
+
+Then add to your `configuration.yaml`:
 
 ```yaml
 panel_custom:
@@ -69,6 +93,8 @@ homeassistant:
 
 - `npm run dev` - Start development server
 - `npm run build` - Build SPA application
+- `npm run build:ha` - Build Home Assistant panel (development)
+- `npm run build:ha:prod` - Build Home Assistant panel (production)
 - `npm run typecheck` - Run TypeScript type checking
 - `npm run lint` - Run ESLint
 - `npm run format` - Format code with Prettier

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite dev",
     "build": "vite build && tsc --noEmit",
     "build:ha": "vite build --config vite.config.ha.ts",
+    "build:ha:prod": "vite build --config vite.config.ha.prod.ts",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "tsc --noEmit && eslint . --ext .ts,.tsx && prettier --check .",

--- a/vite.config.ha.prod.ts
+++ b/vite.config.ha.prod.ts
@@ -1,0 +1,36 @@
+import { defineConfig } from 'vite'
+import tsConfigPaths from 'vite-tsconfig-paths'
+import { resolve } from 'path'
+
+export default defineConfig({
+  mode: 'production',
+  define: {
+    'process.env.NODE_ENV': JSON.stringify('production'),
+    'process.env': JSON.stringify({}),
+    process: JSON.stringify({ env: {} }),
+  },
+  build: {
+    minify: true,
+    sourcemap: false,
+    lib: {
+      entry: resolve(__dirname, 'src/panel.ts'),
+      name: 'Liebe',
+      fileName: () => 'panel.js',
+      formats: ['iife'],
+    },
+    outDir: 'dist',
+    emptyOutDir: true,
+    rollupOptions: {
+      external: [],
+      output: {
+        globals: {},
+        assetFileNames: '[name][extname]',
+      },
+    },
+  },
+  plugins: [
+    tsConfigPaths({
+      projects: ['./tsconfig.json'],
+    }),
+  ],
+})


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to automatically build and deploy to GitHub Pages
- Create production build configuration for minified output
- Add landing page with installation instructions
- Update documentation with GitHub Pages deployment options

## Details
This PR sets up automatic deployment to GitHub Pages whenever changes are pushed to the main branch. Users will be able to use the hosted version at `https://fx.github.io/liebe/panel.js` without needing to build or host the panel themselves.

### Changes Made:
1. **GitHub Actions Workflow** (`.github/workflows/deploy.yml`):
   - Builds the Home Assistant panel in production mode
   - Creates GitHub Pages artifacts
   - Deploys to GitHub Pages with proper permissions

2. **Production Build Config** (`vite.config.ha.prod.ts`):
   - Minified output for smaller file size
   - Production mode settings
   - Source maps disabled

3. **Landing Page** (`.github/pages-index.html`):
   - Simple installation instructions
   - Links to repository and panel.js

4. **Documentation Updates**:
   - Updated README.md with GitHub Pages installation option
   - Added deployment section to CLAUDE.md
   - New npm script for production builds

## Testing
- [x] All tests pass locally (`npm test`)
- [x] Linting passes (`npm run lint`)
- [x] TypeScript checks pass (`npm run typecheck`)
- [x] Production build works (`npm run build:ha:prod`)
- [ ] Workflow will be tested when merged to main

## Deployment Notes
After merging, the workflow will:
1. Automatically run on pushes to main
2. Build and deploy to https://fx.github.io/liebe/
3. Make the panel available at https://fx.github.io/liebe/panel.js

Users can then simply add this URL to their Home Assistant configuration without needing to build or host anything themselves.