### PR TITLE
docs(specs): use repo-relative paths in spec references

### DIFF
--- a/docs/specs/camera-streaming/index.md
+++ b/docs/specs/camera-streaming/index.md
@@ -8,7 +8,7 @@ Liebe renders live camera feeds inside the dashboard grid using a WebRTC peer co
 
 Home Assistant exposes cameras as entities in the `camera` domain. Modern HA installations stream camera video over WebRTC, typically brokered by the [go2rtc](https://github.com/AlexxIT/go2rtc#quick-start) component that ships with recent HA releases. Rather than embed HA's own `<ha-camera-stream>` element, Liebe negotiates its own `RTCPeerConnection` directly against HA's `camera/webrtc/offer` / `candidate` WebSocket commands, which lets the panel own the video element, its styling, and its lifecycle.
 
-The camera surface was introduced in PR #104 and extended incrementally: fullscreen and mute controls (PR #134), fit/matting/debug-stats configuration (PR #141), an `InvalidStateError` guard in signaling (PR #131), and exclusion from stale-entity tracking (PR #139, issue-driven fullscreen-modal scoping from issue #136). The card and hook total roughly 1400 lines (`CameraCard.tsx` 852 lines, `useWebRTC.ts` 584 lines) and have essentially no direct automated coverage — see [Open Questions](#open-questions).
+The camera surface was introduced in PR #104 and extended incrementally: fullscreen and mute controls (PR #134), fit/matting/debug-stats configuration (PR #141), an `InvalidStateError` guard in signaling (PR #131), and exclusion from stale-entity tracking (PR #139, issue-driven fullscreen-modal scoping from issue #136). The card and hook total roughly 1400 lines (`src/components/CameraCard.tsx` 852 lines, `src/hooks/useWebRTC.ts` 584 lines) and have essentially no direct automated coverage — see [Open Questions](#open-questions).
 
 This spec covers the camera card, the WebRTC hook, stale-tracking exclusion for cameras, and the camera fullscreen modal. It does NOT cover the general card registry (see [../entity-cards/](../entity-cards/)) or the entity state pipeline (see [../entity-state/](../entity-state/)); those are linked rather than duplicated.
 
@@ -20,7 +20,7 @@ This spec covers the camera card, the WebRTC hook, stale-tracking exclusion for 
 - When the camera is not stream-capable, the card MUST render a static video icon instead of a video element, tinted blue while recording or streaming and gray otherwise.
 - WebRTC negotiation MUST be enabled only when an entity exists, Home Assistant is connected, and the camera supports streaming.
 
-`CameraCard.tsx:38` defines the flag, and support is derived and gated at `CameraCard.tsx:430`-`440`:
+`src/components/CameraCard.tsx:38` defines the flag, and support is derived and gated at `src/components/CameraCard.tsx:430`-`440`:
 
 ```typescript
 const SUPPORT_STREAM = 2
@@ -56,7 +56,7 @@ const webRTCEnabled = useMemo(() => {
 - The hook MUST queue inbound ICE candidates that arrive before the remote description is set, and flush them immediately after the remote description resolves.
 - Initialization MUST be debounced (200 ms) and guarded by `initializing`/`pending`/existing-connection refs so rapid re-renders do not open duplicate peer connections.
 
-The signaling flow, message handling, and the state guard live in `useWebRTC.ts:271`-`478`:
+The signaling flow, message handling, and the state guard live in `src/hooks/useWebRTC.ts:271`-`478`:
 
 ```typescript
 // Create peer connection with STUN servers
@@ -125,7 +125,7 @@ const unsubscribePromise = hass.connection.subscribeMessage<WebRTCReceiveMessage
 - The hook MUST raise `hasFrameWarning` after 500 ms without a new frame and MUST force a cleanup-and-reconnect after 5 s without a new frame.
 - On connection-state `failed` the hook MUST set an error and clean up; on `disconnected` it MUST set an error; on `connected` it MUST clear the error; on `closed` it MUST stop streaming.
 
-`useWebRTC.ts:118`-`269` implements frame monitoring; the 500 ms warning and 5 s reconnect thresholds are at `useWebRTC.ts:226` and `useWebRTC.ts:241`. Connection-state handling is at `useWebRTC.ts:328`-`351`.
+`src/hooks/useWebRTC.ts:118`-`269` implements frame monitoring; the 500 ms warning and 5 s reconnect thresholds are at `src/hooks/useWebRTC.ts:226` and `src/hooks/useWebRTC.ts:241`. Connection-state handling is at `src/hooks/useWebRTC.ts:328`-`351`.
 
 #### Scenario: First frame received
 
@@ -145,7 +145,7 @@ const unsubscribePromise = hass.connection.subscribeMessage<WebRTCReceiveMessage
 - The hook MUST fully tear down the peer connection, unsubscribe from the WebSocket subscription (ignoring `not_found` errors), clear the video `srcObject`, and stop frame monitoring on cleanup, disable, entity change, and unmount.
 - The card MUST expose a manual `retry` that re-triggers initialization for recoverable errors.
 
-Visibility handling is at `useWebRTC.ts:541`-`567`; cleanup at `useWebRTC.ts:64`-`115`; unmount cleanup at `useWebRTC.ts:570`-`574`.
+Visibility handling is at `src/hooks/useWebRTC.ts:541`-`567`; cleanup at `src/hooks/useWebRTC.ts:64`-`115`; unmount cleanup at `src/hooks/useWebRTC.ts:570`-`574`.
 
 #### Scenario: Return to a backgrounded tab
 
@@ -161,7 +161,7 @@ Visibility handling is at `useWebRTC.ts:541`-`567`; cleanup at `useWebRTC.ts:64`
 - Clicking the video (not in edit mode, no error) MUST open the in-app fullscreen modal.
 - When the stream error indicates the camera is not yet configured, the card MUST show go2rtc setup guidance linking to `https://github.com/AlexxIT/go2rtc#quick-start`; other errors MUST show the message plus a Retry button.
 
-Status resolution is at `CameraCard.tsx:316`-`328`; controls at `CameraCard.tsx:333`-`394`; mute default at `CameraCard.tsx:412`; the go2rtc guidance branch at `CameraCard.tsx:580`-`617`.
+Status resolution is at `src/components/CameraCard.tsx:316`-`328`; controls at `src/components/CameraCard.tsx:333`-`394`; mute default at `src/components/CameraCard.tsx:412`; the go2rtc guidance branch at `src/components/CameraCard.tsx:580`-`617`.
 
 #### Scenario: Streaming card in view mode
 
@@ -181,7 +181,7 @@ Status resolution is at `CameraCard.tsx:316`-`328`; controls at `CameraCard.tsx:
 - The modal MUST close on backdrop click or ESC, MUST render the feed with `object-fit: contain`, and MUST show mute/fullscreen controls scaled to the viewport plus an "Click or press ESC to exit" hint.
 - The native-fullscreen button MUST request/exit `requestFullscreen()` on the underlying `<video>` element directly.
 
-The `KeepAlive` portal (`KeepAlive.tsx`) moves the single cached video element between the normal container and the fullscreen container (`CameraCard.tsx:633`-`649`), so entering/leaving the modal does not tear down the WebRTC session. The modal is `FullscreenModal` (`CameraCard.tsx:731`-`814`); native fullscreen at `CameraCard.tsx:461`-`475`.
+The `KeepAlive` portal (`src/components/KeepAlive.tsx`) moves the single cached video element between the normal container and the fullscreen container (`src/components/CameraCard.tsx:633`-`649`), so entering/leaving the modal does not tear down the WebRTC session. The modal is `FullscreenModal` (`src/components/CameraCard.tsx:731`-`814`); native fullscreen at `src/components/CameraCard.tsx:461`-`475`.
 
 #### Scenario: Enter and leave in-app fullscreen
 
@@ -194,7 +194,7 @@ The `KeepAlive` portal (`KeepAlive.tsx`) moves the single cached video element b
 - When `showStats` is enabled, the card MUST overlay FPS, bitrate (kbps), decoded frame count, dropped frame count, and resolution, sampled once per second from the video element and the peer connection's `getStats()`.
 - The overlay MUST render a compact single line at `small` size and a labeled multi-column layout at `medium`/`large`, and MUST appear in both the normal and fullscreen views.
 
-`CameraStats` is at `CameraCard.tsx:41`-`230`; bitrate is computed from `inbound-rtp` video reports at `CameraCard.tsx:105`-`116`.
+`CameraStats` is at `src/components/CameraCard.tsx:41`-`230`; bitrate is computed from `inbound-rtp` video reports at `src/components/CameraCard.tsx:105`-`116`.
 
 #### Scenario: Debug stats enabled
 
@@ -207,7 +207,7 @@ The `KeepAlive` portal (`KeepAlive.tsx`) moves the single cached video element b
 - The camera card MUST expose three per-card configuration options: `fit` (`cover` default, or `contain`), `matting` (`none` / `small` default / `large` card padding), and `showStats` (boolean, default false).
 - The card MUST map `matting` to Radix space tokens relative to the card size (`small` matches the size's default padding; `large` uses `--space-5`; `none` uses `0`).
 
-Option schema is at `cardConfigurations.ts:77`-`109`; the card reads them at `CameraCard.tsx:419`-`422` and maps matting at `CameraCard.tsx:520`-`529`.
+Option schema is at `src/components/configurations/cardConfigurations.ts:77`-`109`; the card reads them at `src/components/CameraCard.tsx:419`-`422` and maps matting at `src/components/CameraCard.tsx:520`-`529`.
 
 #### Scenario: Contain fit with large matting
 
@@ -220,7 +220,7 @@ Option schema is at `cardConfigurations.ts:77`-`109`; the card reads them at `Ca
 - Camera entities MUST be excluded from stale-entity tracking; a camera MUST never be reported stale even if it produces no state events for longer than the stale threshold (PR #139).
 - If a camera was previously marked stale, the monitor MUST mark it fresh on its next pass.
 
-`StaleEntityMonitor` excludes the `camera` domain (`staleEntityMonitor.ts:9`, `:48`-`54`, `:98`-`104`). The full stale pipeline is specified in [../entity-state/](../entity-state/); only the camera exclusion is in scope here.
+`StaleEntityMonitor` excludes the `camera` domain (`src/services/staleEntityMonitor.ts:9`, `:48`-`54`, `:98`-`104`). The full stale pipeline is specified in [../entity-state/](../entity-state/); only the camera exclusion is in scope here.
 
 #### Scenario: Camera with no recent state updates
 
@@ -246,11 +246,11 @@ CameraCard.tsx ──uses──► useWebRTC.ts ──► HA WebSocket (camera/w
 staleEntityMonitor.ts ── excludes 'camera' domain (independent path)
 ```
 
-The card owns UI, state labels, configuration, mute/fullscreen, and the stats overlay. The hook owns the peer connection, signaling, frame monitoring, and reconnection. `KeepAlive` owns a single cached `<video>` element per camera so it survives moving between the grid and the fullscreen modal. Camera registration into the card system is via the card registry (`cardRegistry.ts:43`, `camera: CameraCard`) — see [../entity-cards/](../entity-cards/).
+The card owns UI, state labels, configuration, mute/fullscreen, and the stats overlay. The hook owns the peer connection, signaling, frame monitoring, and reconnection. `KeepAlive` owns a single cached `<video>` element per camera so it survives moving between the grid and the fullscreen modal. Camera registration into the card system is via the card registry (`src/components/cardRegistry.ts:43`, `camera: CameraCard`) — see [../entity-cards/](../entity-cards/).
 
 ### Data Models
 
-Hook interfaces (`useWebRTC.ts:5`-`36`):
+Hook interfaces (`src/hooks/useWebRTC.ts:5`-`36`):
 
 ```typescript
 interface UseWebRTCOptions {
@@ -282,7 +282,7 @@ interface ExtendedRTCPeerConnection extends RTCPeerConnection {
 }
 ```
 
-Camera attributes read by the card (`CameraCard.tsx:29`-`35`): `access_token`, `entity_picture`, `frontend_stream_type` (declared but currently unused), `friendly_name`, `supported_features`.
+Camera attributes read by the card (`src/components/CameraCard.tsx:29`-`35`): `access_token`, `entity_picture`, `frontend_stream_type` (declared but currently unused), `friendly_name`, `supported_features`.
 
 Configuration values live on the grid item (`item.config`): `fit`, `matting`, `showStats`.
 
@@ -293,36 +293,36 @@ WebSocket commands sent to Home Assistant:
 - `camera/webrtc/offer` — subscription carrying `{ entity_id, offer: sdp }`; streams back `session`/`answer`/`candidate`/`error` messages.
 - `camera/webrtc/candidate` — `sendMessagePromise` with `{ entity_id, session_id, candidate }` per locally-gathered ICE candidate.
 
-STUN servers are hardcoded to Google's public STUN (`useWebRTC.ts:294`-`296`); no TURN servers are configured.
+STUN servers are hardcoded to Google's public STUN (`src/hooks/useWebRTC.ts:294`-`296`); no TURN servers are configured.
 
 ### UI Components
 
-- `CameraCardComponent` (`CameraCard.tsx:399`) — memoized (`CameraCard.tsx:838`), default grid dimensions 4×2 (`CameraCard.tsx:850`-`852`).
-- `CameraControls` (`CameraCard.tsx:233`) — status label + mute/fullscreen buttons, `em`-scaled by card size.
-- `CameraStats` (`CameraCard.tsx:41`) — debug overlay.
-- `FullscreenModal` (`ui/FullscreenModal.tsx`) — body-portaled modal (default z-index 99999 to escape shadow DOM), used camera-only per issue #136.
-- `KeepAlive` (`KeepAlive.tsx`) — portal cache keyed `camera-${entityId}` that relocates the live `<video>` between containers without unmounting.
+- `CameraCardComponent` (`src/components/CameraCard.tsx:399`) — memoized (`src/components/CameraCard.tsx:838`), default grid dimensions 4×2 (`src/components/CameraCard.tsx:850`-`852`).
+- `CameraControls` (`src/components/CameraCard.tsx:233`) — status label + mute/fullscreen buttons, `em`-scaled by card size.
+- `CameraStats` (`src/components/CameraCard.tsx:41`) — debug overlay.
+- `FullscreenModal` (`src/components/ui/FullscreenModal.tsx`) — body-portaled modal (default z-index 99999 to escape shadow DOM), used camera-only per issue #136.
+- `KeepAlive` (`src/components/KeepAlive.tsx`) — portal cache keyed `camera-${entityId}` that relocates the live `<video>` between containers without unmounting.
 
 ### Business Logic
 
-The video element uses `muted={isMuted}` (default true), `autoPlay`, `playsInline`, and toggles visibility via `display: isStreaming ? 'block' : 'none'` (`CameraCard.tsx:637`-`648`). A combined ref callback (`CameraCard.tsx:489`-`495`) feeds the element to both the hook's `videoRef` and a local ref used by the stats overlay and native-fullscreen handler.
+The video element uses `muted={isMuted}` (default true), `autoPlay`, `playsInline`, and toggles visibility via `display: isStreaming ? 'block' : 'none'` (`src/components/CameraCard.tsx:637`-`648`). A combined ref callback (`src/components/CameraCard.tsx:489`-`495`) feeds the element to both the hook's `videoRef` and a local ref used by the stats overlay and native-fullscreen handler.
 
-The commented-out block at `useWebRTC.ts:536`-`538` documents a deliberate design decision from PR #139: camera streams do NOT reconnect on global entity-update events, only on their own connection state — consistent with excluding cameras from stale tracking.
+The commented-out block at `src/hooks/useWebRTC.ts:536`-`538` documents a deliberate design decision from PR #139: camera streams do NOT reconnect on global entity-update events, only on their own connection state — consistent with excluding cameras from stale tracking.
 
 ## Constraints
 
-- **No TURN / hardcoded STUN.** Only Google public STUN is configured (`useWebRTC.ts:294`-`296`); cameras that require TURN relaying (strict NATs) will fail to connect. There is no configuration surface for ICE servers.
+- **No TURN / hardcoded STUN.** Only Google public STUN is configured (`src/hooks/useWebRTC.ts:294`-`296`); cameras that require TURN relaying (strict NATs) will fail to connect. There is no configuration surface for ICE servers.
 - **HA/go2rtc dependency.** Streaming requires the HA `camera/webrtc/*` WebSocket API, which in practice depends on go2rtc; unconfigured cameras surface the "Camera Configuration Required" guidance rather than video.
 - **`trust_external_script` tradeoff.** When Liebe is loaded from the hosted `panel.js` (`https://fx.github.io/liebe/panel.js`), HA may raise an `alert()` unless `trust_external_script: true` is set in `panel_custom`. The README warns this disables certain security protections and recommends self-hosting the build for maximum security (README.md:18-45). This affects the whole panel, not only cameras, but is load-bearing for camera users on the hosted build.
 - **Single cached video element per camera.** `KeepAlive` caches one `<video>` per `entityId`; two cards for the same camera would contend for the same portal element.
-- **Component size.** `CameraCard.tsx` (852 lines) and `useWebRTC.ts` (584 lines) are large and mix rendering, signaling, frame heuristics, and stats in single files.
+- **Component size.** `src/components/CameraCard.tsx` (852 lines) and `src/hooks/useWebRTC.ts` (584 lines) are large and mix rendering, signaling, frame heuristics, and stats in single files.
 
 ## Open Questions
 
-- **Zero direct automated coverage of ~1400 lines.** There are no tests exercising `CameraCard.tsx` rendering or `useWebRTC.ts` signaling/frame-monitoring/reconnection logic. Only two peripheral tests touch cameras: `useEntity.test.tsx:100` (camera excluded from stale tracking) and `cardDimensions.test.ts:9` (default 4×2 dimensions). All scenarios above are derived from code paths and `docs/test-camera-card.md`, not from executable tests. Should the signaling state machine and frame-monitoring heuristics get unit/integration coverage?
-- **Hardcoded Google STUN (`useWebRTC.ts:295`).** No TURN and no user configuration — is this acceptable for the target deployments, or should ICE servers be configurable / sourced from HA?
-- **Component size / separation.** Should `CameraStats`, `CameraControls`, and the frame-monitoring logic be extracted into their own modules to reduce the size and interleaving of `CameraCard.tsx` and `useWebRTC.ts`?
-- **`frontend_stream_type` unused.** The attribute is declared (`CameraCard.tsx:32`) but never read; is HLS/native-stream-type branching intended?
+- **Zero direct automated coverage of ~1400 lines.** There are no tests exercising `src/components/CameraCard.tsx` rendering or `src/hooks/useWebRTC.ts` signaling/frame-monitoring/reconnection logic. Only two peripheral tests touch cameras: `src/hooks/__tests__/useEntity.test.tsx:100` (camera excluded from stale tracking) and `src/utils/__tests__/cardDimensions.test.ts:9` (default 4×2 dimensions). All scenarios above are derived from code paths and `docs/test-camera-card.md`, not from executable tests. Should the signaling state machine and frame-monitoring heuristics get unit/integration coverage?
+- **Hardcoded Google STUN (`src/hooks/useWebRTC.ts:295`).** No TURN and no user configuration — is this acceptable for the target deployments, or should ICE servers be configurable / sourced from HA?
+- **Component size / separation.** Should `CameraStats`, `CameraControls`, and the frame-monitoring logic be extracted into their own modules to reduce the size and interleaving of `src/components/CameraCard.tsx` and `src/hooks/useWebRTC.ts`?
+- **`frontend_stream_type` unused.** The attribute is declared (`src/components/CameraCard.tsx:32`) but never read; is HLS/native-stream-type branching intended?
 
 ## References
 

--- a/docs/specs/entity-cards/card-reference.md
+++ b/docs/specs/entity-cards/card-reference.md
@@ -1,51 +1,51 @@
 # Entity Card System — Card Reference
 
-Companion to [index.md](./index.md). This document is the exhaustive per-card catalog: declared dimensions, the Home Assistant services each card calls with exact payloads, feature-flag constants, size handling, edit-mode affordances, lifecycle states, and GIVEN/WHEN/THEN scenarios derived from the real test suites. Every claim is referenced to `path:line`. It is a living baseline of the implementation as it stands.
+Companion to [index.md](./index.md). This document is the exhaustive per-card catalog: declared dimensions, the Home Assistant services each card calls with exact payloads, feature-flag constants, size handling, edit-mode affordances, lifecycle states, and GIVEN/WHEN/THEN scenarios derived from the real test suites. Every claim is referenced to a repo-relative `path:line`; where a section already names its source file, subsequent bare `line`/`line-range` citations refer to that file. It is a living baseline of the implementation as it stands.
 
 ## Dimensions and capabilities matrix
 
-| Card                | Domain(s)             | `defaultDimensions`               | Config modal               | Interactive                   | Test file(s)                                                                           |
-| ------------------- | --------------------- | --------------------------------- | -------------------------- | ----------------------------- | -------------------------------------------------------------------------------------- |
-| LightCard           | `light`               | 2×2 (`LightCard.tsx:293`)         | Yes (light)                | toggle + brightness           | LightCard.test.tsx, LightCard.brightness.test.tsx, LightCard.slider-usability.test.tsx |
-| ClimateCard         | `climate`             | 3×3 (`ClimateCard.tsx:960`)       | No                         | mode + setpoints              | ClimateCard.test.tsx                                                                   |
-| CoverCard           | `cover`               | 2×3 (`CoverCard.tsx:420`)         | No                         | open/close/stop/position/tilt | CoverCard.test.tsx                                                                     |
-| FanCard             | `fan`                 | 2×2 (`FanCard.tsx:384`)           | No                         | toggle + speed + preset       | —                                                                                      |
-| SensorCard          | `sensor`              | 2×2 (`SensorCard.tsx:244`)        | No                         | read-only                     | SensorCard.test.tsx                                                                    |
-| BinarySensorCard    | `binary_sensor`       | 2×2 (`BinarySensorCard.tsx:198`)  | Yes (icons)                | read-only                     | — (previewed in CardConfig)                                                            |
-| ButtonCard          | `switch` + fallback   | 2×1 (`ButtonCard.tsx:155`)        | No                         | toggle                        | ButtonCard.test.tsx                                                                    |
-| WeatherCard         | `weather`             | 4×3 (`WeatherCard/index.tsx:311`) | Yes (variant/unit)         | read-only                     | WeatherCard.test.tsx                                                                   |
-| WeatherCardDefault  | variant               | 4×3                               | via parent                 | read-only                     | —                                                                                      |
-| WeatherCardModern   | variant               | 3×3                               | via parent                 | read-only                     | —                                                                                      |
-| WeatherCardDetailed | variant               | 4×4                               | via parent                 | read-only                     | —                                                                                      |
-| WeatherCardMinimal  | variant               | 2×2                               | via parent                 | read-only                     | —                                                                                      |
-| InputBooleanCard    | `input_boolean`       | 2×1 (`InputBooleanCard.tsx:128`)  | No                         | toggle                        | InputBooleanCard.test.tsx                                                              |
-| InputNumberCard     | `input_number`        | none → 2×2                        | No                         | stepper + edit                | InputNumberCard.test.tsx                                                               |
-| InputSelectCard     | `input_select`        | none → 2×2                        | No                         | select                        | InputSelectCard.test.tsx                                                               |
-| InputTextCard       | `input_text`          | none → 2×2                        | No                         | inline edit                   | InputTextCard.test.tsx                                                                 |
-| InputDateTimeCard   | `input_datetime`      | none → 2×2                        | No                         | native picker                 | InputDateTimeCard.test.tsx                                                             |
-| TextCard            | grid type `text`      | 3×2 (`TextCard.tsx:343`)          | via CardConfig (text)      | inline edit                   | —                                                                                      |
-| Separator           | grid type `separator` | 4×1 (`Separator.tsx:133`)         | via CardConfig (separator) | edit-select only              | —                                                                                      |
+| Card                | Domain(s)             | `defaultDimensions`                              | Config modal               | Interactive                   | Test file(s)                                                                                                                                                            |
+| ------------------- | --------------------- | ------------------------------------------------ | -------------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| LightCard           | `light`               | 2×2 (`src/components/LightCard.tsx:293`)         | Yes (light)                | toggle + brightness           | `src/components/__tests__/LightCard.test.tsx`, `src/components/__tests__/LightCard.brightness.test.tsx`, `src/components/__tests__/LightCard.slider-usability.test.tsx` |
+| ClimateCard         | `climate`             | 3×3 (`src/components/ClimateCard.tsx:960`)       | No                         | mode + setpoints              | `src/components/ClimateCard.test.tsx`                                                                                                                                   |
+| CoverCard           | `cover`               | 2×3 (`src/components/CoverCard.tsx:420`)         | No                         | open/close/stop/position/tilt | `src/components/CoverCard.test.tsx`                                                                                                                                     |
+| FanCard             | `fan`                 | 2×2 (`src/components/FanCard.tsx:384`)           | No                         | toggle + speed + preset       | —                                                                                                                                                                       |
+| SensorCard          | `sensor`              | 2×2 (`src/components/SensorCard.tsx:244`)        | No                         | read-only                     | `src/components/__tests__/SensorCard.test.tsx`                                                                                                                          |
+| BinarySensorCard    | `binary_sensor`       | 2×2 (`src/components/BinarySensorCard.tsx:198`)  | Yes (icons)                | read-only                     | — (previewed in CardConfig)                                                                                                                                             |
+| ButtonCard          | `switch` + fallback   | 2×1 (`src/components/ButtonCard.tsx:155`)        | No                         | toggle                        | `src/components/__tests__/ButtonCard.test.tsx`                                                                                                                          |
+| WeatherCard         | `weather`             | 4×3 (`src/components/WeatherCard/index.tsx:311`) | Yes (variant/unit)         | read-only                     | `src/components/WeatherCard.test.tsx`                                                                                                                                   |
+| WeatherCardDefault  | variant               | 4×3                                              | via parent                 | read-only                     | —                                                                                                                                                                       |
+| WeatherCardModern   | variant               | 3×3                                              | via parent                 | read-only                     | —                                                                                                                                                                       |
+| WeatherCardDetailed | variant               | 4×4                                              | via parent                 | read-only                     | —                                                                                                                                                                       |
+| WeatherCardMinimal  | variant               | 2×2                                              | via parent                 | read-only                     | —                                                                                                                                                                       |
+| InputBooleanCard    | `input_boolean`       | 2×1 (`src/components/InputBooleanCard.tsx:128`)  | No                         | toggle                        | `src/components/InputBooleanCard.test.tsx`                                                                                                                              |
+| InputNumberCard     | `input_number`        | none → 2×2                                       | No                         | stepper + edit                | `src/components/InputNumberCard.test.tsx`                                                                                                                               |
+| InputSelectCard     | `input_select`        | none → 2×2                                       | No                         | select                        | `src/components/InputSelectCard.test.tsx`                                                                                                                               |
+| InputTextCard       | `input_text`          | none → 2×2                                       | No                         | inline edit                   | `src/components/InputTextCard.test.tsx`                                                                                                                                 |
+| InputDateTimeCard   | `input_datetime`      | none → 2×2                                       | No                         | native picker                 | `src/components/InputDateTimeCard.test.tsx`                                                                                                                             |
+| TextCard            | grid type `text`      | 3×2 (`src/components/TextCard.tsx:343`)          | via CardConfig (text)      | inline edit                   | —                                                                                                                                                                       |
+| Separator           | grid type `separator` | 4×1 (`src/components/Separator.tsx:133`)         | via CardConfig (separator) | edit-select only              | —                                                                                                                                                                       |
 
-Cards without declared `defaultDimensions` fall back to `{ width: 2, height: 2 }` (`utils/cardDimensions.ts:8-17`). Most cards export as `Object.assign(memo(Component, comparator), { defaultDimensions })`; `Separator` is a plain function with a static `.defaultDimensions` and no memo. Every card except `SensorCard`/`ButtonCard`/`TextCard`/`Separator` reads the store `mode` either directly or through `GridCard`.
+Cards without declared `defaultDimensions` fall back to `{ width: 2, height: 2 }` (`src/utils/cardDimensions.ts:8-17`). Most cards export as `Object.assign(memo(Component, comparator), { defaultDimensions })`; `Separator` is a plain function with a static `.defaultDimensions` and no memo. Every card except `SensorCard`/`ButtonCard`/`TextCard`/`Separator` reads the store `mode` either directly or through `GridCard`.
 
 ## Lights
 
-**Services** (`LightCard.tsx`): `light.turn_on` / `light.turn_off` on toggle (`145-158`); brightness commit sends `light.turn_on` with `{ brightness }` on 0–255 scale, or `turn_off` when the committed value is 0 (`66-81`).
+**Services** (`src/components/LightCard.tsx`): `light.turn_on` / `light.turn_off` on toggle (`145-158`); brightness commit sends `light.turn_on` with `{ brightness }` on 0–255 scale, or `turn_off` when the committed value is 0 (`66-81`).
 
 **Feature detection**: `SUPPORT_BRIGHTNESS = 1` (`22`). Brightness is supported when `supported_color_modes` includes any of `brightness`, `color_temp`, `hs`, `xy`, `rgb`, `rgbw`, `rgbww`, else the legacy `supported_features & 1` (`87-102`). Color and color-temp checks are stubbed as comments (`104-111`, `171`).
 
 **Slider** (`226-244`): visible only when `!isEditMode && isOn && supportsBrightness && config.enableBrightness !== false`. Uses `localBrightness` + `isDragging` while dragging, `onValueCommit` to send. Display is `round(brightness/255*100)`; card click is suppressed while dragging (`185`).
 
-**Config**: `enableBrightness` boolean, default true (`configurations/cardConfigurations.ts:13-24`), edited via `CardConfig.Modal` (`LightCard.tsx:267-274`).
+**Config**: `enableBrightness` boolean, default true (`src/components/configurations/cardConfigurations.ts:13-24`), edited via `CardConfig.Modal` (`src/components/LightCard.tsx:267-274`).
 
 **States**: skeleton `124-126`; ErrorDisplay `129-138`; `on` styling amber-3 bg / amber-6 border, 2px border when selected/error/on (`191-193`).
 
 ### Scenarios (from the three LightCard test files)
 
-- **Toggle off→on**: GIVEN an off light, WHEN the card is clicked, THEN `light.turn_on` is called for the entity (`LightCard.test.tsx`, toggle test).
-- **Brightness commit**: GIVEN an on light at 100%, WHEN the slider is dragged to 50% and released, THEN `turn_on` is called with `brightness ≈ 128` (`LightCard.tsx:66-81`; `LightCard.brightness.test.tsx`).
-- **Commit 0 turns off**: GIVEN an on light, WHEN brightness is committed at 0, THEN `light.turn_off` is called instead of `turn_on` (`LightCard.tsx:72-76`).
-- **Slider hidden in edit mode**: GIVEN edit mode, WHEN the on light renders, THEN no brightness slider appears (`LightCard.tsx:222`; `LightCard.slider-usability.test.tsx`).
+- **Toggle off→on**: GIVEN an off light, WHEN the card is clicked, THEN `light.turn_on` is called for the entity (`src/components/__tests__/LightCard.test.tsx`, toggle test).
+- **Brightness commit**: GIVEN an on light at 100%, WHEN the slider is dragged to 50% and released, THEN `turn_on` is called with `brightness ≈ 128` (`src/components/LightCard.tsx:66-81`; `src/components/__tests__/LightCard.brightness.test.tsx`).
+- **Commit 0 turns off**: GIVEN an on light, WHEN brightness is committed at 0, THEN `light.turn_off` is called instead of `turn_on` (`src/components/LightCard.tsx:72-76`).
+- **Slider hidden in edit mode**: GIVEN edit mode, WHEN the on light renders, THEN no brightness slider appears (`src/components/LightCard.tsx:222`; `src/components/__tests__/LightCard.slider-usability.test.tsx`).
 - **No slider without brightness support**: GIVEN a light whose `supported_color_modes` is `['onoff']`, THEN the slider is not rendered (`87-102`).
 
 ## Climate
@@ -58,7 +58,7 @@ Cards without declared `defaultDimensions` fall back to `{ width: 2, height: 2 }
 
 **Sizing**: arc radius 50/70/90; container `minHeight` 220/280/320px (`282`, `482`). All controls hidden in edit mode. No config modal (`cardConfigurations` has a placeholder only, `25-29`).
 
-### Scenarios (`ClimateCard.test.tsx`)
+### Scenarios (`src/components/ClimateCard.test.tsx`)
 
 - **Increase setpoint**: GIVEN `heat` at 21, step 0.5, WHEN increase clicked, THEN `set_temperature { temperature: 21.5 }` (`127-156`).
 - **Min limit disables decrease**: GIVEN temp 7 with `min_temp: 7`, THEN the decrease button is disabled (`189-210`).
@@ -77,7 +77,7 @@ Cards without declared `defaultDimensions` fall back to `{ width: 2, height: 2 }
 
 **Sizing**: button size 1/2/3; container `minHeight` 160/180/200px (`264`) — but the test asserts 60/80/100px (see index Open Questions). Controls hidden in edit mode; no config modal.
 
-**Scenarios** (`CoverCard.test.tsx`):
+**Scenarios** (`src/components/CoverCard.test.tsx`):
 
 - **Open**: GIVEN `supported_features: 1`, WHEN "Open cover" clicked, THEN `open_cover` no-data (`139-159`).
 - **State-based disable**: GIVEN `closed` at position 0 with features 3, THEN open enabled and close disabled (`207-222`).
@@ -99,7 +99,7 @@ Cards without declared `defaultDimensions` fall back to `{ width: 2, height: 2 }
 
 **Icon by `device_class`** (`getSensorIcon`, `35-65`): temperature→Value, humidity→Circle, motion/occupancy/moving→ActivityLog, power/energy/current/voltage→LightningBolt, pressure→Mix, timestamp/duration→Clock, default→Home. Icon size 24/20/16; value font 2/3/4; container `minHeight` 120/100/80px. No config modal, no `onConfigure`.
 
-**Scenarios** (`__tests__/SensorCard.test.tsx`):
+**Scenarios** (`src/components/__tests__/SensorCard.test.tsx`):
 
 - Temperature `21.5` °C → `21.5 °C` with friendly name.
 - Power `1250` W → `1.3 kW`.
@@ -114,28 +114,28 @@ Cards without declared `defaultDimensions` fall back to `{ width: 2, height: 2 }
 
 `on = entity.state === 'on'` (`74`). Icon resolution (`64-71`): `config.onIcon`/`config.offIcon` → `device_class` default pair (`getDefaultIcons`, `23-44`) → `getTablerIcon || getIcon || (isOn ? CircleCheck : Circle)`. Device-class defaults include occupancy, door/window, motion, moisture, lock, safety, smoke, sound, vibration, light. Status text is `entity.state.toUpperCase()`. `on` uses amber background/border (2px) and amber icon/text.
 
-**Config**: `onIcon` (default `CircleCheck`) / `offIcon` (default `Circle`), both `icon`-type (`cardConfigurations.ts:59-76`); wires `onConfigure`, `hasConfiguration={!!item}`, and a `CardConfig.Modal` saving to `item.config`. States mirror SensorCard (skeleton / ErrorDisplay / unavailable). The icon `useMemo` runs before early returns to keep hook order stable.
+**Config**: `onIcon` (default `CircleCheck`) / `offIcon` (default `Circle`), both `icon`-type (`src/components/configurations/cardConfigurations.ts:59-76`); wires `onConfigure`, `hasConfiguration={!!item}`, and a `CardConfig.Modal` saving to `item.config`. States mirror SensorCard (skeleton / ErrorDisplay / unavailable). The icon `useMemo` runs before early returns to keep hook order stable.
 
 ## Weather
 
-Variant selection: `config.variant || config.preset || 'default'` (`WeatherCard/index.tsx:248`); saving migrates `preset` → `variant` (`268-282`). Variants registered on first render via `registerCardVariant` (`15-22`).
+Variant selection: `config.variant || config.preset || 'default'` (`src/components/WeatherCard/index.tsx:248`); saving migrates `preset` → `variant` (`268-282`). Variants registered on first render via `registerCardVariant` (`15-22`).
 
 **Per-variant attributes and display:**
 
-| Variant                              | Reads                                                 | Displays                                                                 | Background                          |
-| ------------------------------------ | ----------------------------------------------------- | ------------------------------------------------------------------------ | ----------------------------------- |
-| Default (`WeatherCardDefault.tsx`)   | temperature, humidity, temperature_unit               | emoji icon, temp (Thermometer), humidity % (Droplets), capitalized state | Yes; `backdrop` off when bg present |
-| Modern (`WeatherCardModern.tsx`)     | temperature, humidity, temperature_unit               | lucide icon, large temp, "{humidity}% humidity", state                   | Yes; emphasis text shadow           |
-| Detailed (`WeatherCardDetailed.tsx`) | temperature, humidity, **pressure**, temperature_unit | labeled Temperature/Humidity/Pressure rows (`{round(pressure)} hPa`)     | Yes; header icon does not whiten    |
-| Minimal (`WeatherCardMinimal.tsx`)   | temperature, temperature_unit only                    | name, large temp, state                                                  | No — `transparent`, no icon         |
+| Variant                                                         | Reads                                                 | Displays                                                                 | Background                          |
+| --------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------ | ----------------------------------- |
+| Default (`src/components/WeatherCard/WeatherCardDefault.tsx`)   | temperature, humidity, temperature_unit               | emoji icon, temp (Thermometer), humidity % (Droplets), capitalized state | Yes; `backdrop` off when bg present |
+| Modern (`src/components/WeatherCard/WeatherCardModern.tsx`)     | temperature, humidity, temperature_unit               | lucide icon, large temp, "{humidity}% humidity", state                   | Yes; emphasis text shadow           |
+| Detailed (`src/components/WeatherCard/WeatherCardDetailed.tsx`) | temperature, humidity, **pressure**, temperature_unit | labeled Temperature/Humidity/Pressure rows (`{round(pressure)} hPa`)     | Yes; header icon does not whiten    |
+| Minimal (`src/components/WeatherCard/WeatherCardMinimal.tsx`)   | temperature, temperature_unit only                    | name, large temp, state                                                  | No — `transparent`, no icon         |
 
 **Temperature unit** (duplicated `convertTemperature` + `getTemperatureDisplay` in each variant): native unit inferred from whether `temperature_unit` contains `f`; `auto` shows native, `celsius`/`fahrenheit` convert (C→F `t*9/5+32`, F→C `(t-32)*5/9`); value is `Math.round(...)`.
 
 **Condition→icon**: Default uses emoji (`☀️ 🌧️ ☁️ ❄️ ⛈️`, fallback `🌤️`); Modern/Detailed use lucide (`Sun`, `CloudRain`, `CloudDrizzle`, `CloudSnow`, `Zap`, fallback `Cloud`); Minimal none.
 
-**Backgrounds (PR #140)**: `getWeatherBackground(condition)` (`index.tsx:136-232`) maps Pirate-Weather icon names and common HA conditions to one of 10 PNGs under `public/weather-backgrounds/` (`clear-day`, `clear-night`, `rain`, `snow`, `sleet`, `wind`, `fog`, `cloudy`, `partly-cloudy-day`, `partly-cloudy-night`), with partial-match fallbacks, returning `null` when nothing matches. URLs are prefixed by `getAssetBaseUrl()` → `window.__LIEBE_ASSET_BASE_URL__` or `/` (`123-133`). When a background exists, `getWeatherTextStyles`/`getWeatherTextColor` switch text to white with shadows and icons to white with drop-shadow.
+**Backgrounds (PR #140)**: `getWeatherBackground(condition)` (`src/components/WeatherCard/index.tsx:136-232`) maps Pirate-Weather icon names and common HA conditions to one of 10 PNGs under `public/weather-backgrounds/` (`clear-day`, `clear-night`, `rain`, `snow`, `sleet`, `wind`, `fog`, `cloudy`, `partly-cloudy-day`, `partly-cloudy-night`), with partial-match fallbacks, returning `null` when nothing matches. URLs are prefixed by `getAssetBaseUrl()` → `window.__LIEBE_ASSET_BASE_URL__` or `/` (`123-133`). When a background exists, `getWeatherTextStyles`/`getWeatherTextColor` switch text to white with shadows and icons to white with drop-shadow.
 
-**Scenarios** (`WeatherCard.test.tsx`):
+**Scenarios** (`src/components/WeatherCard.test.tsx`):
 
 - Unit conversion: 22°C default → `22°C`; with `temperatureUnit: 'fahrenheit'` → `72°F` (`44-50`).
 - Preset backwards-compat: `preset: 'minimal' | 'detailed' | 'modern'` render the matching variant (`53-84`).
@@ -147,7 +147,7 @@ Variant selection: `config.variant || config.preset || 'default'` (`WeatherCard/
 
 ## Input helper cards
 
-Shared plumbing: `useEntity` + `useServiceCall`; title fallback `friendly_name || entity_id.split('.')[1]`; uniform skeleton / ErrorDisplay / unavailable states; error state = `grid-card-error`, red 2px border, error string as `title`. `useServiceCall.setValue` maps `input_number`/`input_text` → `set_value { value }` and `input_select` → `select_option { option }` (`hooks/useServiceCall.ts:150-179`); there is **no** `input_datetime` branch.
+Shared plumbing: `useEntity` + `useServiceCall`; title fallback `friendly_name || entity_id.split('.')[1]`; uniform skeleton / ErrorDisplay / unavailable states; error state = `grid-card-error`, red 2px border, error string as `title`. `useServiceCall.setValue` maps `input_number`/`input_text` → `set_value { value }` and `input_select` → `select_option { option }` (`src/hooks/useServiceCall.ts:150-179`); there is **no** `input_datetime` branch.
 
 ### InputBooleanCard
 
@@ -178,13 +178,13 @@ Shared plumbing: `useEntity` + `useServiceCall`; title fallback `friendly_name |
 
 ## Button and fallback card
 
-`ButtonCard` (`switch` + fallback, 2×1). Toggles via `useServiceCall.toggle` on click, guarded against loading/unavailable (`63-72`). Icon by domain: light→Sun, switch→LightningBolt, input_boolean→Check, default→LightningBolt (`17-30`). `on` styling amber-3/amber-6, 2px border. Status shows `ERROR` on failure or the uppercased state. No config modal. Scenario (`ButtonCard.test.tsx`): clicking an on switch calls `toggle` for the entity.
+`ButtonCard` (`switch` + fallback, 2×1). Toggles via `useServiceCall.toggle` on click, guarded against loading/unavailable (`63-72`). Icon by domain: light→Sun, switch→LightningBolt, input_boolean→Check, default→LightningBolt (`17-30`). `on` styling amber-3/amber-6, 2px border. Status shows `ERROR` on failure or the uppercased state. No config modal. Scenario (`src/components/__tests__/ButtonCard.test.tsx`): clicking an on switch calls `toggle` for the entity.
 
 ## Text and separator widgets
 
 ### TextCard (grid type `text`, 3×2)
 
-- Renders Markdown via `react-markdown` with Radix components for h1–h3/p/strong/em/ul/ol/li/code/blockquote. Props resolve `config?.X || propX || default` (`TextCard.tsx:35-38`): `content`, `alignment` (left/center/right), `textSize` (small/medium/large → Radix 1/2/3), `textColor` (`default` → undefined, else Radix color). Note the `||` chains treat valid falsy values as absent — clearing `content` to an empty string falls back to the placeholder. Fixing this to nullish semantics is tracked in [0002-repo-hygiene](../../changes/0002-repo-hygiene.md).
+- Renders Markdown via `react-markdown` with Radix components for h1–h3/p/strong/em/ul/ol/li/code/blockquote. Props resolve `config?.X || propX || default` (`src/components/TextCard.tsx:35-38`): `content`, `alignment` (left/center/right), `textSize` (small/medium/large → Radix 1/2/3), `textColor` (`default` → undefined, else Radix color). Note the `||` chains treat valid falsy values as absent — clearing `content` to an empty string falls back to the placeholder. Fixing this to nullish semantics is tracked in [0002-repo-hygiene](../../changes/0002-repo-hygiene.md).
 - Edit mode renders an auto-focused `TextArea`; `handleContentChange` persists live via `dashboardActions.updateGridItem(currentScreenId, itemId, { content })` (`80-91`). `onDelete`/`onConfigure` are accepted but unused. No entity binding → no loading/error states. Config is edited through `CardConfig` as direct item properties.
 
 ### Separator (grid type `separator`, 4×1)
@@ -193,11 +193,11 @@ Shared plumbing: `useEntity` + `useServiceCall`; title fallback `friendly_name |
 
 ## Configuration modal (CardConfig)
 
-`CardConfig.Modal` (`CardConfig.tsx:407-533`) is a 900px two-pane dialog. Left pane: `Content` builds a form from `cardConfigurations[cardType].definition` via `Component`, rendering one control per `ConfigOption` type — boolean (`Switch`), string (`TextField`), textarea (`TextArea`), number (`TextField type=number` reverting empty to default), select (`Select`), icon (`IconSelect`) (`90-229`). Right pane: `Preview` renders the live card inside `ViewModeWrapper` (temporarily forces store mode `view`, restores on unmount) with `pointer-events: none` (`296-405`) — implemented for weather, light, binary_sensor, text, and separator; other types show a "Preview not available" note.
+`CardConfig.Modal` (`src/components/CardConfig.tsx:407-533`) is a 900px two-pane dialog. Left pane: `Content` builds a form from `cardConfigurations[cardType].definition` via `Component`, rendering one control per `ConfigOption` type — boolean (`Switch`), string (`TextField`), textarea (`TextArea`), number (`TextField type=number` reverting empty to default), select (`Select`), icon (`IconSelect`) (`90-229`). Right pane: `Preview` renders the live card inside `ViewModeWrapper` (temporarily forces store mode `view`, restores on unmount) with `pointer-events: none` (`296-405`) — implemented for weather, light, binary_sensor, text, and separator; other types show a "Preview not available" note.
 
 Local config initializes from the item (`text`/`separator` from direct properties, else `item.config`), updates on change, and persists only on "Save Changes" — `text`/`separator` are saved as direct properties, entity cards under `config` (`407-460`).
 
-**Scenarios** (`__tests__/CardConfig.test.tsx`):
+**Scenarios** (`src/components/__tests__/CardConfig.test.tsx`):
 
 - Weather config renders a variant select and opens/selects it (`60-129`).
 - Save persists the chosen config (`130-170`); temperature-unit select works (`171-207`).
@@ -206,9 +206,9 @@ Local config initializes from the item (`text`/`separator` from direct propertie
 
 ## Entity discovery (EntityBrowser)
 
-`EntityBrowser` (`EntityBrowser.tsx`) is a fullscreen modal with Entities and Cards tabs. `EntitiesBrowserTab` virtualizes the list (`@tanstack/react-virtual`, 64px rows), debounces search 300ms over id/friendly-name/domain, filters `SYSTEM_DOMAINS` (`persistent_notification`, `person`, `sun`, `zone`, `EntitiesBrowserTab.tsx:66`), and pre-excludes domains not in `SUPPORTED_DOMAINS` (`77-92`). `getFriendlyDomain` maps domains to display names (`41-63`). Adding creates one `GridItem` per selected entity, each sized by `getDefaultCardDimensions` and positioned via `findOptimalPositionsForBatch` (`278-337`). `CardsBrowserTab` adds Text and Separator widgets (Separator via a configuration dialog).
+`EntityBrowser` (`src/components/EntityBrowser.tsx`) is a fullscreen modal with Entities and Cards tabs. `EntitiesBrowserTab` virtualizes the list (`@tanstack/react-virtual`, 64px rows), debounces search 300ms over id/friendly-name/domain, filters `SYSTEM_DOMAINS` (`persistent_notification`, `person`, `sun`, `zone`, `src/components/EntitiesBrowserTab.tsx:66`), and pre-excludes domains not in `SUPPORTED_DOMAINS` (`77-92`). `getFriendlyDomain` maps domains to display names (`41-63`). Adding creates one `GridItem` per selected entity, each sized by `getDefaultCardDimensions` and positioned via `findOptimalPositionsForBatch` (`278-337`). `CardsBrowserTab` adds Text and Separator widgets (Separator via a configuration dialog).
 
-**Scenarios** (`__tests__/EntityBrowser.test.tsx`):
+**Scenarios** (`src/components/__tests__/EntityBrowser.test.tsx`):
 
 - Renders/omits the dialog by `open` (`111-123`); shows both tabs (`124`).
 - Groups entities by domain (`131`); filters out system domains (`144`); search filters the list (`150-172`).

--- a/docs/specs/grid-layout/index.md
+++ b/docs/specs/grid-layout/index.md
@@ -8,7 +8,7 @@ The grid layout system renders each dashboard screen as a responsive, react-grid
 
 Liebe organises a dashboard into a tree of screens; each screen of type `grid` carries a `grid` object with a `resolution` (`{ columns, rows }`) and an ordered array of `GridItem`s (`src/store/types.ts:27`). The grid layout system is the rendering and interaction layer that turns those stored items into a live, editable canvas.
 
-Rendering flows top-down: `Dashboard.tsx` selects the current screen and, when it has items, renders `GridView` (`src/components/Dashboard.tsx:94`). `GridView` owns selection/delete/config UI state and dispatches each item to the correct card via a render-prop child, while delegating the actual grid mechanics to `GridLayoutSection`, which wraps `react-grid-layout`. Shared card chrome (selection border, delete/configure buttons, loading/error/stale states, fullscreen overlay) lives in `GridCard`. Supporting pure utilities compute new-item placement (`gridPositioning.ts`), compaction (`gridPacking.ts`), and default card sizes (`cardDimensions.ts`).
+Rendering flows top-down: `src/components/Dashboard.tsx` selects the current screen and, when it has items, renders `GridView` (`src/components/Dashboard.tsx:94`). `GridView` owns selection/delete/config UI state and dispatches each item to the correct card via a render-prop child, while delegating the actual grid mechanics to `GridLayoutSection`, which wraps `react-grid-layout`. Shared card chrome (selection border, delete/configure buttons, loading/error/stale states, fullscreen overlay) lives in `GridCard`. Supporting pure utilities compute new-item placement (`src/utils/gridPositioning.ts`), compaction (`src/utils/gridPacking.ts`), and default card sizes (`src/utils/cardDimensions.ts`).
 
 This spec is the living baseline of the grid layout system as implemented. Entity card internals are out of scope (see `../entity-cards/`); store mutation and persistence semantics are out of scope (see `../dashboard-config/`).
 
@@ -36,7 +36,7 @@ This spec is the living baseline of the grid layout system as implemented. Entit
 
 - **GIVEN** a grid with items `item-1`, `item-2`, `item-3`
 - **WHEN** the `items` prop is re-ordered
-- **THEN** each item is still rendered under its original id (`GridLayoutSection.test.tsx:248`)
+- **THEN** each item is still rendered under its original id (`src/components/__tests__/GridLayoutSection.test.tsx:248`)
 
 ### Item-Type Dispatch
 
@@ -102,25 +102,25 @@ This spec is the living baseline of the grid layout system as implemented. Entit
 
 - **GIVEN** an item `{ id: 'item-1', x: 0, y: 0, width: 2, height: 2 }` at desktop resolution
 - **WHEN** `GridLayoutSection` builds the layout
-- **THEN** the emitted entry matches `{ i: 'item-1', x: 0, y: 0, w: 2, h: 2, minW: 1, minH: 1, isDraggable: true, isResizable: true }` (`GridLayoutSection.test.tsx:141`)
+- **THEN** the emitted entry matches `{ i: 'item-1', x: 0, y: 0, w: 2, h: 2, minW: 1, minH: 1, isDraggable: true, isResizable: true }` (`src/components/__tests__/GridLayoutSection.test.tsx:141`)
 
 #### Scenario: Edit mode enables interaction
 
 - **GIVEN** `isEditMode` is true
 - **WHEN** the grid renders
-- **THEN** the react-grid-layout is draggable and resizable (`GridLayoutSection.test.tsx:154`)
+- **THEN** the react-grid-layout is draggable and resizable (`src/components/__tests__/GridLayoutSection.test.tsx:154`)
 
 #### Scenario: View mode disables interaction
 
 - **GIVEN** `isEditMode` is false
 - **WHEN** the grid renders
-- **THEN** the grid is neither draggable nor resizable (`GridLayoutSection.test.tsx:162`)
+- **THEN** the grid is neither draggable nor resizable (`src/components/__tests__/GridLayoutSection.test.tsx:162`)
 
 #### Scenario: Whole card is the drag surface
 
 - **GIVEN** the grid is in edit mode
 - **WHEN** it renders
-- **THEN** no `draggableHandle` is set (`GridLayoutSection.test.tsx:170`)
+- **THEN** no `draggableHandle` is set (`src/components/__tests__/GridLayoutSection.test.tsx:170`)
 
 ### Responsive Column Scaling
 
@@ -138,7 +138,7 @@ This spec is the living baseline of the grid layout system as implemented. Entit
 
 - **GIVEN** a mounted grid
 - **WHEN** the container mounts and later unmounts
-- **THEN** a `ResizeObserver` observes the container and is disconnected on unmount (`GridLayoutSection.test.tsx:261`)
+- **THEN** a `ResizeObserver` observes the container and is disconnected on unmount (`src/components/__tests__/GridLayoutSection.test.tsx:261`)
 
 ### Layout-Change Persistence
 
@@ -149,13 +149,13 @@ This spec is the living baseline of the grid layout system as implemented. Entit
 
 - **GIVEN** `item-1` at `x: 0` is dragged to `x: 1`
 - **WHEN** `onLayoutChange` fires
-- **THEN** `updateGridItem('screen-1', 'item-1', { x: 1, y: 0, width: 2, height: 2 })` is called (`GridLayoutSection.test.tsx:178`)
+- **THEN** `updateGridItem('screen-1', 'item-1', { x: 1, y: 0, width: 2, height: 2 })` is called (`src/components/__tests__/GridLayoutSection.test.tsx:178`)
 
 #### Scenario: Only changed items update
 
 - **GIVEN** a layout change touching a single item
 - **WHEN** `onLayoutChange` fires
-- **THEN** `updateGridItem` is called exactly once (`GridLayoutSection.test.tsx:196`)
+- **THEN** `updateGridItem` is called exactly once (`src/components/__tests__/GridLayoutSection.test.tsx:196`)
 
 ### Card Chrome (GridCard)
 
@@ -252,13 +252,13 @@ This spec is the living baseline of the grid layout system as implemented. Entit
 
 - **GIVEN** entity `weather.home`
 - **WHEN** `getDefaultCardDimensions` runs
-- **THEN** it returns `{ width: 4, height: 3 }` from `WeatherCard.defaultDimensions` (`cardDimensions.test.ts:23`)
+- **THEN** it returns `{ width: 4, height: 3 }` from `WeatherCard.defaultDimensions` (`src/utils/__tests__/cardDimensions.test.ts:23`)
 
 #### Scenario: Unknown domain default size
 
 - **GIVEN** entity `unknown.something`
 - **WHEN** `getDefaultCardDimensions` runs
-- **THEN** it returns `{ width: 2, height: 2 }` (`cardDimensions.test.ts:49`)
+- **THEN** it returns `{ width: 2, height: 2 }` (`src/utils/__tests__/cardDimensions.test.ts:49`)
 
 ### Touch-First Sizing
 
@@ -394,7 +394,7 @@ item.width >= 4 && item.height >= 3
 
 ## Open Questions
 
-- **`gridPacking.ts` and `gridPositioning.ts` have no direct unit tests.** Their behavior (overlap avoidance, compaction, batch threading) is asserted only indirectly through store/UI usage. `packGridItems` (the simple top-left variant) currently has no callers — only `packGridItemsCompact` is used (by `reorderGrid`, `src/store/dashboardStore.ts:393`); the simple variant may be dead code.
+- **`src/utils/gridPacking.ts` and `src/utils/gridPositioning.ts` have no direct unit tests.** Their behavior (overlap avoidance, compaction, batch threading) is asserted only indirectly through store/UI usage. `packGridItems` (the simple top-left variant) currently has no callers — only `packGridItemsCompact` is used (by `reorderGrid`, `src/store/dashboardStore.ts:393`); the simple variant may be dead code.
 - **Duplicated size ternary.** The `large`/`medium`/`small` threshold logic is copy-pasted four times in `GridView` (text, separator, entity, plus the `EntityCard` call site) with no shared helper — a change to thresholds must be made in every copy. A `sizeFromDimensions(width, height)` utility would remove the duplication.
 - **Round-trip coordinate drift.** Scaling `x`/`width` down for a responsive breakpoint and back up on `onLayoutChange` uses `Math.round` in both directions; on `mobile`/`tablet` breakpoints a drag can persist coordinates that differ from a pure identity round-trip. No test currently pins this behavior.
 - **`Separator` size prop is inert.** `GridView` computes and passes a `size` to `Separator`, but `Separator` destructures it as `size: _size` and never uses it (text sizing is derived only from orientation, `src/components/Separator.tsx:37`).

--- a/docs/specs/navigation/index.md
+++ b/docs/specs/navigation/index.md
@@ -143,25 +143,25 @@ When embedded in a Home Assistant panel, the app MUST bridge its internal router
 
 - **GIVEN** the app is at a panel path and mounted
 - **WHEN** the router resolves a navigation (the `onResolved` callback fires)
-- **THEN** a `liebe-route-change` event is dispatched with `detail.path` equal to the router's current pathname (`useHomeAssistantRouting.test.ts:81`).
+- **THEN** a `liebe-route-change` event is dispatched with `detail.path` equal to the router's current pathname (`src/hooks/__tests__/useHomeAssistantRouting.test.ts:81`).
 
 #### Scenario: Inbound navigation from the panel element
 
 - **GIVEN** the app is at a panel path and mounted
 - **WHEN** a `liebe-navigate` event fires with `detail.path = '/custom-path'`
-- **THEN** the hook calls `router.navigate({ to: '/custom-path' })` (`useHomeAssistantRouting.test.ts:106`).
+- **THEN** the hook calls `router.navigate({ to: '/custom-path' })` (`src/hooks/__tests__/useHomeAssistantRouting.test.ts:106`).
 
 #### Scenario: No-op outside Home Assistant
 
 - **GIVEN** the pathname is `/some-other-path`
 - **WHEN** the hook mounts
-- **THEN** it neither subscribes to the router nor registers a `liebe-navigate` listener (`useHomeAssistantRouting.test.ts:146`).
+- **THEN** it neither subscribes to the router nor registers a `liebe-navigate` listener (`src/hooks/__tests__/useHomeAssistantRouting.test.ts:146`).
 
 #### Scenario: Cleanup on unmount
 
 - **GIVEN** the hook is mounted at a panel path
 - **WHEN** the component unmounts
-- **THEN** the `liebe-navigate` listener is removed (`useHomeAssistantRouting.test.ts:128`).
+- **THEN** the `liebe-navigate` listener is removed (`src/hooks/__tests__/useHomeAssistantRouting.test.ts:128`).
 
 ### Environment detection
 


### PR DESCRIPTION
## Summary

Follow-up to the baseline docs PR addressing Copilot review feedback that was left unresolved at merge time: spec documents referenced files with bare or shortened names (`useHomeAssistantRouting.test.ts`, `ui/FullscreenModal.tsx`, `LightCard.tsx:293`), breaking the docs' own "every claim is referenced to `path:line`" convention.

- `docs/specs/navigation/index.md` — four test references now use `src/hooks/__tests__/useHomeAssistantRouting.test.ts`
- `docs/specs/grid-layout/index.md` — test references now repo-relative (`src/components/__tests__/...`)
- `docs/specs/camera-streaming/index.md` — all `CameraCard.tsx`/`useWebRTC.ts`/`FullscreenModal.tsx` references now repo-relative
- `docs/specs/entity-cards/card-reference.md` — table references repo-relative and backticked; the `path:line` claim now states the section-scoped shorthand explicitly

Every rewritten path was verified to exist on disk.

## Test plan

- [x] `npx prettier --check` clean on touched files
- [x] All referenced paths verified to exist
- [x] Docs-only change; no runtime surface