### PR TITLE
fix: prevent panel from disappearing when switching tabs

### DIFF
--- a/src/panel.ts
+++ b/src/panel.ts
@@ -18,6 +18,7 @@ import '~/styles/app.css'
 class LiebePanel extends HTMLElement {
   private _hass: HomeAssistant | null = null
   private root?: ReactDOM.Root
+  private initialized = false
 
   set hass(hass: HomeAssistant) {
     this._hass = hass
@@ -25,7 +26,10 @@ class LiebePanel extends HTMLElement {
   }
 
   connectedCallback() {
-    if (!this.root) {
+    // Only initialize once - don't recreate on reconnection
+    if (!this.initialized) {
+      this.initialized = true
+
       const shadow = this.attachShadow({ mode: 'open' })
       const container = document.createElement('div')
       container.style.height = '100%'
@@ -49,11 +53,13 @@ class LiebePanel extends HTMLElement {
 
       this.root = ReactDOM.createRoot(container)
     }
+
     this.render()
   }
 
   disconnectedCallback() {
-    this.root?.unmount()
+    // Do NOT unmount or cleanup - Home Assistant will re-add this element
+    // when the user navigates back to the panel
   }
 
   private render() {


### PR DESCRIPTION
## Summary
- Fixed an issue where the Liebe panel would disappear when switching tabs in Home Assistant
- Panel now persists across tab switches without losing state

## Problem
When users switched away from the Liebe panel to another tab in Home Assistant and then returned, the panel would completely disappear. Home Assistant was removing the `<liebe-panel>` custom element from the DOM when switching tabs, and our `disconnectedCallback` was cleaning up the React app immediately.

## Solution
- Added an `initialized` flag to track one-time setup
- Modified `connectedCallback` to only initialize shadow DOM and React root once
- Removed cleanup logic from `disconnectedCallback` to preserve panel state
- The panel now handles being temporarily removed and re-added to the DOM by Home Assistant

## Testing
- Tested switching between tabs multiple times
- Verified panel persists and maintains state
- Confirmed WebRTC streams continue working after tab switches