### PR TITLE
chore: add dependabot configuration for automated dependency updates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,10 +3,6 @@
   "image": "ghcr.io/fx/docker/devcontainer:latest",
   "containerUser": "vscode",
   "postStartCommand": "bash .devcontainer/post-start-wrapper.sh",
-  "mounts": [
-    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
-  ],
-  "runArgs": [
-    "--privileged"
-  ]
+  "mounts": ["source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"],
+  "runArgs": ["--privileged"]
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,65 @@
+# Dependabot configuration for automated dependency updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '04:00'
+      timezone: 'UTC'
+    open-pull-requests-limit: 5
+    labels:
+      - 'dependencies'
+      - 'npm'
+    commit-message:
+      prefix: 'feat'
+      prefix-development: 'chore'
+      include: 'scope'
+    groups:
+      # React ecosystem packages
+      react-ecosystem:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - 'react-*'
+
+      # TanStack packages (router, store, virtual, etc.)
+      tanstack:
+        patterns:
+          - '@tanstack/*'
+
+      # Radix UI component library
+      radix-ui:
+        patterns:
+          - '@radix-ui/*'
+
+      # TypeScript and type definitions
+      typescript:
+        patterns:
+          - 'typescript'
+          - '@types/*'
+
+      # ESLint and related plugins
+      eslint:
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+          - '@typescript-eslint/*'
+
+      # Testing tools
+      testing:
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
+          - '@testing-library/*'
+          - '@playwright/test'
+          - 'jsdom'
+
+      # Build tools (Vite ecosystem)
+      build-tools:
+        patterns:
+          - 'vite'
+          - '@vitejs/*'
+          - 'vite-*'


### PR DESCRIPTION
Adds Dependabot configuration for automated npm dependency updates.

- Weekly schedule (Monday 4am UTC)
- Max 5 concurrent PRs
- Dependencies grouped by ecosystem (React, TanStack, Radix UI, TypeScript, ESLint, testing, build tools)
- Labels: dependencies, npm
- Semantic commit prefixes (feat for prod, chore for dev)