### PR TITLE
feat: add fullscreen and mute controls to camera cards

### DIFF
--- a/src/components/CameraCard.tsx
+++ b/src/components/CameraCard.tsx
@@ -156,7 +156,6 @@ function FullscreenCameraControls({
         display: 'inline-flex',
         alignItems: 'center',
         gap: '0.8em',
-        fontSize: 'clamp(12px, 2vw, 16px)', // Base font size scales with viewport
       }}
     >
       {/* Entity info */}
@@ -517,8 +516,11 @@ function CameraCardComponent({
           {/* Controls and info container positioned absolutely at bottom left */}
           <Box
             position="absolute"
-            bottom={isFullscreen ? '4' : '2'}
-            left={isFullscreen ? '4' : '2'}
+            bottom="2"
+            left="2"
+            style={{
+              fontSize: size === 'small' ? '12px' : size === 'large' ? '16px' : '14px',
+            }}
           >
             <CameraControls
               friendlyName={friendlyName}
@@ -571,6 +573,7 @@ function CameraCardComponent({
             bottom: '2%',
             left: '2%',
             zIndex: 10,
+            fontSize: 'min(4vw, 24px)', // Scale based on viewport width
           }}
         >
           <FullscreenCameraControls

--- a/src/components/CameraCard.tsx
+++ b/src/components/CameraCard.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text, Button, IconButton } from '@radix-ui/themes'
+import { Flex, Text, Button, IconButton, Box, Card } from '@radix-ui/themes'
 import {
   VideoIcon,
   ReloadIcon,
@@ -287,78 +287,60 @@ function CameraCardComponent({
           )}
 
           {/* Controls and info container positioned absolutely at bottom left */}
-          <Flex
-            style={{
-              position: 'absolute',
-              bottom: isFullscreen ? '20px' : '8px',
-              left: isFullscreen ? '20px' : '8px',
-              background: 'rgba(0, 0, 0, 0.7)',
-              padding: isFullscreen ? '8px 12px' : '4px 8px',
-              borderRadius: isFullscreen ? '8px' : 'var(--radius-1)',
-              backdropFilter: 'blur(4px)',
-              zIndex: 15,
-            }}
-            align="center"
-            gap={isFullscreen ? '3' : '2'}
+          <Box
+            position="absolute"
+            bottom={isFullscreen ? '4' : '2'}
+            left={isFullscreen ? '4' : '2'}
           >
-            {/* Entity info */}
-            <Flex direction="column" gap="0">
-              <Text
-                size={isFullscreen ? '3' : '1'}
-                weight="medium"
-                style={{
-                  color: 'white',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  maxWidth: isFullscreen ? '300px' : '150px',
-                }}
-              >
-                {friendlyName}
-              </Text>
-              <Text
-                size={isFullscreen ? '2' : '1'}
-                style={{
-                  color: streamError ? '#ff6b6b' : isRecording || isStreaming_ ? '#4c9aff' : '#aaa',
-                  opacity: 0.9,
-                }}
-              >
-                {streamError
-                  ? 'ERROR'
-                  : isRecording
-                    ? 'RECORDING'
-                    : isStreaming_
-                      ? 'STREAMING'
-                      : isIdle
-                        ? 'IDLE'
-                        : entity.state.toUpperCase()}
-              </Text>
-            </Flex>
+            <Card size={isFullscreen ? '2' : '1'}>
+              <Flex align="center" gap={isFullscreen ? '3' : '2'}>
+                {/* Entity info */}
+                <Flex direction="column" gap="0">
+                  <Text size={isFullscreen ? '3' : '1'} weight="medium" truncate>
+                    {friendlyName}
+                  </Text>
+                  <Text
+                    size={isFullscreen ? '2' : '1'}
+                    color={streamError ? 'red' : isRecording || isStreaming_ ? 'blue' : 'gray'}
+                  >
+                    {streamError
+                      ? 'ERROR'
+                      : isRecording
+                        ? 'RECORDING'
+                        : isStreaming_
+                          ? 'STREAMING'
+                          : isIdle
+                            ? 'IDLE'
+                            : entity.state.toUpperCase()}
+                  </Text>
+                </Flex>
 
-            {/* Control buttons - only show when streaming and not in edit mode */}
-            {supportsStream && isStreaming && !streamError && !isEditMode && (
-              <Flex gap={isFullscreen ? '2' : '1'}>
-                <IconButton
-                  size={isFullscreen ? '2' : '1'}
-                  variant="soft"
-                  highContrast
-                  onClick={handleToggleMute}
-                  title={isMuted ? 'Unmute' : 'Mute'}
-                >
-                  {isMuted ? <SpeakerOffIcon /> : <SpeakerLoudIcon />}
-                </IconButton>
-                <IconButton
-                  size={isFullscreen ? '2' : '1'}
-                  variant="soft"
-                  highContrast
-                  onClick={handleVideoFullscreen}
-                  title="Toggle native fullscreen"
-                >
-                  <EnterFullScreenIcon />
-                </IconButton>
+                {/* Control buttons - only show when streaming and not in edit mode */}
+                {supportsStream && isStreaming && !streamError && !isEditMode && (
+                  <Flex gap={isFullscreen ? '2' : '1'}>
+                    <IconButton
+                      size={isFullscreen ? '2' : '1'}
+                      variant="soft"
+                      highContrast
+                      onClick={handleToggleMute}
+                      title={isMuted ? 'Unmute' : 'Mute'}
+                    >
+                      {isMuted ? <SpeakerOffIcon /> : <SpeakerLoudIcon />}
+                    </IconButton>
+                    <IconButton
+                      size={isFullscreen ? '2' : '1'}
+                      variant="soft"
+                      highContrast
+                      onClick={handleVideoFullscreen}
+                      title="Toggle native fullscreen"
+                    >
+                      <EnterFullScreenIcon />
+                    </IconButton>
+                  </Flex>
+                )}
               </Flex>
-            )}
-          </Flex>
+            </Card>
+          </Box>
         </div>
       </GridCard>
 
@@ -391,77 +373,56 @@ function CameraCardComponent({
         />
 
         {/* Fullscreen controls and info container */}
-        <Flex
-          style={{
-            position: 'absolute',
-            bottom: '20px',
-            left: '20px',
-            background: 'rgba(0, 0, 0, 0.7)',
-            padding: '8px 12px',
-            borderRadius: '8px',
-            backdropFilter: 'blur(4px)',
-          }}
-          align="center"
-          gap="3"
-        >
-          {/* Entity info */}
-          <Flex direction="column" gap="0">
-            <Text
-              size="3"
-              weight="medium"
-              style={{
-                color: 'white',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                maxWidth: '300px',
-              }}
-            >
-              {friendlyName}
-            </Text>
-            <Text
-              size="2"
-              style={{
-                color: streamError ? '#ff6b6b' : isRecording || isStreaming_ ? '#4c9aff' : '#aaa',
-                opacity: 0.9,
-              }}
-            >
-              {streamError
-                ? 'ERROR'
-                : isRecording
-                  ? 'RECORDING'
-                  : isStreaming_
-                    ? 'STREAMING'
-                    : isIdle
-                      ? 'IDLE'
-                      : entity.state.toUpperCase()}
-            </Text>
-          </Flex>
+        <Box position="absolute" bottom="4" left="4">
+          <Card size="2">
+            <Flex align="center" gap="3">
+              {/* Entity info */}
+              <Flex direction="column" gap="0">
+                <Text size="3" weight="medium" truncate>
+                  {friendlyName}
+                </Text>
+                <Text
+                  size="2"
+                  color={streamError ? 'red' : isRecording || isStreaming_ ? 'blue' : 'gray'}
+                >
+                  {streamError
+                    ? 'ERROR'
+                    : isRecording
+                      ? 'RECORDING'
+                      : isStreaming_
+                        ? 'STREAMING'
+                        : isIdle
+                          ? 'IDLE'
+                          : entity.state.toUpperCase()}
+                </Text>
+              </Flex>
 
-          {/* Control buttons in fullscreen modal */}
-          {supportsStream && isStreaming && !streamError && (
-            <Flex gap="2">
-              <IconButton
-                size="2"
-                variant="soft"
-                highContrast
-                onClick={handleToggleMute}
-                title={isMuted ? 'Unmute' : 'Mute'}
-              >
-                {isMuted ? <SpeakerOffIcon /> : <SpeakerLoudIcon />}
-              </IconButton>
-              <IconButton
-                size="2"
-                variant="soft"
-                highContrast
-                onClick={handleVideoFullscreen}
-                title="Toggle native fullscreen"
-              >
-                <EnterFullScreenIcon />
-              </IconButton>
+              {/* Control buttons in fullscreen modal */}
+              {supportsStream && isStreaming && !streamError && (
+                <Flex gap="2">
+                  <IconButton
+                    size="2"
+                    variant="soft"
+                    highContrast
+                    onClick={handleToggleMute}
+                    title={isMuted ? 'Unmute' : 'Mute'}
+                  >
+                    {isMuted ? <SpeakerOffIcon /> : <SpeakerLoudIcon />}
+                  </IconButton>
+                  <IconButton
+                    size="2"
+                    variant="soft"
+                    highContrast
+                    onClick={handleVideoFullscreen}
+                    title="Toggle native fullscreen"
+                  >
+                    <EnterFullScreenIcon />
+                  </IconButton>
+                </Flex>
+              )}
             </Flex>
-          )}
-        </Flex>
+          </Card>
+        </Box>
 
         {/* Exit indicator */}
         <div

--- a/src/components/CameraCard.tsx
+++ b/src/components/CameraCard.tsx
@@ -63,7 +63,7 @@ function CameraControls({
   isFullscreen?: boolean
 }) {
   // Base scale factor for different sizes
-  const scaleFactor = size === 'small' ? 0.8 : size === 'large' ? 1.2 : 1
+  const scaleFactor = size === 'small' ? 0.64 : size === 'large' ? 0.96 : 0.8
 
   return (
     <div
@@ -441,7 +441,7 @@ function CameraCardComponent({
               position: 'absolute',
               bottom: '8px',
               left: '8px',
-              fontSize: size === 'small' ? '10px' : size === 'large' ? '14px' : '12px',
+              fontSize: size === 'small' ? '8px' : size === 'large' ? '11.2px' : '9.6px',
             }}
           >
             <CameraControls
@@ -495,7 +495,7 @@ function CameraCardComponent({
             bottom: '2%',
             left: '2%',
             zIndex: 10,
-            fontSize: 'min(4vw, 24px)', // Scale based on viewport width
+            fontSize: 'min(3.2vw, 19.2px)', // Scale based on viewport width (reduced by 20%)
           }}
         >
           <CameraControls

--- a/src/components/CameraCard.tsx
+++ b/src/components/CameraCard.tsx
@@ -150,22 +150,23 @@ function FullscreenCameraControls({
     <div
       style={{
         backgroundColor: 'rgba(0, 0, 0, 0.8)',
-        borderRadius: '12px',
-        padding: '12px 16px',
+        borderRadius: '0.75em',
+        padding: '0.6em 0.8em',
         backdropFilter: 'blur(8px)',
-        display: 'flex',
+        display: 'inline-flex',
         alignItems: 'center',
-        gap: '16px',
+        gap: '0.8em',
+        fontSize: 'clamp(12px, 2vw, 16px)', // Base font size scales with viewport
       }}
     >
       {/* Entity info */}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.1em' }}>
         <div
           style={{
             color: 'white',
-            fontSize: '16px',
+            fontSize: '1em',
             fontWeight: 600,
-            lineHeight: '20px',
+            lineHeight: 1.25,
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
@@ -176,8 +177,8 @@ function FullscreenCameraControls({
         <div
           style={{
             color: streamError ? '#ff6b6b' : isRecording || isStreaming ? '#4dabf7' : '#868e96',
-            fontSize: '13px',
-            lineHeight: '16px',
+            fontSize: '0.8em',
+            lineHeight: 1.2,
             textTransform: 'uppercase',
             fontWeight: 500,
           }}
@@ -196,14 +197,14 @@ function FullscreenCameraControls({
 
       {/* Control buttons */}
       {supportsStream && isStreaming && !streamError && !isEditMode && (
-        <div style={{ display: 'flex', gap: '8px' }}>
+        <div style={{ display: 'flex', gap: '0.5em' }}>
           <button
             onClick={handleToggleMute}
             title={isMuted ? 'Unmute' : 'Mute'}
             style={{
-              width: '36px',
-              height: '36px',
-              borderRadius: '8px',
+              width: '2.2em',
+              height: '2.2em',
+              borderRadius: '0.5em',
               border: 'none',
               backgroundColor: 'rgba(255, 255, 255, 0.1)',
               color: 'white',
@@ -212,6 +213,7 @@ function FullscreenCameraControls({
               justifyContent: 'center',
               cursor: 'pointer',
               transition: 'background-color 0.2s ease',
+              padding: 0,
             }}
             onMouseEnter={(e) => {
               e.currentTarget.style.backgroundColor = 'rgba(255, 255, 255, 0.2)'
@@ -221,18 +223,18 @@ function FullscreenCameraControls({
             }}
           >
             {isMuted ? (
-              <SpeakerOffIcon width={18} height={18} />
+              <SpeakerOffIcon style={{ width: '60%', height: '60%' }} />
             ) : (
-              <SpeakerLoudIcon width={18} height={18} />
+              <SpeakerLoudIcon style={{ width: '60%', height: '60%' }} />
             )}
           </button>
           <button
             onClick={handleVideoFullscreen}
             title="Toggle native fullscreen"
             style={{
-              width: '36px',
-              height: '36px',
-              borderRadius: '8px',
+              width: '2.2em',
+              height: '2.2em',
+              borderRadius: '0.5em',
               border: 'none',
               backgroundColor: 'rgba(255, 255, 255, 0.1)',
               color: 'white',
@@ -241,6 +243,7 @@ function FullscreenCameraControls({
               justifyContent: 'center',
               cursor: 'pointer',
               transition: 'background-color 0.2s ease',
+              padding: 0,
             }}
             onMouseEnter={(e) => {
               e.currentTarget.style.backgroundColor = 'rgba(255, 255, 255, 0.2)'
@@ -249,7 +252,7 @@ function FullscreenCameraControls({
               e.currentTarget.style.backgroundColor = 'rgba(255, 255, 255, 0.1)'
             }}
           >
-            <EnterFullScreenIcon width={18} height={18} />
+            <EnterFullScreenIcon style={{ width: '60%', height: '60%' }} />
           </button>
         </div>
       )}
@@ -565,8 +568,8 @@ function CameraCardComponent({
         <div
           style={{
             position: 'absolute',
-            bottom: '20px',
-            left: '20px',
+            bottom: '2%',
+            left: '2%',
             zIndex: 10,
           }}
         >

--- a/src/components/CameraCard.tsx
+++ b/src/components/CameraCard.tsx
@@ -32,7 +32,7 @@ interface CameraAttributes {
 // Camera supported features bit flags from Home Assistant
 const SUPPORT_STREAM = 2
 
-// Camera controls component to avoid duplication
+// Camera controls component for use inside shadow DOM with Radix UI
 function CameraControls({
   friendlyName,
   entity,
@@ -117,6 +117,143 @@ function CameraControls({
         )}
       </Flex>
     </Card>
+  )
+}
+
+// Custom-styled camera controls for fullscreen modal (outside shadow DOM)
+function FullscreenCameraControls({
+  friendlyName,
+  entity,
+  streamError,
+  isRecording,
+  isStreaming,
+  isIdle,
+  supportsStream,
+  isEditMode,
+  isMuted,
+  handleToggleMute,
+  handleVideoFullscreen,
+}: {
+  friendlyName: string
+  entity: { state: string; attributes: CameraAttributes }
+  streamError: string | null
+  isRecording: boolean
+  isStreaming: boolean
+  isIdle: boolean
+  supportsStream: boolean
+  isEditMode: boolean
+  isMuted: boolean
+  handleToggleMute: (e: React.MouseEvent) => void
+  handleVideoFullscreen: (e: React.MouseEvent) => void
+}) {
+  return (
+    <div
+      style={{
+        backgroundColor: 'rgba(0, 0, 0, 0.8)',
+        borderRadius: '12px',
+        padding: '12px 16px',
+        backdropFilter: 'blur(8px)',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '16px',
+      }}
+    >
+      {/* Entity info */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+        <div
+          style={{
+            color: 'white',
+            fontSize: '16px',
+            fontWeight: 600,
+            lineHeight: '20px',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {friendlyName}
+        </div>
+        <div
+          style={{
+            color: streamError ? '#ff6b6b' : isRecording || isStreaming ? '#4dabf7' : '#868e96',
+            fontSize: '13px',
+            lineHeight: '16px',
+            textTransform: 'uppercase',
+            fontWeight: 500,
+          }}
+        >
+          {streamError
+            ? 'ERROR'
+            : isRecording
+              ? 'RECORDING'
+              : isStreaming
+                ? 'STREAMING'
+                : isIdle
+                  ? 'IDLE'
+                  : entity.state.toUpperCase()}
+        </div>
+      </div>
+
+      {/* Control buttons */}
+      {supportsStream && isStreaming && !streamError && !isEditMode && (
+        <div style={{ display: 'flex', gap: '8px' }}>
+          <button
+            onClick={handleToggleMute}
+            title={isMuted ? 'Unmute' : 'Mute'}
+            style={{
+              width: '36px',
+              height: '36px',
+              borderRadius: '8px',
+              border: 'none',
+              backgroundColor: 'rgba(255, 255, 255, 0.1)',
+              color: 'white',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: 'pointer',
+              transition: 'background-color 0.2s ease',
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.backgroundColor = 'rgba(255, 255, 255, 0.2)'
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.backgroundColor = 'rgba(255, 255, 255, 0.1)'
+            }}
+          >
+            {isMuted ? (
+              <SpeakerOffIcon width={18} height={18} />
+            ) : (
+              <SpeakerLoudIcon width={18} height={18} />
+            )}
+          </button>
+          <button
+            onClick={handleVideoFullscreen}
+            title="Toggle native fullscreen"
+            style={{
+              width: '36px',
+              height: '36px',
+              borderRadius: '8px',
+              border: 'none',
+              backgroundColor: 'rgba(255, 255, 255, 0.1)',
+              color: 'white',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: 'pointer',
+              transition: 'background-color 0.2s ease',
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.backgroundColor = 'rgba(255, 255, 255, 0.2)'
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.backgroundColor = 'rgba(255, 255, 255, 0.1)'
+            }}
+          >
+            <EnterFullScreenIcon width={18} height={18} />
+          </button>
+        </div>
+      )}
+    </div>
   )
 }
 
@@ -433,7 +570,7 @@ function CameraCardComponent({
             zIndex: 10,
           }}
         >
-          <CameraControls
+          <FullscreenCameraControls
             friendlyName={friendlyName}
             entity={entity}
             streamError={streamError}
@@ -445,7 +582,6 @@ function CameraCardComponent({
             isMuted={isMuted}
             handleToggleMute={handleToggleMute}
             handleVideoFullscreen={handleVideoFullscreen}
-            size="large"
           />
         </div>
 

--- a/src/components/CameraCard.tsx
+++ b/src/components/CameraCard.tsx
@@ -356,9 +356,7 @@ function CameraCardComponent({
         contentStyle={{
           width: '100%',
           height: '100%',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
+          position: 'relative',
         }}
       >
         <div

--- a/src/components/CameraCard.tsx
+++ b/src/components/CameraCard.tsx
@@ -288,10 +288,10 @@ function CameraCardComponent({
 
           {/* Controls and info container positioned absolutely at bottom left */}
           <Flex
-            position="absolute"
-            bottom={isFullscreen ? '4' : '2'}
-            left={isFullscreen ? '4' : '2'}
             style={{
+              position: 'absolute',
+              bottom: isFullscreen ? '20px' : '8px',
+              left: isFullscreen ? '20px' : '8px',
               background: 'rgba(0, 0, 0, 0.7)',
               padding: isFullscreen ? '8px 12px' : '4px 8px',
               borderRadius: isFullscreen ? '8px' : 'var(--radius-1)',
@@ -392,10 +392,10 @@ function CameraCardComponent({
 
         {/* Fullscreen controls and info container */}
         <Flex
-          position="absolute"
-          bottom="4"
-          left="4"
           style={{
+            position: 'absolute',
+            bottom: '20px',
+            left: '20px',
             background: 'rgba(0, 0, 0, 0.7)',
             padding: '8px 12px',
             borderRadius: '8px',

--- a/src/components/CameraCard.tsx
+++ b/src/components/CameraCard.tsx
@@ -371,7 +371,14 @@ function CameraCardComponent({
         />
 
         {/* Fullscreen controls and info container */}
-        <Box position="absolute" bottom="4" left="4">
+        <div
+          style={{
+            position: 'absolute',
+            bottom: '20px',
+            left: '20px',
+            zIndex: 10,
+          }}
+        >
           <Card size="2">
             <Flex align="center" gap="3">
               {/* Entity info */}
@@ -420,7 +427,7 @@ function CameraCardComponent({
               )}
             </Flex>
           </Card>
-        </Box>
+        </div>
 
         {/* Exit indicator */}
         <div

--- a/src/components/CameraCard.tsx
+++ b/src/components/CameraCard.tsx
@@ -286,51 +286,41 @@ function CameraCardComponent({
             </Flex>
           )}
 
-          {/* Controls and info container positioned absolutely at bottom */}
-          <div
+          {/* Controls and info container positioned absolutely at bottom left */}
+          <Flex
+            position="absolute"
+            bottom={isFullscreen ? '4' : '2'}
+            left={isFullscreen ? '4' : '2'}
             style={{
-              position: 'absolute',
-              bottom: isFullscreen ? '20px' : '8px',
-              left: isFullscreen ? '20px' : '8px',
-              right: isFullscreen ? '20px' : '8px',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              gap: isFullscreen ? '16px' : '8px',
+              background: 'rgba(0, 0, 0, 0.7)',
+              padding: isFullscreen ? '8px 12px' : '4px 8px',
+              borderRadius: isFullscreen ? '8px' : 'var(--radius-1)',
+              backdropFilter: 'blur(4px)',
               zIndex: 15,
             }}
+            align="center"
+            gap={isFullscreen ? '3' : '2'}
           >
             {/* Entity info */}
-            <div
-              style={{
-                background: 'rgba(0, 0, 0, 0.7)',
-                padding: isFullscreen ? '8px 16px' : '4px 8px',
-                borderRadius: isFullscreen ? '8px' : 'var(--radius-1)',
-                backdropFilter: 'blur(4px)',
-                color: 'white',
-                fontSize: isFullscreen ? '16px' : '12px',
-                lineHeight: '1.2',
-                flex: '1 1 auto',
-                minWidth: 0,
-                overflow: 'hidden',
-              }}
-            >
-              <div
+            <Flex direction="column" gap="0">
+              <Text
+                size={isFullscreen ? '3' : '1'}
+                weight="medium"
                 style={{
-                  fontWeight: isFullscreen ? '600' : '500',
-                  marginBottom: '2px',
+                  color: 'white',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',
+                  maxWidth: isFullscreen ? '300px' : '150px',
                 }}
               >
                 {friendlyName}
-              </div>
-              <div
+              </Text>
+              <Text
+                size={isFullscreen ? '2' : '1'}
                 style={{
-                  fontSize: isFullscreen ? '14px' : '10px',
-                  opacity: 0.9,
                   color: streamError ? '#ff6b6b' : isRecording || isStreaming_ ? '#4c9aff' : '#aaa',
+                  opacity: 0.9,
                 }}
               >
                 {streamError
@@ -342,21 +332,12 @@ function CameraCardComponent({
                       : isIdle
                         ? 'IDLE'
                         : entity.state.toUpperCase()}
-              </div>
-            </div>
+              </Text>
+            </Flex>
 
             {/* Control buttons - only show when streaming and not in edit mode */}
             {supportsStream && isStreaming && !streamError && !isEditMode && (
-              <div
-                style={{
-                  display: 'flex',
-                  gap: isFullscreen ? '8px' : '4px',
-                  background: 'rgba(0, 0, 0, 0.7)',
-                  padding: isFullscreen ? '6px' : '4px',
-                  borderRadius: isFullscreen ? '8px' : 'var(--radius-1)',
-                  backdropFilter: 'blur(4px)',
-                }}
-              >
+              <Flex gap={isFullscreen ? '2' : '1'}>
                 <IconButton
                   size={isFullscreen ? '2' : '1'}
                   variant="ghost"
@@ -364,7 +345,6 @@ function CameraCardComponent({
                   style={{
                     color: 'white',
                     backgroundColor: 'rgba(255, 255, 255, 0.1)',
-                    cursor: 'pointer',
                   }}
                   title={isMuted ? 'Unmute' : 'Mute'}
                 >
@@ -377,15 +357,14 @@ function CameraCardComponent({
                   style={{
                     color: 'white',
                     backgroundColor: 'rgba(255, 255, 255, 0.1)',
-                    cursor: 'pointer',
                   }}
                   title="Toggle native fullscreen"
                 >
                   <EnterFullScreenIcon />
                 </IconButton>
-              </div>
+              </Flex>
             )}
-          </div>
+          </Flex>
         </div>
       </GridCard>
 
@@ -418,48 +397,39 @@ function CameraCardComponent({
         />
 
         {/* Fullscreen controls and info container */}
-        <div
+        <Flex
+          position="absolute"
+          bottom="4"
+          left="4"
           style={{
-            position: 'absolute',
-            bottom: '20px',
-            left: '20px',
-            right: '20px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            gap: '16px',
+            background: 'rgba(0, 0, 0, 0.7)',
+            padding: '8px 12px',
+            borderRadius: '8px',
+            backdropFilter: 'blur(4px)',
           }}
+          align="center"
+          gap="3"
         >
           {/* Entity info */}
-          <div
-            style={{
-              background: 'rgba(0, 0, 0, 0.7)',
-              padding: '8px 16px',
-              borderRadius: '8px',
-              backdropFilter: 'blur(4px)',
-              color: 'white',
-              fontSize: '16px',
-              lineHeight: '1.2',
-              flex: '1 1 auto',
-              minWidth: 0,
-            }}
-          >
-            <div
+          <Flex direction="column" gap="0">
+            <Text
+              size="3"
+              weight="medium"
               style={{
-                fontWeight: '600',
-                marginBottom: '2px',
+                color: 'white',
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
                 whiteSpace: 'nowrap',
+                maxWidth: '300px',
               }}
             >
               {friendlyName}
-            </div>
-            <div
+            </Text>
+            <Text
+              size="2"
               style={{
-                fontSize: '14px',
-                opacity: 0.9,
                 color: streamError ? '#ff6b6b' : isRecording || isStreaming_ ? '#4c9aff' : '#aaa',
+                opacity: 0.9,
               }}
             >
               {streamError
@@ -471,21 +441,12 @@ function CameraCardComponent({
                     : isIdle
                       ? 'IDLE'
                       : entity.state.toUpperCase()}
-            </div>
-          </div>
+            </Text>
+          </Flex>
 
           {/* Control buttons in fullscreen modal */}
           {supportsStream && isStreaming && !streamError && (
-            <div
-              style={{
-                display: 'flex',
-                gap: '8px',
-                background: 'rgba(0, 0, 0, 0.7)',
-                padding: '6px',
-                borderRadius: '8px',
-                backdropFilter: 'blur(4px)',
-              }}
-            >
+            <Flex gap="2">
               <IconButton
                 size="2"
                 variant="ghost"
@@ -493,7 +454,6 @@ function CameraCardComponent({
                 style={{
                   color: 'white',
                   backgroundColor: 'rgba(255, 255, 255, 0.1)',
-                  cursor: 'pointer',
                 }}
                 title={isMuted ? 'Unmute' : 'Mute'}
               >
@@ -506,15 +466,14 @@ function CameraCardComponent({
                 style={{
                   color: 'white',
                   backgroundColor: 'rgba(255, 255, 255, 0.1)',
-                  cursor: 'pointer',
                 }}
                 title="Toggle native fullscreen"
               >
                 <EnterFullScreenIcon />
               </IconButton>
-            </div>
+            </Flex>
           )}
-        </div>
+        </Flex>
 
         {/* Exit indicator */}
         <div

--- a/src/components/CameraCard.tsx
+++ b/src/components/CameraCard.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text, Button, IconButton, Box, Card } from '@radix-ui/themes'
+import { Flex, Text, Button } from '@radix-ui/themes'
 import {
   VideoIcon,
   ReloadIcon,
@@ -32,7 +32,7 @@ interface CameraAttributes {
 // Camera supported features bit flags from Home Assistant
 const SUPPORT_STREAM = 2
 
-// Camera controls component for use inside shadow DOM with Radix UI
+// Custom-styled camera controls for both regular and fullscreen views
 function CameraControls({
   friendlyName,
   entity,
@@ -46,6 +46,7 @@ function CameraControls({
   handleToggleMute,
   handleVideoFullscreen,
   size,
+  isFullscreen = false,
 }: {
   friendlyName: string
   entity: { state: string; attributes: CameraAttributes }
@@ -59,107 +60,26 @@ function CameraControls({
   handleToggleMute: (e: React.MouseEvent) => void
   handleVideoFullscreen: (e: React.MouseEvent) => void
   size: 'small' | 'medium' | 'large'
+  isFullscreen?: boolean
 }) {
-  const isSmall = size === 'small'
-  const cardSize = isSmall ? '1' : '2'
-  const textSize = isSmall ? '1' : '3'
-  const textSizeSmall = isSmall ? '1' : '2'
-  const buttonSize = isSmall ? '1' : '2'
-  const gap = isSmall ? '2' : '3'
-  const buttonGap = isSmall ? '1' : '2'
+  // Base scale factor for different sizes
+  const scaleFactor = size === 'small' ? 0.8 : size === 'large' ? 1.2 : 1
 
-  return (
-    <Card size={cardSize}>
-      <Flex align="center" gap={gap}>
-        {/* Entity info */}
-        <Flex direction="column" gap="0">
-          <Text size={textSize} weight="medium" truncate>
-            {friendlyName}
-          </Text>
-          <Text
-            size={textSizeSmall}
-            color={streamError ? 'red' : isRecording || isStreaming ? 'blue' : 'gray'}
-          >
-            {streamError
-              ? 'ERROR'
-              : isRecording
-                ? 'RECORDING'
-                : isStreaming
-                  ? 'STREAMING'
-                  : isIdle
-                    ? 'IDLE'
-                    : entity.state.toUpperCase()}
-          </Text>
-        </Flex>
-
-        {/* Control buttons - only show when streaming and not in edit mode */}
-        {supportsStream && isStreaming && !streamError && !isEditMode && (
-          <Flex gap={buttonGap}>
-            <IconButton
-              size={buttonSize}
-              variant="soft"
-              highContrast
-              onClick={handleToggleMute}
-              title={isMuted ? 'Unmute' : 'Mute'}
-            >
-              {isMuted ? <SpeakerOffIcon /> : <SpeakerLoudIcon />}
-            </IconButton>
-            <IconButton
-              size={buttonSize}
-              variant="soft"
-              highContrast
-              onClick={handleVideoFullscreen}
-              title="Toggle native fullscreen"
-            >
-              <EnterFullScreenIcon />
-            </IconButton>
-          </Flex>
-        )}
-      </Flex>
-    </Card>
-  )
-}
-
-// Custom-styled camera controls for fullscreen modal (outside shadow DOM)
-function FullscreenCameraControls({
-  friendlyName,
-  entity,
-  streamError,
-  isRecording,
-  isStreaming,
-  isIdle,
-  supportsStream,
-  isEditMode,
-  isMuted,
-  handleToggleMute,
-  handleVideoFullscreen,
-}: {
-  friendlyName: string
-  entity: { state: string; attributes: CameraAttributes }
-  streamError: string | null
-  isRecording: boolean
-  isStreaming: boolean
-  isIdle: boolean
-  supportsStream: boolean
-  isEditMode: boolean
-  isMuted: boolean
-  handleToggleMute: (e: React.MouseEvent) => void
-  handleVideoFullscreen: (e: React.MouseEvent) => void
-}) {
   return (
     <div
       style={{
         backgroundColor: 'rgba(0, 0, 0, 0.8)',
-        borderRadius: '0.75em',
-        padding: '0.6em 0.8em',
+        borderRadius: `${0.6 * scaleFactor}em`,
+        padding: `${0.3 * scaleFactor}em ${0.5 * scaleFactor}em`,
         backdropFilter: 'blur(8px)',
         display: 'inline-flex',
         alignItems: 'center',
-        gap: '0.8em',
+        gap: `${0.64 * scaleFactor}em`,
+        fontSize: isFullscreen ? 'inherit' : `${scaleFactor}em`,
       }}
     >
       {/* Entity info */}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.1em' }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: `${0.08 * scaleFactor}em` }}>
         <div
           style={{
             color: 'white',
@@ -196,13 +116,13 @@ function FullscreenCameraControls({
 
       {/* Control buttons */}
       {supportsStream && isStreaming && !streamError && !isEditMode && (
-        <div style={{ display: 'flex', gap: '0.5em' }}>
+        <div style={{ display: 'flex', gap: `${0.4 * scaleFactor}em` }}>
           <button
             onClick={handleToggleMute}
             title={isMuted ? 'Unmute' : 'Mute'}
             style={{
-              width: '2.2em',
-              height: '2.2em',
+              width: '2.5em',
+              height: '2.5em',
               borderRadius: '0.5em',
               border: 'none',
               backgroundColor: 'rgba(255, 255, 255, 0.1)',
@@ -213,6 +133,7 @@ function FullscreenCameraControls({
               cursor: 'pointer',
               transition: 'background-color 0.2s ease',
               padding: 0,
+              fontSize: 'inherit',
             }}
             onMouseEnter={(e) => {
               e.currentTarget.style.backgroundColor = 'rgba(255, 255, 255, 0.2)'
@@ -222,17 +143,17 @@ function FullscreenCameraControls({
             }}
           >
             {isMuted ? (
-              <SpeakerOffIcon style={{ width: '60%', height: '60%' }} />
+              <SpeakerOffIcon style={{ width: '55%', height: '55%' }} />
             ) : (
-              <SpeakerLoudIcon style={{ width: '60%', height: '60%' }} />
+              <SpeakerLoudIcon style={{ width: '55%', height: '55%' }} />
             )}
           </button>
           <button
             onClick={handleVideoFullscreen}
             title="Toggle native fullscreen"
             style={{
-              width: '2.2em',
-              height: '2.2em',
+              width: '2.5em',
+              height: '2.5em',
               borderRadius: '0.5em',
               border: 'none',
               backgroundColor: 'rgba(255, 255, 255, 0.1)',
@@ -243,6 +164,7 @@ function FullscreenCameraControls({
               cursor: 'pointer',
               transition: 'background-color 0.2s ease',
               padding: 0,
+              fontSize: 'inherit',
             }}
             onMouseEnter={(e) => {
               e.currentTarget.style.backgroundColor = 'rgba(255, 255, 255, 0.2)'
@@ -251,7 +173,7 @@ function FullscreenCameraControls({
               e.currentTarget.style.backgroundColor = 'rgba(255, 255, 255, 0.1)'
             }}
           >
-            <EnterFullScreenIcon style={{ width: '60%', height: '60%' }} />
+            <EnterFullScreenIcon style={{ width: '55%', height: '55%' }} />
           </button>
         </div>
       )}
@@ -514,12 +436,12 @@ function CameraCardComponent({
           )}
 
           {/* Controls and info container positioned absolutely at bottom left */}
-          <Box
-            position="absolute"
-            bottom="2"
-            left="2"
+          <div
             style={{
-              fontSize: size === 'small' ? '12px' : size === 'large' ? '16px' : '14px',
+              position: 'absolute',
+              bottom: '8px',
+              left: '8px',
+              fontSize: size === 'small' ? '10px' : size === 'large' ? '14px' : '12px',
             }}
           >
             <CameraControls
@@ -536,7 +458,7 @@ function CameraCardComponent({
               handleVideoFullscreen={handleVideoFullscreen}
               size={size}
             />
-          </Box>
+          </div>
         </div>
       </GridCard>
 
@@ -576,7 +498,7 @@ function CameraCardComponent({
             fontSize: 'min(4vw, 24px)', // Scale based on viewport width
           }}
         >
-          <FullscreenCameraControls
+          <CameraControls
             friendlyName={friendlyName}
             entity={entity}
             streamError={streamError}
@@ -588,6 +510,8 @@ function CameraCardComponent({
             isMuted={isMuted}
             handleToggleMute={handleToggleMute}
             handleVideoFullscreen={handleVideoFullscreen}
+            size="large"
+            isFullscreen={true}
           />
         </div>
 

--- a/src/components/CameraCard.tsx
+++ b/src/components/CameraCard.tsx
@@ -32,6 +32,94 @@ interface CameraAttributes {
 // Camera supported features bit flags from Home Assistant
 const SUPPORT_STREAM = 2
 
+// Camera controls component to avoid duplication
+function CameraControls({
+  friendlyName,
+  entity,
+  streamError,
+  isRecording,
+  isStreaming,
+  isIdle,
+  supportsStream,
+  isEditMode,
+  isMuted,
+  handleToggleMute,
+  handleVideoFullscreen,
+  size,
+}: {
+  friendlyName: string
+  entity: { state: string; attributes: CameraAttributes }
+  streamError: string | null
+  isRecording: boolean
+  isStreaming: boolean
+  isIdle: boolean
+  supportsStream: boolean
+  isEditMode: boolean
+  isMuted: boolean
+  handleToggleMute: (e: React.MouseEvent) => void
+  handleVideoFullscreen: (e: React.MouseEvent) => void
+  size: 'small' | 'medium' | 'large'
+}) {
+  const isSmall = size === 'small'
+  const cardSize = isSmall ? '1' : '2'
+  const textSize = isSmall ? '1' : '3'
+  const textSizeSmall = isSmall ? '1' : '2'
+  const buttonSize = isSmall ? '1' : '2'
+  const gap = isSmall ? '2' : '3'
+  const buttonGap = isSmall ? '1' : '2'
+
+  return (
+    <Card size={cardSize}>
+      <Flex align="center" gap={gap}>
+        {/* Entity info */}
+        <Flex direction="column" gap="0">
+          <Text size={textSize} weight="medium" truncate>
+            {friendlyName}
+          </Text>
+          <Text
+            size={textSizeSmall}
+            color={streamError ? 'red' : isRecording || isStreaming ? 'blue' : 'gray'}
+          >
+            {streamError
+              ? 'ERROR'
+              : isRecording
+                ? 'RECORDING'
+                : isStreaming
+                  ? 'STREAMING'
+                  : isIdle
+                    ? 'IDLE'
+                    : entity.state.toUpperCase()}
+          </Text>
+        </Flex>
+
+        {/* Control buttons - only show when streaming and not in edit mode */}
+        {supportsStream && isStreaming && !streamError && !isEditMode && (
+          <Flex gap={buttonGap}>
+            <IconButton
+              size={buttonSize}
+              variant="soft"
+              highContrast
+              onClick={handleToggleMute}
+              title={isMuted ? 'Unmute' : 'Mute'}
+            >
+              {isMuted ? <SpeakerOffIcon /> : <SpeakerLoudIcon />}
+            </IconButton>
+            <IconButton
+              size={buttonSize}
+              variant="soft"
+              highContrast
+              onClick={handleVideoFullscreen}
+              title="Toggle native fullscreen"
+            >
+              <EnterFullScreenIcon />
+            </IconButton>
+          </Flex>
+        )}
+      </Flex>
+    </Card>
+  )
+}
+
 function CameraCardComponent({
   entityId,
   size = 'medium',
@@ -292,54 +380,20 @@ function CameraCardComponent({
             bottom={isFullscreen ? '4' : '2'}
             left={isFullscreen ? '4' : '2'}
           >
-            <Card size={isFullscreen ? '2' : '1'}>
-              <Flex align="center" gap={isFullscreen ? '3' : '2'}>
-                {/* Entity info */}
-                <Flex direction="column" gap="0">
-                  <Text size={isFullscreen ? '3' : '1'} weight="medium" truncate>
-                    {friendlyName}
-                  </Text>
-                  <Text
-                    size={isFullscreen ? '2' : '1'}
-                    color={streamError ? 'red' : isRecording || isStreaming_ ? 'blue' : 'gray'}
-                  >
-                    {streamError
-                      ? 'ERROR'
-                      : isRecording
-                        ? 'RECORDING'
-                        : isStreaming_
-                          ? 'STREAMING'
-                          : isIdle
-                            ? 'IDLE'
-                            : entity.state.toUpperCase()}
-                  </Text>
-                </Flex>
-
-                {/* Control buttons - only show when streaming and not in edit mode */}
-                {supportsStream && isStreaming && !streamError && !isEditMode && (
-                  <Flex gap={isFullscreen ? '2' : '1'}>
-                    <IconButton
-                      size={isFullscreen ? '2' : '1'}
-                      variant="soft"
-                      highContrast
-                      onClick={handleToggleMute}
-                      title={isMuted ? 'Unmute' : 'Mute'}
-                    >
-                      {isMuted ? <SpeakerOffIcon /> : <SpeakerLoudIcon />}
-                    </IconButton>
-                    <IconButton
-                      size={isFullscreen ? '2' : '1'}
-                      variant="soft"
-                      highContrast
-                      onClick={handleVideoFullscreen}
-                      title="Toggle native fullscreen"
-                    >
-                      <EnterFullScreenIcon />
-                    </IconButton>
-                  </Flex>
-                )}
-              </Flex>
-            </Card>
+            <CameraControls
+              friendlyName={friendlyName}
+              entity={entity}
+              streamError={streamError}
+              isRecording={isRecording}
+              isStreaming={isStreaming}
+              isIdle={isIdle}
+              supportsStream={supportsStream}
+              isEditMode={isEditMode}
+              isMuted={isMuted}
+              handleToggleMute={handleToggleMute}
+              handleVideoFullscreen={handleVideoFullscreen}
+              size={size}
+            />
           </Box>
         </div>
       </GridCard>
@@ -379,54 +433,20 @@ function CameraCardComponent({
             zIndex: 10,
           }}
         >
-          <Card size="2">
-            <Flex align="center" gap="3">
-              {/* Entity info */}
-              <Flex direction="column" gap="0">
-                <Text size="3" weight="medium" truncate>
-                  {friendlyName}
-                </Text>
-                <Text
-                  size="2"
-                  color={streamError ? 'red' : isRecording || isStreaming_ ? 'blue' : 'gray'}
-                >
-                  {streamError
-                    ? 'ERROR'
-                    : isRecording
-                      ? 'RECORDING'
-                      : isStreaming_
-                        ? 'STREAMING'
-                        : isIdle
-                          ? 'IDLE'
-                          : entity.state.toUpperCase()}
-                </Text>
-              </Flex>
-
-              {/* Control buttons in fullscreen modal */}
-              {supportsStream && isStreaming && !streamError && (
-                <Flex gap="2">
-                  <IconButton
-                    size="2"
-                    variant="soft"
-                    highContrast
-                    onClick={handleToggleMute}
-                    title={isMuted ? 'Unmute' : 'Mute'}
-                  >
-                    {isMuted ? <SpeakerOffIcon /> : <SpeakerLoudIcon />}
-                  </IconButton>
-                  <IconButton
-                    size="2"
-                    variant="soft"
-                    highContrast
-                    onClick={handleVideoFullscreen}
-                    title="Toggle native fullscreen"
-                  >
-                    <EnterFullScreenIcon />
-                  </IconButton>
-                </Flex>
-              )}
-            </Flex>
-          </Card>
+          <CameraControls
+            friendlyName={friendlyName}
+            entity={entity}
+            streamError={streamError}
+            isRecording={isRecording}
+            isStreaming={isStreaming}
+            isIdle={isIdle}
+            supportsStream={supportsStream}
+            isEditMode={isEditMode}
+            isMuted={isMuted}
+            handleToggleMute={handleToggleMute}
+            handleVideoFullscreen={handleVideoFullscreen}
+            size="large"
+          />
         </div>
 
         {/* Exit indicator */}

--- a/src/components/CameraCard.tsx
+++ b/src/components/CameraCard.tsx
@@ -340,24 +340,18 @@ function CameraCardComponent({
               <Flex gap={isFullscreen ? '2' : '1'}>
                 <IconButton
                   size={isFullscreen ? '2' : '1'}
-                  variant="ghost"
+                  variant="soft"
+                  highContrast
                   onClick={handleToggleMute}
-                  style={{
-                    color: 'white',
-                    backgroundColor: 'rgba(255, 255, 255, 0.1)',
-                  }}
                   title={isMuted ? 'Unmute' : 'Mute'}
                 >
                   {isMuted ? <SpeakerOffIcon /> : <SpeakerLoudIcon />}
                 </IconButton>
                 <IconButton
                   size={isFullscreen ? '2' : '1'}
-                  variant="ghost"
+                  variant="soft"
+                  highContrast
                   onClick={handleVideoFullscreen}
-                  style={{
-                    color: 'white',
-                    backgroundColor: 'rgba(255, 255, 255, 0.1)',
-                  }}
                   title="Toggle native fullscreen"
                 >
                   <EnterFullScreenIcon />
@@ -449,24 +443,18 @@ function CameraCardComponent({
             <Flex gap="2">
               <IconButton
                 size="2"
-                variant="ghost"
+                variant="soft"
+                highContrast
                 onClick={handleToggleMute}
-                style={{
-                  color: 'white',
-                  backgroundColor: 'rgba(255, 255, 255, 0.1)',
-                }}
                 title={isMuted ? 'Unmute' : 'Mute'}
               >
                 {isMuted ? <SpeakerOffIcon /> : <SpeakerLoudIcon />}
               </IconButton>
               <IconButton
                 size="2"
-                variant="ghost"
+                variant="soft"
+                highContrast
                 onClick={handleVideoFullscreen}
-                style={{
-                  color: 'white',
-                  backgroundColor: 'rgba(255, 255, 255, 0.1)',
-                }}
                 title="Toggle native fullscreen"
               >
                 <EnterFullScreenIcon />


### PR DESCRIPTION
## Summary
- Added native video fullscreen button that puts video element into fullscreen mode (different from modal fullscreen)
- Added mute/unmute button to control audio playback
- Controls are positioned in a container alongside the title at the bottom of the card
- Controls scale properly relative to card size in both normal and fullscreen modal views

## Features
- **Fullscreen button**: Uses browser's native video fullscreen API (`video.requestFullscreen()`)
- **Mute/unmute toggle**: Controls video audio with visual feedback (speaker icons)
- **Responsive sizing**: Controls scale based on card size (small/medium/large) and fullscreen state
- **Smart visibility**: Controls only show when video is streaming successfully
- **Non-intrusive design**: Semi-transparent background with proper contrast

## Testing
- [x] All tests pass locally (`npm test`)
- [x] Linting passes (`npm run lint`)
- [x] TypeScript checks pass (`npm run typecheck`)
- [x] Tested controls in normal card view
- [x] Tested controls in fullscreen modal
- [x] Verified proper scaling at different sizes