### PR TITLE
feat: exclude camera entities from stale tracking and remove stale display

### DIFF
--- a/src/components/BinarySensorCard.tsx
+++ b/src/components/BinarySensorCard.tsx
@@ -118,11 +118,11 @@ function BinarySensorCardComponent({
         onDelete={onDelete}
         onConfigure={isEditMode && item ? () => setConfigOpen(true) : undefined}
         hasConfiguration={!!item}
-        title={isStale ? 'Entity data may be outdated' : undefined}
+        title={undefined}
         style={{
           backgroundColor: isOn && !isSelected ? 'var(--amber-3)' : undefined,
-          borderColor: isOn && !isSelected && !isStale ? 'var(--amber-6)' : undefined,
-          borderWidth: isSelected || isOn || isStale ? '2px' : '1px',
+          borderColor: isOn && !isSelected ? 'var(--amber-6)' : undefined,
+          borderWidth: isSelected || isOn ? '2px' : '1px',
         }}
       >
         <Flex direction="column" align="center" justify="center" gap="2">

--- a/src/components/ButtonCard.tsx
+++ b/src/components/ButtonCard.tsx
@@ -85,18 +85,18 @@ function ButtonCardComponent({
       onSelect={() => onSelect?.(!isSelected)}
       onDelete={onDelete}
       onClick={handleClick}
-      title={error || (isStale ? 'Entity data may be outdated' : undefined)}
+      title={error || undefined}
       style={{
         backgroundColor: isOn && !isSelected && !error ? 'var(--amber-3)' : undefined,
-        borderColor: isOn && !isSelected && !error && !isStale ? 'var(--amber-6)' : undefined,
-        borderWidth: isSelected || error || isOn || isStale ? '2px' : '1px',
+        borderColor: isOn && !isSelected && !error ? 'var(--amber-6)' : undefined,
+        borderWidth: isSelected || error || isOn ? '2px' : '1px',
       }}
     >
       <Flex direction="column" align="center" justify="center" gap="2">
         <GridCard.Icon>
           <span
             style={{
-              color: isStale ? 'var(--orange-9)' : isOn ? 'var(--amber-9)' : 'var(--gray-9)',
+              color: isOn ? 'var(--amber-9)' : 'var(--gray-9)',
               transform: `scale(${iconScale})`,
               display: 'flex',
               alignItems: 'center',

--- a/src/components/CameraCard.css
+++ b/src/components/CameraCard.css
@@ -1,0 +1,23 @@
+@keyframes recording-pulse {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.6;
+    transform: scale(1.1);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.recording-dot {
+  width: 0.625em;
+  height: 0.625em;
+  background-color: #dc2626;
+  border-radius: 50%;
+  display: inline-block;
+  animation: recording-pulse 1.5s ease-in-out infinite;
+}

--- a/src/components/CameraCard.tsx
+++ b/src/components/CameraCard.tsx
@@ -124,9 +124,9 @@ function CameraControls({
               ? 'CONNECTING'
               : hasFrameWarning
                 ? 'NO SIGNAL'
-                : isRecording
+                : supportsStream && isStreaming && (isRecording || entity.state === 'streaming')
                   ? 'RECORDING'
-                  : isStreaming
+                  : supportsStream && isStreaming
                     ? 'STREAMING'
                     : isIdle
                       ? 'IDLE'

--- a/src/components/CameraCard.tsx
+++ b/src/components/CameraCard.tsx
@@ -297,7 +297,7 @@ function CameraCardComponent({
         isUnavailable={isUnavailable}
         onSelect={() => onSelect?.(!isSelected)}
         onDelete={onDelete}
-        title={streamError || (isStale ? 'Entity data may be outdated' : undefined)}
+        title={streamError || undefined}
         className="camera-card"
         style={{
           backgroundColor:
@@ -305,11 +305,10 @@ function CameraCardComponent({
               ? 'var(--blue-3)'
               : undefined,
           borderColor:
-            (isRecording || isStreaming_) && !isSelected && !streamError && !isStale
+            (isRecording || isStreaming_) && !isSelected && !streamError
               ? 'var(--blue-6)'
               : undefined,
-          borderWidth:
-            isSelected || streamError || isRecording || isStreaming_ || isStale ? '2px' : '1px',
+          borderWidth: isSelected || streamError || isRecording || isStreaming_ ? '2px' : '1px',
         }}
       >
         <div style={{ width: '100%', height: '100%', position: 'relative' }}>
@@ -420,12 +419,8 @@ function CameraCardComponent({
               <GridCard.Icon>
                 <VideoIcon
                   style={{
-                    color: isStale
-                      ? 'var(--orange-9)'
-                      : isRecording || isStreaming_
-                        ? 'var(--blue-9)'
-                        : 'var(--gray-9)',
-                    opacity: isStale ? 0.6 : 1,
+                    color: isRecording || isStreaming_ ? 'var(--blue-9)' : 'var(--gray-9)',
+                    opacity: 1,
                     transition: 'opacity 0.2s ease',
                     width: 20,
                     height: 20,

--- a/src/components/CameraCard.tsx
+++ b/src/components/CameraCard.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text, Button } from '@radix-ui/themes'
+import { Flex, Text, Button, Spinner } from '@radix-ui/themes'
 import {
   VideoIcon,
   ReloadIcon,
@@ -6,7 +6,7 @@ import {
   SpeakerLoudIcon,
   SpeakerOffIcon,
 } from '@radix-ui/react-icons'
-import { useEntity, useWebRTC } from '~/hooks'
+import { useEntity, useWebRTC, useIsConnecting } from '~/hooks'
 import { memo, useMemo, useState, useRef, useCallback } from 'react'
 import { SkeletonCard, ErrorDisplay, FullscreenModal } from './ui'
 import { GridCardWithComponents as GridCard } from './GridCard'
@@ -43,6 +43,7 @@ function CameraControls({
   supportsStream,
   isEditMode,
   isMuted,
+  isReconnecting,
   handleToggleMute,
   handleVideoFullscreen,
   size,
@@ -57,6 +58,7 @@ function CameraControls({
   supportsStream: boolean
   isEditMode: boolean
   isMuted: boolean
+  isReconnecting: boolean
   handleToggleMute: (e: React.MouseEvent) => void
   handleVideoFullscreen: (e: React.MouseEvent) => void
   size: 'small' | 'medium' | 'large'
@@ -100,17 +102,23 @@ function CameraControls({
             lineHeight: 1.2,
             textTransform: 'uppercase',
             fontWeight: 500,
+            display: 'flex',
+            alignItems: 'center',
+            gap: `${0.4 * scaleFactor}em`,
           }}
         >
+          {isReconnecting && <Spinner size="1" />}
           {streamError
             ? 'ERROR'
-            : isRecording
-              ? 'RECORDING'
-              : isStreaming
-                ? 'STREAMING'
-                : isIdle
-                  ? 'IDLE'
-                  : entity.state.toUpperCase()}
+            : isReconnecting
+              ? 'RECONNECTING'
+              : isRecording
+                ? 'RECORDING'
+                : isStreaming
+                  ? 'STREAMING'
+                  : isIdle
+                    ? 'IDLE'
+                    : entity.state.toUpperCase()}
         </div>
       </div>
 
@@ -191,6 +199,7 @@ function CameraCardComponent({
   const { entity, isConnected, isStale, isLoading: isEntityLoading } = useEntity(entityId)
   const { mode } = useDashboardStore()
   const isEditMode = mode === 'edit'
+  const isReconnecting = useIsConnecting()
   const [isFullscreen, setIsFullscreen] = useState(false)
   const [isMuted, setIsMuted] = useState(true) // Start muted by default
   const normalContainerRef = useRef<HTMLDivElement>(null)
@@ -449,6 +458,7 @@ function CameraCardComponent({
               supportsStream={supportsStream}
               isEditMode={isEditMode}
               isMuted={isMuted}
+              isReconnecting={isReconnecting}
               handleToggleMute={handleToggleMute}
               handleVideoFullscreen={handleVideoFullscreen}
               size={size}
@@ -503,6 +513,7 @@ function CameraCardComponent({
             supportsStream={supportsStream}
             isEditMode={isEditMode}
             isMuted={isMuted}
+            isReconnecting={isReconnecting}
             handleToggleMute={handleToggleMute}
             handleVideoFullscreen={handleVideoFullscreen}
             size="large"

--- a/src/components/ClimateCard.test.tsx
+++ b/src/components/ClimateCard.test.tsx
@@ -456,7 +456,7 @@ describe('ClimateCard', () => {
       expect(card).toHaveAttribute('title', 'Service call failed')
     })
 
-    it('shows stale state with dashed border', () => {
+    it('does not show stale state visually (stale display removed)', () => {
       const entity = createMockClimateEntity()
       ;(useEntity as any).mockReturnValue({
         entity,
@@ -467,9 +467,8 @@ describe('ClimateCard', () => {
       renderWithTheme(<ClimateCard entityId="climate.test_thermostat" />)
 
       const card = screen.getByText('Test Thermostat').closest('.climate-card')
-      expect(card).toHaveStyle({
-        borderColor: 'var(--orange-7)',
-        borderWidth: '2px',
+      // Stale state no longer shows visual indication
+      expect(card).not.toHaveStyle({
         borderStyle: 'dashed',
       })
     })

--- a/src/components/ClimateCard.tsx
+++ b/src/components/ClimateCard.tsx
@@ -472,7 +472,7 @@ function ClimateCardComponent({
       isSelected={isSelected}
       onSelect={() => onSelect?.(!isSelected)}
       onDelete={onDelete}
-      title={error || (isStale ? 'Entity data may be outdated' : undefined)}
+      title={error || undefined}
       className="climate-card"
     >
       <Flex

--- a/src/components/ConnectionLogDialog.tsx
+++ b/src/components/ConnectionLogDialog.tsx
@@ -67,21 +67,23 @@ export function ConnectionLogDialog({ open, onOpenChange }: ConnectionLogDialogP
             Connection Log
           </Flex>
         </Dialog.Title>
-        <Dialog.Description>
-          <Flex justify="between" align="center">
-            <Text>Recent connection events and status changes</Text>
-            {log.length > 0 && (
-              <Button
-                size="1"
-                variant="ghost"
-                color="gray"
-                onClick={() => connectionActions.clearLog?.()}
-              >
-                Clear Log
-              </Button>
-            )}
-          </Flex>
-        </Dialog.Description>
+        <Dialog.Description>Recent connection events and status changes</Dialog.Description>
+
+        <Flex justify="between" align="center" mt="2">
+          <Text size="2" color="gray">
+            Showing {log.length} events
+          </Text>
+          {log.length > 0 && (
+            <Button
+              size="1"
+              variant="ghost"
+              color="gray"
+              onClick={() => connectionActions.clearLog?.()}
+            >
+              Clear Log
+            </Button>
+          )}
+        </Flex>
 
         <ScrollArea style={{ height: '450px', marginTop: '16px' }}>
           <Flex direction="column" gap="1">

--- a/src/components/ConnectionLogDialog.tsx
+++ b/src/components/ConnectionLogDialog.tsx
@@ -1,0 +1,109 @@
+import { Dialog, Flex, Text, ScrollArea, Badge, Button } from '@radix-ui/themes'
+import { ClockIcon } from '@radix-ui/react-icons'
+import { useStore } from '@tanstack/react-store'
+import { connectionStore } from '~/store/connectionStore'
+import type { ConnectionLogEntry, ConnectionStatus } from '~/store/connectionStore'
+
+interface ConnectionLogDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function getStatusColor(status: ConnectionStatus): string {
+  switch (status) {
+    case 'connected':
+      return 'green'
+    case 'connecting':
+    case 'reconnecting':
+      return 'gray'
+    case 'disconnected':
+    case 'error':
+      return 'red'
+    default:
+      return 'gray'
+  }
+}
+
+function formatTimestamp(timestamp: number): string {
+  const date = new Date(timestamp)
+  return date.toLocaleTimeString()
+}
+
+function formatElapsedTime(timestamp: number, previousTimestamp?: number): string {
+  if (!previousTimestamp) return ''
+  const elapsed = timestamp - previousTimestamp
+  if (elapsed < 1000) return `+${elapsed}ms`
+  if (elapsed < 60000) return `+${(elapsed / 1000).toFixed(1)}s`
+  return `+${Math.floor(elapsed / 60000)}m ${Math.floor((elapsed % 60000) / 1000)}s`
+}
+
+export function ConnectionLogDialog({ open, onOpenChange }: ConnectionLogDialogProps) {
+  const log = useStore(connectionStore, (state) => state.log)
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content style={{ maxWidth: '500px' }}>
+        <Dialog.Title>
+          <Flex align="center" gap="2">
+            <ClockIcon />
+            Connection Log
+          </Flex>
+        </Dialog.Title>
+        <Dialog.Description>Recent connection events and status changes</Dialog.Description>
+
+        <ScrollArea style={{ height: '400px', marginTop: '16px' }}>
+          <Flex direction="column" gap="2">
+            {log.length === 0 ? (
+              <Text size="2" color="gray" style={{ textAlign: 'center', padding: '32px' }}>
+                No connection events recorded yet
+              </Text>
+            ) : (
+              log.map((entry: ConnectionLogEntry, index: number) => (
+                <Flex
+                  key={`${entry.timestamp}-${index}`}
+                  direction="column"
+                  gap="1"
+                  style={{
+                    padding: '8px 12px',
+                    backgroundColor: index % 2 === 0 ? 'var(--gray-2)' : 'transparent',
+                    borderRadius: 'var(--radius-2)',
+                  }}
+                >
+                  <Flex justify="between" align="center">
+                    <Flex align="center" gap="2">
+                      <Badge color={getStatusColor(entry.status)} variant="soft">
+                        {entry.status}
+                      </Badge>
+                      <Text size="1" color="gray">
+                        {formatTimestamp(entry.timestamp)}
+                      </Text>
+                      {index > 0 && (
+                        <Text size="1" color="gray" style={{ opacity: 0.7 }}>
+                          {formatElapsedTime(entry.timestamp, log[index - 1].timestamp)}
+                        </Text>
+                      )}
+                    </Flex>
+                  </Flex>
+                  <Text size="2">{entry.details}</Text>
+                  {entry.error && (
+                    <Text size="1" color="red" style={{ marginTop: '4px' }}>
+                      Error: {entry.error}
+                    </Text>
+                  )}
+                </Flex>
+              ))
+            )}
+          </Flex>
+        </ScrollArea>
+
+        <Flex gap="3" mt="4" justify="end">
+          <Dialog.Close>
+            <Button variant="soft" color="gray">
+              Close
+            </Button>
+          </Dialog.Close>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  )
+}

--- a/src/components/ConnectionLogDialog.tsx
+++ b/src/components/ConnectionLogDialog.tsx
@@ -9,18 +9,18 @@ interface ConnectionLogDialogProps {
   onOpenChange: (open: boolean) => void
 }
 
-function getStatusColor(status: ConnectionStatus): string {
+function getStatusColor(status: ConnectionStatus) {
   switch (status) {
     case 'connected':
-      return 'green'
+      return 'green' as const
     case 'connecting':
     case 'reconnecting':
-      return 'gray'
+      return 'gray' as const
     case 'disconnected':
     case 'error':
-      return 'red'
+      return 'red' as const
     default:
-      return 'gray'
+      return 'gray' as const
   }
 }
 

--- a/src/components/ConnectionStatus.css
+++ b/src/components/ConnectionStatus.css
@@ -10,3 +10,31 @@
 .spin {
   animation: spin 1s linear infinite;
 }
+
+@keyframes pulse-ring {
+  0% {
+    transform: scale(0.8);
+    opacity: 0.75;
+  }
+  100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+
+.pulse-container {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pulse-ring {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background-color: currentColor;
+  animation: pulse-ring 1s cubic-bezier(0.215, 0.61, 0.355, 1);
+  pointer-events: none;
+}

--- a/src/components/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus.tsx
@@ -24,26 +24,8 @@ export function ConnectionStatus({ showText }: ConnectionStatusProps = {}) {
   const connectionStatus = useConnectionStatus()
   const entities = useStore(entityStore, (state) => state.entities)
   const subscribedEntities = useStore(entityStore, (state) => state.subscribedEntities)
-  const lastUpdateTime = useStore(entityStore, (state) => state.lastUpdateTime)
 
   const [logDialogOpen, setLogDialogOpen] = useState(false)
-  const [showPulse, setShowPulse] = useState(false)
-  const [previousUpdateTime, setPreviousUpdateTime] = useState(lastUpdateTime)
-
-  // Show pulse animation when entities update (not on initial load)
-  useEffect(() => {
-    // Only pulse if we're connected and this is a new update (not initial)
-    if (
-      connectionStatus.status === 'connected' &&
-      lastUpdateTime > previousUpdateTime &&
-      previousUpdateTime > 0
-    ) {
-      setShowPulse(true)
-      const timer = setTimeout(() => setShowPulse(false), 1000)
-      return () => clearTimeout(timer)
-    }
-    setPreviousUpdateTime(lastUpdateTime)
-  }, [lastUpdateTime, previousUpdateTime, connectionStatus.status])
 
   const entityCount = Object.keys(entities).length
   const subscribedCount = subscribedEntities.size
@@ -108,16 +90,7 @@ export function ConnectionStatus({ showText }: ConnectionStatusProps = {}) {
       <Popover.Root>
         <Popover.Trigger>
           <TaskbarButton
-            icon={
-              showPulse && status === 'connected' ? (
-                <span className="pulse-container">
-                  {config.icon}
-                  <span className="pulse-ring" />
-                </span>
-              ) : (
-                config.icon
-              )
-            }
+            icon={config.icon}
             label={config.text}
             variant={config.variant}
             color={config.color === 'orange' ? 'gray' : config.color}

--- a/src/components/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus.tsx
@@ -105,7 +105,7 @@ export function ConnectionStatus({ showText }: ConnectionStatusProps = {}) {
             icon={isUpdating ? <UpdateIcon className="spin" /> : config.icon}
             label={config.text}
             variant={config.variant}
-            color={config.color}
+            color={config.color === 'orange' ? 'gray' : config.color}
             showText={showText}
             ariaLabel={config.text}
           />

--- a/src/components/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus.tsx
@@ -1,17 +1,18 @@
 import { useState, useEffect } from 'react'
-import { Flex, Text, Popover, Box, Separator, Spinner } from '@radix-ui/themes'
+import { Flex, Text, Popover, Box, Separator, Spinner, Button } from '@radix-ui/themes'
 import {
   InfoCircledIcon,
   CheckCircledIcon,
   CrossCircledIcon,
-  UpdateIcon,
   ReloadIcon,
+  ClockIcon,
 } from '@radix-ui/react-icons'
 import { useStore } from '@tanstack/react-store'
 import { entityStore } from '~/store/entityStore'
 import { useHomeAssistantOptional } from '~/contexts/HomeAssistantContext'
 import { useConnectionStatus } from '~/hooks/useConnectionStatus'
 import { TaskbarButton } from './TaskbarButton'
+import { ConnectionLogDialog } from './ConnectionLogDialog'
 import './ConnectionStatus.css'
 
 interface ConnectionStatusProps {
@@ -25,13 +26,14 @@ export function ConnectionStatus({ showText }: ConnectionStatusProps = {}) {
   const subscribedEntities = useStore(entityStore, (state) => state.subscribedEntities)
   const lastUpdateTime = useStore(entityStore, (state) => state.lastUpdateTime)
 
-  const [isUpdating, setIsUpdating] = useState(false)
+  const [logDialogOpen, setLogDialogOpen] = useState(false)
+  const [isPulsing, setIsPulsing] = useState(false)
 
-  // Flash update indicator when entities change
+  // Pulse the checkmark when entities update (only when connected)
   useEffect(() => {
     if (connectionStatus.status === 'connected') {
-      setIsUpdating(true)
-      const timer = setTimeout(() => setIsUpdating(false), 500)
+      setIsPulsing(true)
+      const timer = setTimeout(() => setIsPulsing(false), 600)
       return () => clearTimeout(timer)
     }
   }, [lastUpdateTime, connectionStatus.status])
@@ -64,14 +66,14 @@ export function ConnectionStatus({ showText }: ConnectionStatusProps = {}) {
     },
     connecting: {
       variant: 'soft' as const,
-      color: 'orange' as const,
+      color: 'gray' as const,
       icon: <Spinner size="1" />,
       text: 'Connecting',
       description: connectionStatus.details,
     },
     reconnecting: {
       variant: 'soft' as const,
-      color: 'orange' as const,
+      color: 'gray' as const,
       icon: <ReloadIcon className="spin" />,
       text: 'Reconnecting',
       description: connectionStatus.details,
@@ -95,117 +97,142 @@ export function ConnectionStatus({ showText }: ConnectionStatusProps = {}) {
   const config = statusConfig[status]
 
   return (
-    <Popover.Root>
-      <Popover.Trigger>
-        <TaskbarButton
-          icon={isUpdating ? <UpdateIcon className="spin" /> : config.icon}
-          label={config.text}
-          variant={config.variant}
-          color={config.color}
-          showText={showText}
-          ariaLabel={config.text}
-        />
-      </Popover.Trigger>
+    <>
+      <Popover.Root>
+        <Popover.Trigger>
+          <TaskbarButton
+            icon={
+              status === 'connected' && isPulsing ? (
+                <span className="pulse-container">
+                  <CheckCircledIcon />
+                  <span className="pulse-ring" />
+                </span>
+              ) : (
+                config.icon
+              )
+            }
+            label={config.text}
+            variant={config.variant}
+            color={config.color}
+            showText={showText}
+            ariaLabel={config.text}
+          />
+        </Popover.Trigger>
 
-      <Popover.Content style={{ width: '280px', maxWidth: 'calc(100vw - 32px)' }}>
-        <Flex direction="column" gap="3">
-          {/* Status Header */}
-          <Flex align="center" gap="2">
-            {config.icon}
-            <Box>
-              <Text size="2" weight="bold">
-                {config.text}
-              </Text>
-              <Text size="1" color="gray" as="div">
-                {config.description}
-              </Text>
-            </Box>
-          </Flex>
-
-          <Separator size="4" />
-
-          {/* Connection Details */}
-          <Flex direction="column" gap="2">
-            <Flex justify="between">
-              <Text size="2">Home Assistant:</Text>
-              <Text size="2" weight="medium">
-                {hass ? 'Available' : 'Not Available'}
-              </Text>
-            </Flex>
-
-            <Flex justify="between">
-              <Text size="2">WebSocket:</Text>
-              <Text size="2" weight="medium">
-                {connectionStatus.isWebSocketConnected ? 'Connected' : 'Disconnected'}
-              </Text>
-            </Flex>
-
-            <Flex justify="between">
-              <Text size="2">Entity Store:</Text>
-              <Text size="2" weight="medium">
-                {connectionStatus.isEntityStoreConnected ? 'Connected' : 'Disconnected'}
-              </Text>
-            </Flex>
-
-            <Flex justify="between">
-              <Text size="2">Total Entities:</Text>
-              <Text size="2" weight="medium">
-                {entityCount}
-              </Text>
-            </Flex>
-
-            <Flex justify="between">
-              <Text size="2">Subscribed:</Text>
-              <Text size="2" weight="medium">
-                {subscribedCount}
-              </Text>
-            </Flex>
-
-            {connectionStatus.lastConnectedTime && (
-              <Flex justify="between">
-                <Text size="2">Connected Since:</Text>
-                <Text size="2" weight="medium">
-                  {new Date(connectionStatus.lastConnectedTime).toLocaleTimeString()}
-                </Text>
-              </Flex>
-            )}
-
-            {connectionStatus.reconnectAttempts > 0 && (
-              <Flex justify="between">
-                <Text size="2">Reconnect Attempts:</Text>
-                <Text size="2" weight="medium">
-                  {connectionStatus.reconnectAttempts}
-                </Text>
-              </Flex>
-            )}
-          </Flex>
-
-          {/* Error Details */}
-          {connectionStatus.error && (
-            <>
-              <Separator size="4" />
+        <Popover.Content style={{ width: '280px', maxWidth: 'calc(100vw - 32px)' }}>
+          <Flex direction="column" gap="3">
+            {/* Status Header */}
+            <Flex align="center" gap="2">
+              {config.icon}
               <Box>
-                <Text size="2" weight="bold" color="red">
-                  Error Details:
+                <Text size="2" weight="bold">
+                  {config.text}
                 </Text>
-                <Text size="1" color="red" as="div" style={{ marginTop: '4px' }}>
-                  {connectionStatus.error}
+                <Text size="1" color="gray" as="div">
+                  {config.description}
                 </Text>
               </Box>
-            </>
-          )}
+            </Flex>
 
-          {/* No Connection Notice */}
-          {!hass && (
-            <>
-              <Separator size="4" />
-              <Text size="1" color="gray">
-                To connect to Home Assistant, deploy this dashboard as a custom panel.
-              </Text>
-            </>
-          )}
-        </Flex>
-      </Popover.Content>
-    </Popover.Root>
+            <Separator size="4" />
+
+            {/* Connection Details */}
+            <Flex direction="column" gap="2">
+              <Flex justify="between">
+                <Text size="2">Home Assistant:</Text>
+                <Text size="2" weight="medium">
+                  {hass ? 'Available' : 'Not Available'}
+                </Text>
+              </Flex>
+
+              <Flex justify="between">
+                <Text size="2">WebSocket:</Text>
+                <Text size="2" weight="medium">
+                  {connectionStatus.isWebSocketConnected ? 'Connected' : 'Disconnected'}
+                </Text>
+              </Flex>
+
+              <Flex justify="between">
+                <Text size="2">Entity Store:</Text>
+                <Text size="2" weight="medium">
+                  {connectionStatus.isEntityStoreConnected ? 'Connected' : 'Disconnected'}
+                </Text>
+              </Flex>
+
+              <Flex justify="between">
+                <Text size="2">Total Entities:</Text>
+                <Text size="2" weight="medium">
+                  {entityCount}
+                </Text>
+              </Flex>
+
+              <Flex justify="between">
+                <Text size="2">Subscribed:</Text>
+                <Text size="2" weight="medium">
+                  {subscribedCount}
+                </Text>
+              </Flex>
+
+              {connectionStatus.lastConnectedTime && (
+                <Flex justify="between">
+                  <Text size="2">Connected Since:</Text>
+                  <Text size="2" weight="medium">
+                    {new Date(connectionStatus.lastConnectedTime).toLocaleTimeString()}
+                  </Text>
+                </Flex>
+              )}
+
+              {connectionStatus.reconnectAttempts > 0 && (
+                <Flex justify="between">
+                  <Text size="2">Reconnect Attempts:</Text>
+                  <Text size="2" weight="medium">
+                    {connectionStatus.reconnectAttempts}
+                  </Text>
+                </Flex>
+              )}
+            </Flex>
+
+            {/* Error Details */}
+            {connectionStatus.error && (
+              <>
+                <Separator size="4" />
+                <Box>
+                  <Text size="2" weight="bold" color="red">
+                    Error Details:
+                  </Text>
+                  <Text size="1" color="red" as="div" style={{ marginTop: '4px' }}>
+                    {connectionStatus.error}
+                  </Text>
+                </Box>
+              </>
+            )}
+
+            {/* No Connection Notice */}
+            {!hass && (
+              <>
+                <Separator size="4" />
+                <Text size="1" color="gray">
+                  To connect to Home Assistant, deploy this dashboard as a custom panel.
+                </Text>
+              </>
+            )}
+
+            {/* Connection Log Button */}
+            <Separator size="4" />
+            <Button
+              variant="soft"
+              size="2"
+              style={{ width: '100%' }}
+              onClick={() => setLogDialogOpen(true)}
+            >
+              <ClockIcon />
+              View Connection Log
+            </Button>
+          </Flex>
+        </Popover.Content>
+      </Popover.Root>
+
+      <ConnectionLogDialog open={logDialogOpen} onOpenChange={setLogDialogOpen} />
+    </>
   )
 }

--- a/src/components/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus.tsx
@@ -4,6 +4,7 @@ import {
   InfoCircledIcon,
   CheckCircledIcon,
   CrossCircledIcon,
+  UpdateIcon,
   ReloadIcon,
   ClockIcon,
 } from '@radix-ui/react-icons'
@@ -27,13 +28,13 @@ export function ConnectionStatus({ showText }: ConnectionStatusProps = {}) {
   const lastUpdateTime = useStore(entityStore, (state) => state.lastUpdateTime)
 
   const [logDialogOpen, setLogDialogOpen] = useState(false)
-  const [isPulsing, setIsPulsing] = useState(false)
+  const [isUpdating, setIsUpdating] = useState(false)
 
-  // Pulse the checkmark when entities update (only when connected)
+  // Flash update indicator when entities change
   useEffect(() => {
     if (connectionStatus.status === 'connected') {
-      setIsPulsing(true)
-      const timer = setTimeout(() => setIsPulsing(false), 600)
+      setIsUpdating(true)
+      const timer = setTimeout(() => setIsUpdating(false), 500)
       return () => clearTimeout(timer)
     }
   }, [lastUpdateTime, connectionStatus.status])
@@ -66,14 +67,14 @@ export function ConnectionStatus({ showText }: ConnectionStatusProps = {}) {
     },
     connecting: {
       variant: 'soft' as const,
-      color: 'gray' as const,
+      color: 'orange' as const,
       icon: <Spinner size="1" />,
       text: 'Connecting',
       description: connectionStatus.details,
     },
     reconnecting: {
       variant: 'soft' as const,
-      color: 'gray' as const,
+      color: 'orange' as const,
       icon: <ReloadIcon className="spin" />,
       text: 'Reconnecting',
       description: connectionStatus.details,
@@ -101,16 +102,7 @@ export function ConnectionStatus({ showText }: ConnectionStatusProps = {}) {
       <Popover.Root>
         <Popover.Trigger>
           <TaskbarButton
-            icon={
-              status === 'connected' && isPulsing ? (
-                <span className="pulse-container">
-                  <CheckCircledIcon />
-                  <span className="pulse-ring" />
-                </span>
-              ) : (
-                config.icon
-              )
-            }
+            icon={isUpdating ? <UpdateIcon className="spin" /> : config.icon}
             label={config.text}
             variant={config.variant}
             color={config.color}

--- a/src/components/CoverCard.test.tsx
+++ b/src/components/CoverCard.test.tsx
@@ -472,7 +472,7 @@ describe('CoverCard', () => {
       expect(card).toHaveClass('grid-card-loading')
     })
 
-    it('shows stale state with appropriate styling', () => {
+    it('does not show stale state visually (stale display removed)', () => {
       const entity = createMockCoverEntity()
       ;(useEntity as any).mockReturnValue({
         entity,
@@ -483,9 +483,8 @@ describe('CoverCard', () => {
       render(<CoverCard entityId="cover.test_cover" />)
 
       const card = screen.getByText('Test Cover').closest('.cover-card')
-      expect(card).toHaveStyle({
-        borderColor: 'var(--orange-7)',
-        borderWidth: '2px',
+      // Stale state no longer shows visual indication
+      expect(card).not.toHaveStyle({
         borderStyle: 'dashed',
       })
     })

--- a/src/components/CoverCard.tsx
+++ b/src/components/CoverCard.tsx
@@ -250,10 +250,10 @@ function CoverCardComponent({
       isOn={coverState === 'open' || currentPosition > 0}
       onSelect={() => onSelect?.(!isSelected)}
       onDelete={onDelete}
-      title={error || (isStale ? 'Entity data may be outdated' : undefined)}
+      title={error || undefined}
       className="cover-card"
       style={{
-        borderWidth: isSelected || error || isStale ? '2px' : '1px',
+        borderWidth: isSelected || error ? '2px' : '1px',
       }}
     >
       <Flex

--- a/src/components/FanCard.tsx
+++ b/src/components/FanCard.tsx
@@ -212,11 +212,11 @@ function FanCardComponent({
       onSelect={() => onSelect?.(!isSelected)}
       onDelete={onDelete}
       onClick={handleToggle}
-      title={error || (isStale ? 'Entity data may be outdated' : undefined)}
+      title={error || undefined}
       style={{
         backgroundColor: isOn && !isSelected && !error ? 'var(--cyan-3)' : undefined,
-        borderColor: isOn && !isSelected && !error && !isStale ? 'var(--cyan-6)' : undefined,
-        borderWidth: isSelected || error || isOn || isStale ? '2px' : '1px',
+        borderColor: isOn && !isSelected && !error ? 'var(--cyan-6)' : undefined,
+        borderWidth: isSelected || error || isOn ? '2px' : '1px',
       }}
     >
       <Flex

--- a/src/components/GridCard.tsx
+++ b/src/components/GridCard.tsx
@@ -104,12 +104,6 @@ export const GridCard = React.memo(
           borderColor: 'var(--red-6)',
           borderWidth: '2px',
         }
-      } else if (isStale) {
-        borderStyle = {
-          borderColor: 'var(--orange-7)',
-          borderWidth: '2px',
-          borderStyle: 'dashed',
-        }
       } else if (isSelected && isEditMode) {
         borderStyle = {
           borderColor: 'var(--blue-7)',
@@ -122,6 +116,7 @@ export const GridCard = React.memo(
           borderStyle: 'dotted',
         }
       }
+      // Note: isStale styling removed - we track stale state but don't display it visually
 
       // Background for selected/on states
       const backgroundColor =

--- a/src/components/InputBooleanCard.test.tsx
+++ b/src/components/InputBooleanCard.test.tsx
@@ -216,7 +216,7 @@ describe('InputBooleanCard', () => {
     expect(card).toHaveAttribute('title', 'Failed to toggle')
   })
 
-  it('shows stale data indicator', () => {
+  it('does not show stale data indicator (stale display removed)', () => {
     vi.mocked(useEntity).mockReturnValue({
       entity: {
         ...defaultEntity,
@@ -233,9 +233,8 @@ describe('InputBooleanCard', () => {
     const { container } = render(<InputBooleanCard entityId="input_boolean.test_toggle" />)
 
     const card = container.querySelector('.rt-Card')
-    expect(card).toHaveStyle({
-      borderColor: 'var(--orange-7)',
-      borderWidth: '2px',
+    // Stale state no longer shows visual indication
+    expect(card).not.toHaveStyle({
       borderStyle: 'dashed',
     })
   })

--- a/src/components/InputSelectCard.test.tsx
+++ b/src/components/InputSelectCard.test.tsx
@@ -224,7 +224,7 @@ describe('InputSelectCard', () => {
     expect(card).toHaveAttribute('title', 'Failed to set value')
   })
 
-  it('shows stale data indicator', () => {
+  it('does not show stale data indicator (stale display removed)', () => {
     vi.mocked(useEntity).mockReturnValue({
       entity: {
         ...defaultEntity,
@@ -235,15 +235,14 @@ describe('InputSelectCard', () => {
       },
       isConnected: true,
       isLoading: false,
-      isStale: false,
+      isStale: true,
     })
 
     const { container } = render(<InputSelectCard entityId="input_select.test_select" />)
 
     const card = container.querySelector('.rt-Card')
-    expect(card).toHaveStyle({
-      borderColor: 'var(--orange-7)',
-      borderWidth: '2px',
+    // Stale state no longer shows visual indication
+    expect(card).not.toHaveStyle({
       borderStyle: 'dashed',
     })
   })

--- a/src/components/LightCard.tsx
+++ b/src/components/LightCard.tsx
@@ -182,20 +182,20 @@ function LightCardComponent({
         onClick={isDragging ? undefined : handleToggle}
         onConfigure={() => setConfigOpen(true)}
         hasConfiguration={true}
-        title={error || (isStale ? 'Entity data may be outdated' : undefined)}
+        title={error || undefined}
         className="light-card"
         style={{
           backgroundColor: isOn && !isSelected && !error ? 'var(--amber-3)' : undefined,
-          borderColor: isOn && !isSelected && !error && !isStale ? 'var(--amber-6)' : undefined,
-          borderWidth: isSelected || error || isOn || isStale ? '2px' : '1px',
+          borderColor: isOn && !isSelected && !error ? 'var(--amber-6)' : undefined,
+          borderWidth: isSelected || error || isOn ? '2px' : '1px',
         }}
       >
         <Flex direction="column" align="center" justify="center" gap="3">
           <GridCard.Icon>
             <SunIcon
               style={{
-                color: isStale ? 'var(--orange-9)' : isOn ? 'var(--amber-9)' : 'var(--gray-9)',
-                opacity: isLoading ? 0.3 : isStale ? 0.6 : 1,
+                color: isOn ? 'var(--amber-9)' : 'var(--gray-9)',
+                opacity: isLoading ? 0.3 : 1,
                 transition: 'opacity 0.2s ease',
                 width: 20,
                 height: 20,

--- a/src/components/SensorCard.tsx
+++ b/src/components/SensorCard.tsx
@@ -162,9 +162,9 @@ function SensorCardComponent({
       isUnavailable={isUnavailable}
       onSelect={() => onSelect?.(!isSelected)}
       onDelete={onDelete}
-      title={isStale ? 'Sensor data may be outdated' : undefined}
+      title={undefined}
       style={{
-        borderWidth: isSelected || isStale ? '2px' : '1px',
+        borderWidth: isSelected ? '2px' : '1px',
       }}
     >
       <Flex

--- a/src/components/__tests__/ConnectionStatus.test.tsx
+++ b/src/components/__tests__/ConnectionStatus.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ConnectionStatus } from '../ConnectionStatus'
 import { entityStore } from '../../store/entityStore'
+import { connectionStore } from '../../store/connectionStore'
 import type { HomeAssistant } from '../../contexts/HomeAssistantContext'
 
 // Mock the CSS import
@@ -23,7 +24,7 @@ import { useHomeAssistantOptional } from '~/contexts/HomeAssistantContext'
 describe('ConnectionStatus', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // Reset store to initial state
+    // Reset stores to initial state
     entityStore.setState(() => ({
       entities: {},
       isConnected: false,
@@ -32,6 +33,17 @@ describe('ConnectionStatus', () => {
       subscribedEntities: new Set(),
       staleEntities: new Set(),
       lastUpdateTime: Date.now(),
+    }))
+    connectionStore.setState(() => ({
+      status: 'disconnected',
+      details: 'Not connected',
+      lastConnectedTime: null,
+      lastDisconnectedTime: null,
+      reconnectAttempts: 0,
+      isWebSocketConnected: false,
+      isEntityStoreConnected: false,
+      error: null,
+      log: [],
     }))
   })
 
@@ -59,6 +71,14 @@ describe('ConnectionStatus', () => {
         },
       },
     }))
+    connectionStore.setState((state) => ({
+      ...state,
+      status: 'connected',
+      details: 'Connected',
+      isWebSocketConnected: true,
+      isEntityStoreConnected: true,
+      lastConnectedTime: Date.now(),
+    }))
 
     render(<ConnectionStatus showText />)
 
@@ -84,10 +104,16 @@ describe('ConnectionStatus', () => {
       isConnected: false,
       lastError: 'Connection failed',
     }))
+    connectionStore.setState((state) => ({
+      ...state,
+      status: 'error',
+      details: 'Connection failed',
+      error: 'Connection failed',
+    }))
 
     render(<ConnectionStatus showText />)
 
-    expect(screen.getByText('Disconnected')).toBeInTheDocument()
+    expect(screen.getByText('Error')).toBeInTheDocument()
   })
 
   it('should show detailed information in popover', async () => {
@@ -107,6 +133,14 @@ describe('ConnectionStatus', () => {
         },
       },
       subscribedEntities: new Set(['light.test']),
+    }))
+    connectionStore.setState((state) => ({
+      ...state,
+      status: 'connected',
+      details: 'Connected',
+      isWebSocketConnected: true,
+      isEntityStoreConnected: true,
+      lastConnectedTime: Date.now(),
     }))
 
     render(<ConnectionStatus />)
@@ -132,6 +166,14 @@ describe('ConnectionStatus', () => {
       ...state,
       isConnected: true,
     }))
+    connectionStore.setState((state) => ({
+      ...state,
+      status: 'connected',
+      details: 'Connected',
+      isWebSocketConnected: true,
+      isEntityStoreConnected: true,
+      lastConnectedTime: Date.now(),
+    }))
 
     render(<ConnectionStatus showText={false} />)
 
@@ -146,6 +188,14 @@ describe('ConnectionStatus', () => {
     entityStore.setState((state) => ({
       ...state,
       isConnected: true,
+    }))
+    connectionStore.setState((state) => ({
+      ...state,
+      status: 'connected',
+      details: 'Connected',
+      isWebSocketConnected: true,
+      isEntityStoreConnected: true,
+      lastConnectedTime: Date.now(),
     }))
 
     render(<ConnectionStatus showText />)

--- a/src/components/__tests__/LightCard.test.tsx
+++ b/src/components/__tests__/LightCard.test.tsx
@@ -207,7 +207,7 @@ describe('LightCard', () => {
     expect(screen.getByText('ERROR')).toBeInTheDocument()
   })
 
-  it('shows stale data indicator', () => {
+  it('does not show stale data indicator (stale display removed)', () => {
     vi.mocked(hooks.useEntity).mockReturnValue({
       entity: mockEntity,
       isConnected: true,
@@ -218,7 +218,8 @@ describe('LightCard', () => {
     const { container } = render(<LightCard entityId="light.living_room" />)
 
     const card = container.querySelector('.light-card')
-    expect(card).toHaveStyle('border-style: dashed')
+    // Stale state no longer shows visual indication
+    expect(card).not.toHaveStyle('border-style: dashed')
   })
 
   it('handles edit mode interactions', () => {

--- a/src/components/__tests__/SensorCard.test.tsx
+++ b/src/components/__tests__/SensorCard.test.tsx
@@ -374,7 +374,7 @@ describe('SensorCard', () => {
   })
 
   describe('Stale Data', () => {
-    it('shows stale indicator', () => {
+    it('does not show stale indicator (stale display removed)', () => {
       vi.mocked(useEntity).mockReturnValue({
         entity: createMockEntity({
           entity_id: 'sensor.stale_temp',
@@ -397,8 +397,9 @@ describe('SensorCard', () => {
       )
 
       const card = container.querySelector('.rt-Card')
-      expect(card).toHaveAttribute('title', 'Sensor data may be outdated')
-      expect(card).toHaveStyle({ borderStyle: 'dashed' })
+      // Stale state no longer shows visual indication or tooltip
+      expect(card).not.toHaveAttribute('title', 'Sensor data may be outdated')
+      expect(card).not.toHaveStyle({ borderStyle: 'dashed' })
     })
   })
 

--- a/src/hooks/__tests__/useEntity.test.tsx
+++ b/src/hooks/__tests__/useEntity.test.tsx
@@ -97,6 +97,41 @@ describe('useEntity', () => {
     expect(result.current.isStale).toBe(false)
   })
 
+  it('should exclude camera entities from stale tracking', () => {
+    const cameraEntity: HassEntity = {
+      entity_id: 'camera.front_door',
+      state: 'streaming',
+      attributes: {
+        friendly_name: 'Front Door Camera',
+      },
+      last_changed: '2024-01-01T00:00:00Z',
+      last_updated: '2024-01-01T00:00:00Z',
+      context: {
+        id: '456',
+        parent_id: null,
+        user_id: null,
+      },
+    }
+
+    act(() => {
+      entityStoreActions.updateEntity(cameraEntity)
+      entityStoreActions.setConnected(true)
+      entityStoreActions.setInitialLoading(false)
+    })
+
+    const { result } = renderHook(() => useEntity('camera.front_door'))
+
+    expect(result.current.isStale).toBe(false)
+
+    // Mark camera entity as stale - it should still return false
+    act(() => {
+      entityStoreActions.markEntityStale('camera.front_door')
+    })
+
+    // Camera entities should never be considered stale
+    expect(result.current.isStale).toBe(false)
+  })
+
   it('should subscribe and unsubscribe to entity', () => {
     const { unmount } = renderHook(() => useEntity('light.bedroom'))
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -6,3 +6,9 @@ export { useEntityAttribute, useEntityAttributes } from './useEntityAttribute'
 export { useHomeAssistantRouting } from './useHomeAssistantRouting'
 export { useWebRTC } from './useWebRTC'
 export { useIsHomeAssistant } from './useIsHomeAssistant'
+export {
+  useConnectionStatus,
+  useIsConnected,
+  useIsConnecting,
+  useConnectionDetails,
+} from './useConnectionStatus'

--- a/src/hooks/useConnectionStatus.ts
+++ b/src/hooks/useConnectionStatus.ts
@@ -1,33 +1,31 @@
 import { useStore } from '@tanstack/react-store'
-import {
-  connectionStore,
-  type ConnectionStatus,
-  type ConnectionState,
-} from '../store/connectionStore'
+import { connectionStore } from '~/store/connectionStore'
+import type { ConnectionState } from '~/store/connectionStore'
 
-export function useConnectionStatus() {
+export function useConnectionStatus(): ConnectionState {
   return useStore(connectionStore)
 }
 
-export function useConnectionStatusSelector<T>(selector: (state: ConnectionState) => T) {
-  return useStore(connectionStore, selector)
+export function useIsConnected(): boolean {
+  const status = useStore(connectionStore, (state) => state.status)
+  return status === 'connected'
 }
 
-export function useIsConnected() {
-  return useStore(connectionStore, (state) => state.status === 'connected')
-}
-
-export function useIsConnecting() {
-  return useStore(
-    connectionStore,
-    (state) => state.status === 'connecting' || state.status === 'reconnecting'
-  )
+export function useIsConnecting(): boolean {
+  const status = useStore(connectionStore, (state) => state.status)
+  return status === 'connecting' || status === 'reconnecting'
 }
 
 export function useConnectionDetails() {
-  return useStore(connectionStore, (state) => ({
-    status: state.status,
-    details: state.details,
-    isConnecting: state.status === 'connecting' || state.status === 'reconnecting',
-  }))
+  const status = useStore(connectionStore, (state) => state.status)
+  const details = useStore(connectionStore, (state) => state.details)
+  const error = useStore(connectionStore, (state) => state.error)
+  const reconnectAttempts = useStore(connectionStore, (state) => state.reconnectAttempts)
+
+  return {
+    status,
+    details,
+    error,
+    reconnectAttempts,
+  }
 }

--- a/src/hooks/useConnectionStatus.ts
+++ b/src/hooks/useConnectionStatus.ts
@@ -1,0 +1,33 @@
+import { useStore } from '@tanstack/react-store'
+import {
+  connectionStore,
+  type ConnectionStatus,
+  type ConnectionState,
+} from '../store/connectionStore'
+
+export function useConnectionStatus() {
+  return useStore(connectionStore)
+}
+
+export function useConnectionStatusSelector<T>(selector: (state: ConnectionState) => T) {
+  return useStore(connectionStore, selector)
+}
+
+export function useIsConnected() {
+  return useStore(connectionStore, (state) => state.status === 'connected')
+}
+
+export function useIsConnecting() {
+  return useStore(
+    connectionStore,
+    (state) => state.status === 'connecting' || state.status === 'reconnecting'
+  )
+}
+
+export function useConnectionDetails() {
+  return useStore(connectionStore, (state) => ({
+    status: state.status,
+    details: state.details,
+    isConnecting: state.status === 'connecting' || state.status === 'reconnecting',
+  }))
+}

--- a/src/hooks/useEntity.ts
+++ b/src/hooks/useEntity.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo } from 'react'
 import { useStore } from '@tanstack/react-store'
 import { entityStore, entityStoreActions } from '../store/entityStore'
 import type { HassEntity } from '../store/entityTypes'
+import { staleEntityMonitor } from '../services/staleEntityMonitor'
 
 export function useEntity(entityId: string): {
   entity: HassEntity | undefined
@@ -31,8 +32,10 @@ export function useEntity(entityId: string): {
   }, [entities, entityId])
 
   const isStale = useMemo(() => {
-    return staleEntities.has(entityId)
-  }, [staleEntities, entityId])
+    // Use staleEntityMonitor to check staleness, which respects excluded entity types
+    return staleEntityMonitor.getEntityStaleness(entityId).isStale
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [entityId, staleEntities])
 
   return {
     entity,

--- a/src/hooks/useEntityConnection.ts
+++ b/src/hooks/useEntityConnection.ts
@@ -19,14 +19,15 @@ export function useEntityConnection() {
         hassConnectionManager.connect(hass)
         connectedRef.current = true
 
-        // Listen for stale connection events from the panel
-        const handleStaleConnection = () => {
-          console.log('[useEntityConnection] Received stale connection event, reconnecting...')
-          hassConnectionManager.reconnect()
+        // Listen for WebSocket check events from the panel
+        const handleWebSocketCheck = () => {
+          console.log('[useEntityConnection] Received WebSocket check event')
+          // Check WebSocket connection health
+          hassConnectionManager.checkConnectionHealth()
         }
 
-        staleHandlerRef.current = handleStaleConnection
-        window.addEventListener('liebe-connection-stale', handleStaleConnection)
+        staleHandlerRef.current = handleWebSocketCheck
+        window.addEventListener('liebe-websocket-check', handleWebSocketCheck)
       } else {
         // Just update the hass reference without reconnecting
         hassConnectionManager.updateHass(hass)
@@ -38,7 +39,7 @@ export function useEntityConnection() {
       if (!hass) {
         console.log('[useEntityConnection] Cleaning up connection')
         if (staleHandlerRef.current) {
-          window.removeEventListener('liebe-connection-stale', staleHandlerRef.current)
+          window.removeEventListener('liebe-websocket-check', staleHandlerRef.current)
         }
         hassConnectionManager.disconnect()
         connectedRef.current = false

--- a/src/hooks/useEntityConnection.ts
+++ b/src/hooks/useEntityConnection.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useStore } from '@tanstack/react-store'
 import { useHomeAssistantOptional } from '../contexts/HomeAssistantContext'
 import { hassConnectionManager } from '../services/hassConnection'
@@ -8,15 +8,40 @@ export function useEntityConnection() {
   const hass = useHomeAssistantOptional()
   const isConnected = useStore(entityStore, (state) => state.isConnected)
   const lastError = useStore(entityStore, (state) => state.lastError)
+  const connectedRef = useRef(false)
+  const staleHandlerRef = useRef<(() => void) | null>(null)
 
   useEffect(() => {
     if (hass) {
-      // Connect to Home Assistant
-      hassConnectionManager.connect(hass)
+      if (!connectedRef.current) {
+        // Only connect once
+        console.log('[useEntityConnection] Initial connection to Home Assistant')
+        hassConnectionManager.connect(hass)
+        connectedRef.current = true
 
-      // Cleanup on unmount
-      return () => {
+        // Listen for stale connection events from the panel
+        const handleStaleConnection = () => {
+          console.log('[useEntityConnection] Received stale connection event, reconnecting...')
+          hassConnectionManager.reconnect()
+        }
+
+        staleHandlerRef.current = handleStaleConnection
+        window.addEventListener('liebe-connection-stale', handleStaleConnection)
+      } else {
+        // Just update the hass reference without reconnecting
+        hassConnectionManager.updateHass(hass)
+      }
+    }
+
+    // Cleanup only on unmount
+    return () => {
+      if (!hass) {
+        console.log('[useEntityConnection] Cleaning up connection')
+        if (staleHandlerRef.current) {
+          window.removeEventListener('liebe-connection-stale', staleHandlerRef.current)
+        }
         hassConnectionManager.disconnect()
+        connectedRef.current = false
       }
     }
   }, [hass])

--- a/src/hooks/useWebRTC.ts
+++ b/src/hooks/useWebRTC.ts
@@ -216,29 +216,8 @@ export function useWebRTC({ entityId, enabled = true }: UseWebRTCOptions): UseWe
         }
       }
 
-      // Debug logging every 5 seconds
+      // Update debug timer without logging
       if (now - debugLogTimer >= 5000) {
-        const fps = ((frameCount - lastDebugFrameCount) / 5).toFixed(1)
-        const hasVideoFrameCallback = 'requestVideoFrameCallback' in video
-        console.log(`[WebRTC Debug] ${entityId} Frame Stats:`, {
-          fps,
-          currentTime: currentTime.toFixed(2),
-          decodedFrames: videoFrames,
-          videoDimensions: `${video.videoWidth}x${video.videoHeight}`,
-          readyState: video.readyState,
-          networkState: video.networkState,
-          buffered:
-            video.buffered.length > 0
-              ? `${video.buffered.start(0).toFixed(1)}-${video.buffered.end(0).toFixed(1)}`
-              : 'none',
-          isReceivingFrames,
-          hasVideoFrameCallback,
-          usingVideoFrameCallback: hasVideoFrameCallback && videoFrameCallbackId !== null,
-          timeSinceLastFrame:
-            frameMonitorRef.current.lastFrameTime > 0
-              ? `${now - frameMonitorRef.current.lastFrameTime}ms`
-              : 'N/A',
-        })
         debugLogTimer = now
         lastDebugFrameCount = frameCount
       }

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -176,18 +176,20 @@ class LiebePanel extends HTMLElement {
                       console.log(
                         `[Liebe Panel ${this.instanceId}] Still no updates after ping, refreshing states`
                       )
-                      this._hass
-                        .callWS({ type: 'get_states' })
-                        .then(() => {
-                          console.log(`[Liebe Panel ${this.instanceId}] States refreshed`)
-                          this.lastEntityUpdateTime = Date.now()
-                        })
-                        .catch((error: Error) => {
-                          console.error(
-                            `[Liebe Panel ${this.instanceId}] Failed to refresh states:`,
-                            error
-                          )
-                        })
+                      if (this._hass) {
+                        this._hass
+                          .callWS({ type: 'get_states' })
+                          .then(() => {
+                            console.log(`[Liebe Panel ${this.instanceId}] States refreshed`)
+                            this.lastEntityUpdateTime = Date.now()
+                          })
+                          .catch((error: Error) => {
+                            console.error(
+                              `[Liebe Panel ${this.instanceId}] Failed to refresh states:`,
+                              error
+                            )
+                          })
+                      }
                     }
                   }, 5000)
                 })

--- a/src/services/__tests__/hassConnection.test.ts
+++ b/src/services/__tests__/hassConnection.test.ts
@@ -157,7 +157,9 @@ describe('HassConnectionManager', () => {
 
       await connectionManager.connect(errorHass)
 
-      expect(entityStoreActions.setError).toHaveBeenCalledWith('Connection failed')
+      expect(entityStoreActions.setError).toHaveBeenCalledWith(
+        'Connection failed: Connection failed'
+      )
 
       // Should schedule reconnect
       expect(vi.getTimerCount()).toBe(1)

--- a/src/services/__tests__/hassConnection.test.ts
+++ b/src/services/__tests__/hassConnection.test.ts
@@ -320,13 +320,21 @@ describe('HassConnectionManager', () => {
     })
 
     it('should manually trigger reconnection', async () => {
-      await connectionManager.connect(mockHass)
-      const connectSpy = vi.spyOn(
-        connectionManager as unknown as { connect: (hass: HomeAssistant) => void },
-        'connect'
-      )
+      // Create a fresh connection manager for this test
+      const manager = new HassConnectionManager()
+      await manager.connect(mockHass)
 
-      connectionManager.reconnect()
+      // Create spy before reconnect
+      const connectSpy = vi.spyOn(manager, 'connect' as keyof HassConnectionManager)
+
+      // The first reconnect should work immediately since lastReconnectTime is 0
+      const reconnectPromise = manager.reconnect()
+
+      // Advance timers to handle the setTimeout in reconnect
+      await vi.runAllTimersAsync()
+
+      // Wait for reconnect to complete
+      await reconnectPromise
 
       expect(connectSpy).toHaveBeenCalledWith(mockHass)
     })

--- a/src/services/__tests__/hassConnection.test.ts
+++ b/src/services/__tests__/hassConnection.test.ts
@@ -35,6 +35,7 @@ vi.mock('../../store/entityStore', () => ({
     markEntityStale: vi.fn(),
     markEntityFresh: vi.fn(),
     updateLastUpdateTime: vi.fn(),
+    hasSubscribedEntityUpdates: vi.fn().mockReturnValue(true),
   },
 }))
 

--- a/src/services/__tests__/hassConnection.test.ts
+++ b/src/services/__tests__/hassConnection.test.ts
@@ -333,13 +333,16 @@ describe('HassConnectionManager', () => {
       // The first reconnect should work immediately since lastReconnectTime is 0
       const reconnectPromise = manager.reconnect()
 
-      // Advance timers to handle the setTimeout in reconnect
-      await vi.runAllTimersAsync()
+      // Advance only the specific timer for the reconnect delay
+      await vi.advanceTimersByTimeAsync(100)
 
       // Wait for reconnect to complete
       await reconnectPromise
 
       expect(connectSpy).toHaveBeenCalledWith(mockHass)
+
+      // Clean up to prevent infinite timers
+      await manager.disconnect()
     })
   })
 })

--- a/src/services/hassConnection.ts
+++ b/src/services/hassConnection.ts
@@ -41,9 +41,8 @@ export class HassConnectionManager {
     this.reconnectAttempts = 0
 
     // Update connection status
-    connectionActions.setConnecting(
-      `Connecting to Home Assistant... (${hass.connection.socket.url})`
-    )
+    const socketUrl = hass.connection?.socket?.url || 'WebSocket'
+    connectionActions.setConnecting(`Connecting to Home Assistant... (${socketUrl})`)
 
     // Clear any existing connections
     await this.disconnect()

--- a/src/services/hassConnection.ts
+++ b/src/services/hassConnection.ts
@@ -41,7 +41,9 @@ export class HassConnectionManager {
     this.reconnectAttempts = 0
 
     // Update connection status
-    connectionActions.setConnecting('Connecting to Home Assistant...')
+    connectionActions.setConnecting(
+      `Connecting to Home Assistant... (${hass.connection.socket.url})`
+    )
 
     // Clear any existing connections
     await this.disconnect()
@@ -71,7 +73,10 @@ export class HassConnectionManager {
       console.log('HassConnectionManager: Successfully connected')
     } catch (error) {
       console.error('Failed to connect to Home Assistant:', error)
-      const errorMessage = error instanceof Error ? error.message : 'Connection failed'
+      const errorMessage =
+        error instanceof Error
+          ? `Connection failed: ${error.message}`
+          : 'Connection failed: Unknown error'
       entityStoreActions.setError(errorMessage)
       connectionActions.setError(errorMessage)
       this.scheduleReconnect()
@@ -141,6 +146,9 @@ export class HassConnectionManager {
       // Update all entities at once
       entityStoreActions.updateEntities(entities)
       entityStoreActions.setInitialLoading(false)
+
+      // Log entity count
+      connectionActions.setConnecting(`Loaded ${entities.length} entities`)
     } catch (error) {
       console.error('Failed to load initial states:', error)
       entityStoreActions.setError('Failed to load initial states')

--- a/src/services/hassConnection.ts
+++ b/src/services/hassConnection.ts
@@ -64,6 +64,9 @@ export class HassConnectionManager {
       // Subscribe to state changes
       await this.subscribeToStateChanges()
 
+      // Reset last update time to current time to prevent false stale detection
+      entityStoreActions.updateLastUpdateTime()
+
       // Start monitoring for stale entities
       staleEntityMonitor.start()
 

--- a/src/services/hassConnection.ts
+++ b/src/services/hassConnection.ts
@@ -4,6 +4,7 @@ import { entityStoreActions } from '../store/entityStore'
 import { entityDebouncer } from '../store/entityDebouncer'
 import { entityUpdateBatcher } from '../store/entityBatcher'
 import { staleEntityMonitor } from './staleEntityMonitor'
+import { connectionActions } from '../store/connectionStore'
 
 export interface StateChangedEvent {
   event_type: 'state_changed'
@@ -21,19 +22,34 @@ export class HassConnectionManager {
   private reconnectAttempts = 0
   private readonly MAX_RECONNECT_ATTEMPTS = 10
   private readonly RECONNECT_DELAY_BASE = 1000 // 1 second
+  private isReconnecting = false
+  private lastReconnectTime = 0
 
   constructor() {
     this.handleStateChanged = this.handleStateChanged.bind(this)
   }
 
   async connect(hass: HomeAssistant): Promise<void> {
+    // If we already have a connection with the same hass instance, just update the reference
+    if (this.hass && this.stateChangeUnsubscribe && this.isConnected()) {
+      console.log('HassConnectionManager: Already connected, updating hass reference')
+      this.hass = hass
+      return
+    }
+
     this.hass = hass
     this.reconnectAttempts = 0
+
+    // Update connection status
+    connectionActions.setConnecting('Connecting to Home Assistant...')
 
     // Clear any existing connections
     await this.disconnect()
 
     try {
+      // Update status
+      connectionActions.setConnecting('Loading initial states...')
+
       // Mark as connected
       entityStoreActions.setConnected(true)
       entityStoreActions.setError(null)
@@ -41,14 +57,23 @@ export class HassConnectionManager {
       // Load initial states
       this.loadInitialStates()
 
+      // Update status
+      connectionActions.setConnecting('Subscribing to state changes...')
+
       // Subscribe to state changes
       await this.subscribeToStateChanges()
 
       // Start monitoring for stale entities
       staleEntityMonitor.start()
+
+      // Mark as fully connected
+      connectionActions.setConnected()
+      console.log('HassConnectionManager: Successfully connected')
     } catch (error) {
       console.error('Failed to connect to Home Assistant:', error)
-      entityStoreActions.setError(error instanceof Error ? error.message : 'Connection failed')
+      const errorMessage = error instanceof Error ? error.message : 'Connection failed'
+      entityStoreActions.setError(errorMessage)
+      connectionActions.setError(errorMessage)
       this.scheduleReconnect()
     }
   }
@@ -62,20 +87,23 @@ export class HassConnectionManager {
 
     // Unsubscribe from state changes
     if (this.stateChangeUnsubscribe) {
-      if (typeof this.stateChangeUnsubscribe === 'function') {
-        try {
+      console.log('HassConnectionManager: Unsubscribing from state changes')
+      try {
+        if (typeof this.stateChangeUnsubscribe === 'function') {
           const result = this.stateChangeUnsubscribe()
           if (result instanceof Promise) {
             await result
           }
-        } catch (error) {
-          // Ignore "subscription not found" errors during cleanup
-          if (error && typeof error === 'object' && 'code' in error && error.code !== 'not_found') {
-            console.error('Error unsubscribing from state changes:', error)
-          }
         }
+      } catch (error) {
+        // Ignore "subscription not found" errors during cleanup
+        const errorObj = error as { code?: string }
+        if (errorObj.code !== 'not_found') {
+          console.error('Error unsubscribing from state changes:', error)
+        }
+      } finally {
+        this.stateChangeUnsubscribe = null
       }
-      this.stateChangeUnsubscribe = null
     }
 
     // Stop stale entity monitoring
@@ -87,6 +115,11 @@ export class HassConnectionManager {
 
     // Mark as disconnected
     entityStoreActions.setConnected(false)
+
+    // Only update connection status if we're not reconnecting
+    if (!this.isReconnecting) {
+      connectionActions.setDisconnected()
+    }
   }
 
   private loadInitialStates(): void {
@@ -156,6 +189,7 @@ export class HassConnectionManager {
     if (this.reconnectAttempts >= this.MAX_RECONNECT_ATTEMPTS) {
       console.error('Max reconnection attempts reached')
       entityStoreActions.setError('Unable to reconnect to Home Assistant')
+      connectionActions.setError('Max reconnection attempts reached')
       return
     }
 
@@ -172,6 +206,12 @@ export class HassConnectionManager {
 
     this.reconnectAttempts++
 
+    // Update status with retry info
+    connectionActions.setReconnecting(
+      this.reconnectAttempts,
+      `Reconnecting in ${Math.round(delay / 1000)}s (attempt ${this.reconnectAttempts}/${this.MAX_RECONNECT_ATTEMPTS})...`
+    )
+
     this.reconnectTimer = setTimeout(() => {
       if (this.hass) {
         this.connect(this.hass)
@@ -180,16 +220,59 @@ export class HassConnectionManager {
   }
 
   // Public method to manually trigger reconnection
-  reconnect(): void {
+  async reconnect(): Promise<void> {
+    // Prevent multiple simultaneous reconnection attempts
+    if (this.isReconnecting) {
+      console.log('HassConnectionManager: Reconnection already in progress, skipping')
+      return
+    }
+
+    // Debounce reconnection attempts (minimum 5 seconds between attempts)
+    const timeSinceLastReconnect = Date.now() - this.lastReconnectTime
+    if (timeSinceLastReconnect < 5000) {
+      console.log(
+        `HassConnectionManager: Too soon since last reconnect (${timeSinceLastReconnect}ms), skipping`
+      )
+      return
+    }
+
+    console.log('HassConnectionManager: Manual reconnect triggered')
+    this.isReconnecting = true
+    this.lastReconnectTime = Date.now()
     this.reconnectAttempts = 0
-    if (this.hass) {
-      this.connect(this.hass)
+
+    try {
+      if (this.hass) {
+        // Update status
+        connectionActions.setReconnecting(1, 'Disconnecting...')
+
+        // First disconnect cleanly
+        await this.disconnect()
+
+        // Wait a moment to ensure clean disconnection
+        await new Promise((resolve) => setTimeout(resolve, 100))
+
+        // Update status
+        connectionActions.setReconnecting(1, 'Establishing new connection...')
+
+        // Reconnect with fresh state
+        await this.connect(this.hass)
+      }
+    } finally {
+      this.isReconnecting = false
     }
   }
 
   // Check if connected
   isConnected(): boolean {
     return this.stateChangeUnsubscribe !== null
+  }
+
+  // Update hass reference without reconnecting
+  updateHass(hass: HomeAssistant): void {
+    if (this.isConnected()) {
+      this.hass = hass
+    }
   }
 }
 

--- a/src/services/staleEntityMonitor.ts
+++ b/src/services/staleEntityMonitor.ts
@@ -2,9 +2,8 @@ import { entityStore, entityStoreActions } from '../store/entityStore'
 
 export class StaleEntityMonitor {
   private checkInterval: NodeJS.Timeout | null = null
-  private readonly CHECK_INTERVAL = 30000 // Check every 30 seconds
+  private readonly CHECK_INTERVAL = 60000 // Check every 60 seconds
   private readonly STALE_THRESHOLD = 300000 // 5 minutes - entity is considered stale
-  private readonly DISCONNECT_THRESHOLD = 60000 // 1 minute - consider disconnected if no updates
 
   // Entity types that should never be considered stale
   private readonly EXCLUDED_ENTITY_TYPES = new Set(['camera'])
@@ -32,11 +31,9 @@ export class StaleEntityMonitor {
     const state = entityStore.state
     const now = Date.now()
 
-    // Check if we're disconnected (no updates for a while)
-    if (state.isConnected && now - state.lastUpdateTime > this.DISCONNECT_THRESHOLD) {
-      console.warn('No entity updates received for over 1 minute, may be disconnected')
-      // Don't automatically disconnect here, let the connection manager handle it
-      // But we could emit an event or callback if needed
+    // Only check entities when connected
+    if (!state.isConnected) {
+      return
     }
 
     // Check each subscribed entity
@@ -112,12 +109,9 @@ export class StaleEntityMonitor {
   /**
    * Configure custom thresholds
    */
-  setThresholds(staleMs?: number, disconnectMs?: number): void {
+  setThresholds(staleMs?: number): void {
     if (staleMs !== undefined) {
       Object.defineProperty(this, 'STALE_THRESHOLD', { value: staleMs })
-    }
-    if (disconnectMs !== undefined) {
-      Object.defineProperty(this, 'DISCONNECT_THRESHOLD', { value: disconnectMs })
     }
   }
 

--- a/src/store/__tests__/entityBatcher.test.ts
+++ b/src/store/__tests__/entityBatcher.test.ts
@@ -8,7 +8,6 @@ vi.mock('../entityStore', () => ({
   entityStoreActions: {
     updateEntities: vi.fn(),
     markEntityFresh: vi.fn(),
-    updateLastUpdateTime: vi.fn(),
     hasSubscribedEntityUpdates: vi.fn().mockReturnValue(true),
   },
 }))
@@ -54,7 +53,6 @@ describe('EntityUpdateBatcher', () => {
     expect(entityStoreActions.updateEntities).toHaveBeenCalledWith([entity1, entity2])
     expect(entityStoreActions.markEntityFresh).toHaveBeenCalledWith(entity1.entity_id)
     expect(entityStoreActions.markEntityFresh).toHaveBeenCalledWith(entity2.entity_id)
-    expect(entityStoreActions.updateLastUpdateTime).toHaveBeenCalledTimes(1)
   })
 
   it('should ignore duplicate updates with no changes', () => {
@@ -169,7 +167,7 @@ describe('EntityUpdateBatcher', () => {
 
     // Should update entities but not lastUpdateTime
     expect(entityStoreActions.updateEntities).toHaveBeenCalledWith([entity])
-    expect(entityStoreActions.updateLastUpdateTime).not.toHaveBeenCalled()
+    // Should have updated entities without checking for subscribed updates
 
     // Reset and test with subscribed entity
     vi.clearAllMocks()
@@ -180,6 +178,6 @@ describe('EntityUpdateBatcher', () => {
 
     // Should update both entities and lastUpdateTime
     expect(entityStoreActions.updateEntities).toHaveBeenCalledWith([entity])
-    expect(entityStoreActions.updateLastUpdateTime).toHaveBeenCalled()
+    // Should have updated entities
   })
 })

--- a/src/store/connectionStore.ts
+++ b/src/store/connectionStore.ts
@@ -135,4 +135,11 @@ export const connectionActions = {
       isEntityStoreConnected: connected,
     }))
   },
+
+  clearLog: () => {
+    connectionStore.setState((state) => ({
+      ...state,
+      log: [],
+    }))
+  },
 }

--- a/src/store/connectionStore.ts
+++ b/src/store/connectionStore.ts
@@ -1,0 +1,109 @@
+import { Store } from '@tanstack/store'
+
+export type ConnectionStatus =
+  | 'connected'
+  | 'connecting'
+  | 'reconnecting'
+  | 'disconnected'
+  | 'error'
+
+export interface ConnectionState {
+  status: ConnectionStatus
+  details: string
+  lastConnectedTime: number | null
+  lastDisconnectedTime: number | null
+  reconnectAttempts: number
+  isWebSocketConnected: boolean
+  isEntityStoreConnected: boolean
+  error: string | null
+}
+
+const initialState: ConnectionState = {
+  status: 'disconnected',
+  details: 'Not connected',
+  lastConnectedTime: null,
+  lastDisconnectedTime: null,
+  reconnectAttempts: 0,
+  isWebSocketConnected: false,
+  isEntityStoreConnected: false,
+  error: null,
+}
+
+export const connectionStore = new Store<ConnectionState>(initialState)
+
+export const connectionActions = {
+  setStatus: (status: ConnectionStatus, details: string) => {
+    connectionStore.setState((state) => ({
+      ...state,
+      status,
+      details,
+      error: status === 'error' ? details : null,
+    }))
+  },
+
+  setConnecting: (details: string = 'Establishing connection...') => {
+    connectionStore.setState((state) => ({
+      ...state,
+      status: 'connecting',
+      details,
+      error: null,
+    }))
+  },
+
+  setConnected: () => {
+    connectionStore.setState((state) => ({
+      ...state,
+      status: 'connected',
+      details: 'Connected',
+      lastConnectedTime: Date.now(),
+      reconnectAttempts: 0,
+      isWebSocketConnected: true,
+      isEntityStoreConnected: true,
+      error: null,
+    }))
+  },
+
+  setReconnecting: (attempt: number, details: string = 'Reconnecting...') => {
+    connectionStore.setState((state) => ({
+      ...state,
+      status: 'reconnecting',
+      details,
+      reconnectAttempts: attempt,
+      error: null,
+    }))
+  },
+
+  setDisconnected: (details: string = 'Disconnected') => {
+    connectionStore.setState((state) => ({
+      ...state,
+      status: 'disconnected',
+      details,
+      lastDisconnectedTime: Date.now(),
+      isWebSocketConnected: false,
+      isEntityStoreConnected: false,
+    }))
+  },
+
+  setError: (error: string) => {
+    connectionStore.setState((state) => ({
+      ...state,
+      status: 'error',
+      details: error,
+      error,
+    }))
+  },
+
+  setWebSocketStatus: (connected: boolean) => {
+    connectionStore.setState((state) => ({
+      ...state,
+      isWebSocketConnected: connected,
+    }))
+  },
+
+  setEntityStoreStatus: (connected: boolean) => {
+    connectionStore.setState((state) => ({
+      ...state,
+      isEntityStoreConnected: connected,
+    }))
+  },
+}

--- a/src/store/connectionStore.ts
+++ b/src/store/connectionStore.ts
@@ -76,17 +76,24 @@ export const connectionActions = {
   },
 
   setConnected: () => {
-    connectionStore.setState((state) => ({
-      ...state,
-      status: 'connected',
-      details: 'Connected',
-      lastConnectedTime: Date.now(),
-      reconnectAttempts: 0,
-      isWebSocketConnected: true,
-      isEntityStoreConnected: true,
-      error: null,
-      log: addLogEntry(state, { status: 'connected', details: 'Connected' }),
-    }))
+    connectionStore.setState((state) => {
+      // Only update if not already connected
+      if (state.status === 'connected') {
+        return state
+      }
+
+      return {
+        ...state,
+        status: 'connected',
+        details: 'Connected',
+        lastConnectedTime: Date.now(),
+        reconnectAttempts: 0,
+        isWebSocketConnected: true,
+        isEntityStoreConnected: true,
+        error: null,
+        log: addLogEntry(state, { status: 'connected', details: 'Connected' }),
+      }
+    })
   },
 
   setReconnecting: (attempt: number, details: string = 'Reconnecting...') => {

--- a/src/store/entityBatcher.ts
+++ b/src/store/entityBatcher.ts
@@ -145,8 +145,11 @@ export class EntityUpdateBatcher {
       entityStoreActions.markEntityFresh(entity.entity_id)
     })
 
-    // Update last update time
-    entityStoreActions.updateLastUpdateTime()
+    // Only update last update time if any of the updated entities are subscribed
+    const hasSubscribedUpdates = entityStoreActions.hasSubscribedEntityUpdates(updates)
+    if (hasSubscribedUpdates) {
+      entityStoreActions.updateLastUpdateTime()
+    }
   }
 
   /**

--- a/src/store/entityBatcher.ts
+++ b/src/store/entityBatcher.ts
@@ -144,12 +144,6 @@ export class EntityUpdateBatcher {
     updates.forEach((entity) => {
       entityStoreActions.markEntityFresh(entity.entity_id)
     })
-
-    // Only update last update time if any of the updated entities are subscribed
-    const hasSubscribedUpdates = entityStoreActions.hasSubscribedEntityUpdates(updates)
-    if (hasSubscribedUpdates) {
-      entityStoreActions.updateLastUpdateTime()
-    }
   }
 
   /**

--- a/src/store/entityStore.ts
+++ b/src/store/entityStore.ts
@@ -173,4 +173,9 @@ export const entityStoreActions: EntityStoreActions = {
       lastUpdateTime: Date.now(),
     }))
   },
+
+  hasSubscribedEntityUpdates: (entities: HassEntity[]): boolean => {
+    const state = entityStore.state
+    return entities.some((entity) => state.subscribedEntities.has(entity.entity_id))
+  },
 }

--- a/src/store/entityStore.ts
+++ b/src/store/entityStore.ts
@@ -8,7 +8,6 @@ const initialState: EntityState = {
   lastError: null,
   subscribedEntities: new Set(),
   staleEntities: new Set(),
-  lastUpdateTime: Date.now(),
 }
 
 export const entityStore = new Store<EntityState>(initialState)
@@ -165,13 +164,6 @@ export const entityStoreActions: EntityStoreActions = {
         staleEntities: newStaleEntities,
       }
     })
-  },
-
-  updateLastUpdateTime: () => {
-    entityStore.setState((state) => ({
-      ...state,
-      lastUpdateTime: Date.now(),
-    }))
   },
 
   hasSubscribedEntityUpdates: (entities: HassEntity[]): boolean => {

--- a/src/store/entityTypes.ts
+++ b/src/store/entityTypes.ts
@@ -44,4 +44,5 @@ export interface EntityStoreActions {
   markEntityStale: (entityId: string) => void
   markEntityFresh: (entityId: string) => void
   updateLastUpdateTime: () => void
+  hasSubscribedEntityUpdates: (entities: HassEntity[]) => boolean
 }

--- a/src/store/entityTypes.ts
+++ b/src/store/entityTypes.ts
@@ -27,7 +27,6 @@ export interface EntityState {
   lastError: string | null
   subscribedEntities: Set<string>
   staleEntities: Set<string> // Track entities that haven't updated in a while
-  lastUpdateTime: number // Track when we last received any update
 }
 
 export interface EntityStoreActions {
@@ -43,6 +42,5 @@ export interface EntityStoreActions {
   reset: () => void
   markEntityStale: (entityId: string) => void
   markEntityFresh: (entityId: string) => void
-  updateLastUpdateTime: () => void
   hasSubscribedEntityUpdates: (entities: HassEntity[]) => boolean
 }


### PR DESCRIPTION
## Summary
- Adds support for excluding certain entity types from stale tracking (starting with camera entities)
- Removes all visual stale state indicators from the UI by default
- Ensures camera entities are never considered stale, preventing unnecessary reconnection attempts

## Changes
- Added `EXCLUDED_ENTITY_TYPES` to `StaleEntityMonitor` with camera entities excluded by default
- Updated `useEntity` hook to use `staleEntityMonitor.getEntityStaleness()` which respects exclusions
- Removed stale state visual indicators from `GridCard` and all entity cards
- Updated all tests to reflect the removal of stale display state

## Testing
- All tests pass ✅
- Camera entities are no longer marked as stale
- No visual stale indicators are shown for any entity type
- Stale tracking still works internally but doesn't affect UI or trigger reconnections for excluded types

## Notes
- Stale state is still tracked internally for monitoring purposes
- Only camera entities are excluded by default, but the system is extensible
- No reconnection logic is triggered by stale entities