### PR TITLE
refactor(config): define canonical portable configuration contract

### DIFF
--- a/docs/changes/0004-portable-config-contract.md
+++ b/docs/changes/0004-portable-config-contract.md
@@ -5,7 +5,7 @@
 Define one canonical set of portable (shareable/exportable) dashboard-configuration fields and make `DashboardConfig`, the JSON export, the YAML export, and dirty-tracking all follow it. Closes the contract inconsistencies documented in the [Dashboard Config](../specs/dashboard-config/) spec's Open Questions.
 
 **Spec:** [Dashboard Config](../specs/dashboard-config/)
-**Status:** draft
+**Status:** complete
 **Depends On:** —
 
 ## Motivation
@@ -56,7 +56,9 @@ Decide the canonical set first (see Open Questions), then align in one PR: `Dash
 
 ### Decisions
 
-- **Decision**: Deferred until the canonical set is chosen (Open Question below).
+- **Decision**: Adopted the default proposal as the canonical portable set. Portable (in `DashboardConfig`, JSON export, YAML export, import, and dirty-tracking): `version`, `screens`, `theme`, `sidebarOpen`, `tabsExpanded`, `sidebarWidgets`. Device-local (never in the portable document, never marks dirty): `mode` (persisted under `liebe-mode`) and the top-level `gridResolution` (per-screen `grid.resolution` still round-trips).
+- **Decision**: No version bump. The portable shape only gained optional fields, so existing current-version JSON/YAML exports remain importable unchanged; `checkVersionCompatibility` is untouched.
+- **Decision**: `importConfigurationFromFile` persists the resolved exported config (not the raw import) so an imported file that omits an optional portable field keeps the store's fallback value across reloads.
 
 ### Non-Goals
 
@@ -65,11 +67,11 @@ Decide the canonical set first (see Open Questions), then align in one PR: `Dash
 
 ## Tasks
 
-- [ ] Decide canonical portable set, align types/exports/imports/dirty-tracking, add round-trip and dirty-tracking tests, sync the dashboard-config spec
+- [x] Decide canonical portable set, align types/exports/imports/dirty-tracking, add round-trip and dirty-tracking tests, sync the dashboard-config spec
 
 ## Open Questions
 
-- [ ] Canonical set: are `sidebarWidgets` and `tabsExpanded` shareable dashboard content (include everywhere) or device-local preference (exclude everywhere, stop dirty-marking)? Default proposal: `version`, `screens`, `theme`, `sidebarOpen`, `tabsExpanded`, `sidebarWidgets` portable; `mode` and top-level `gridResolution` device-local.
+- [x] Canonical set: are `sidebarWidgets` and `tabsExpanded` shareable dashboard content (include everywhere) or device-local preference (exclude everywhere, stop dirty-marking)? **Resolved — adopted the default proposal:** `version`, `screens`, `theme`, `sidebarOpen`, `tabsExpanded`, `sidebarWidgets` are portable (in `DashboardConfig`, JSON + YAML export, import, dirty-tracking); `mode` (persisted under `liebe-mode`) and the top-level `gridResolution` are device-local — excluded from the portable document and no longer mark it dirty. No version bump is needed: the portable shape only gained optional fields (`tabsExpanded` was already in `DashboardConfig`/JSON, `sidebarWidgets` is new and optional), so existing current-version JSON/YAML exports remain importable.
 
 ## References
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,4 +20,4 @@
 | 0001 | [Per-Entity Store Selectors](changes/0001-per-entity-store-selectors.md)          | [Entity State](specs/entity-state/)         | draft    | —          |
 | 0002 | [Repository Hygiene Bundle](changes/0002-repo-hygiene.md)                         | [Architecture](specs/architecture/)         | complete | —          |
 | 0003 | [Re-enable react-hooks v7 Lint Rules](changes/0003-reenable-react-hooks-rules.md) | [Architecture](specs/architecture/)         | draft    | —          |
-| 0004 | [Portable Configuration Contract](changes/0004-portable-config-contract.md)       | [Dashboard Config](specs/dashboard-config/) | draft    | —          |
+| 0004 | [Portable Configuration Contract](changes/0004-portable-config-contract.md)       | [Dashboard Config](specs/dashboard-config/) | complete | —          |

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -62,5 +62,5 @@ changes:
     path: changes/0004-portable-config-contract.md
     description: Define one canonical portable configuration field set and align types, exports, imports, and dirty-tracking
     spec: dashboard-config
-    status: draft
+    status: complete
     depends_on: []

--- a/docs/specs/dashboard-config/index.md
+++ b/docs/specs/dashboard-config/index.md
@@ -4,6 +4,8 @@
 
 The dashboard configuration subsystem owns the in-memory representation of a Liebe dashboard — the tree of screens, the current screen, view/edit mode, sidebar and theme state — and the persistence of that representation to `localStorage` and to portable JSON/YAML files. The store MUST be the single source of truth mutated exclusively through `dashboardActions`, and every mutation that changes shareable configuration MUST mark the state dirty so it can be auto-saved. The entire dashboard MUST be exportable as, and importable from, a single self-contained YAML (or JSON) document so a configuration can be shared or backed up as one file. Configuration import from untrusted files MUST validate at least the presence of a `version` string and a `screens` array before applying.
 
+The set of shareable fields is a single **canonical portable contract**: `version`, `screens`, `theme`, `sidebarOpen`, `tabsExpanded`, and `sidebarWidgets`. `DashboardConfig`, the JSON export, the YAML export, and import MUST all serialize exactly this set, and `isDirty` MUST be set by exactly the mutations that change one of these fields — no more, no fewer. Device-local state (`mode`, persisted separately under `liebe-mode`, and the top-level `gridResolution`) is deliberately outside the contract: it never travels with the portable document and never marks it dirty.
+
 This spec covers configuration _state and persistence_ only. Grid rendering and layout mechanics are specified in [../grid-layout/](../grid-layout/), the card components placed into grids in [../entity-cards/](../entity-cards/), and the sidebar/navigation UI structure in [../navigation/](../navigation/).
 
 ## Background
@@ -27,7 +29,7 @@ State is held in a TanStack `Store` (`dashboardStore`) and read through the `use
 
 ### Dirty Tracking & Auto-Save
 
-- Every action that changes shareable configuration (screens, grid items, theme, grid resolution, sidebar open/expanded, sidebar widgets, mode) MUST set `isDirty` to `true`.
+- Every action that changes a portable field (screens, grid items, theme, sidebar open/expanded, sidebar widgets) MUST set `isDirty` to `true`, and only those actions may. Device-local mutations — `setMode` and the top-level `setGridResolution` — MUST NOT set `isDirty`.
 - `markClean()` MUST set `isDirty` to `false` without otherwise altering state.
 - `loadConfiguration()` MUST leave `isDirty` `false` (a freshly loaded config is not a pending change).
 - `useDashboardPersistence()` MUST subscribe to the store and, whenever `isDirty` is true, write the exported configuration to `localStorage` and then call `markClean()`. `useAutoSave(interval)` MUST perform the same save-if-dirty check on a timer (default 5000 ms).
@@ -82,7 +84,7 @@ State is held in a TanStack `Store` (`dashboardStore`) and read through the `use
 
 ### Mode Toggle & Persistence
 
-- `setMode(mode)` MUST update `mode`, set `isDirty` true, and asynchronously persist the raw mode string to `localStorage` under `liebe-mode` (via a deferred import to avoid a circular dependency).
+- `setMode(mode)` MUST update `mode` and asynchronously persist the raw mode string to `localStorage` under `liebe-mode` (via a deferred import to avoid a circular dependency). Because `mode` is device-local and outside the portable contract, `setMode` MUST NOT set `isDirty` (a mode toggle MUST NOT rewrite `liebe-config`).
 - `loadDashboardMode()` MUST return the stored mode only when it is exactly `'view'` or `'edit'`, and MUST default to `'view'` for a missing, invalid, or unreadable value.
 - The `ModeToggle` component MUST toggle between `view` and `edit` on click and on the `Ctrl/⌘ + E` keyboard shortcut (preventing that event's default), and MUST remove its key listener on unmount.
 
@@ -97,6 +99,12 @@ State is held in a TanStack `Store` (`dashboardStore`) and read through the `use
 - **GIVEN** the dashboard is in `view` mode and `ModeToggle` is mounted
 - **WHEN** the user presses `Ctrl+E`
 - **THEN** the default is prevented and `mode` becomes `edit`
+
+#### Scenario: Mode switch does not rewrite config
+
+- **GIVEN** a clean (non-dirty) dashboard
+- **WHEN** the user toggles view/edit mode
+- **THEN** `liebe-mode` is updated but `isDirty` stays `false` and `liebe-config` is not rewritten
 
 ### Theme Selection & Application
 
@@ -119,8 +127,8 @@ State is held in a TanStack `Store` (`dashboardStore`) and read through the `use
 ### Sidebar & Tabs State
 
 - `toggleSidebar(open?)` and `toggleTabsExpanded(expanded?)` MUST set the value explicitly when the argument is provided, otherwise invert the current value, and MUST set `isDirty` true.
-- `sidebarOpen` and `tabsExpanded` MUST be included in `exportConfiguration()` and restored by `loadConfiguration()`, but `loadConfiguration()` MUST fall back to the existing store value (via `??`) when the incoming config omits them.
-- The `sidebarWidgets` list is mutated by `updateSidebarWidgets`/`addSidebarWidget`/`removeSidebarWidget` (all set `isDirty` true) but is NOT part of the exported `DashboardConfig`. (Widget rendering belongs to [../navigation/](../navigation/).)
+- `sidebarOpen`, `tabsExpanded`, and `sidebarWidgets` MUST be included in `exportConfiguration()` and restored by `loadConfiguration()`, but `loadConfiguration()` MUST fall back to the existing store value (via `??`) when the incoming config omits them.
+- The `sidebarWidgets` list is mutated by `updateSidebarWidgets`/`addSidebarWidget`/`removeSidebarWidget` (all set `isDirty` true) and IS part of the portable `DashboardConfig`, so it round-trips through JSON and YAML export/import. (Widget rendering belongs to [../navigation/](../navigation/).)
 
 #### Scenario: Sidebar state round-trips through export
 
@@ -150,7 +158,7 @@ State is held in a TanStack `Store` (`dashboardStore`) and read through the `use
 ### File Export
 
 - `exportConfigurationToFile()` MUST download the current configuration as pretty-printed JSON named `liebe-<YYYY-MM-DD>.json`.
-- `exportConfigurationAsYAML()` MUST serialize `version`, `theme` (defaulting to `auto`), `sidebarOpen`, and `screens` — with leading comment keys — into a single YAML document; `exportConfigurationToYAMLFile()` downloads it as `liebe-<YYYY-MM-DD>.yaml`, and `copyYAMLToClipboard()` writes it to the clipboard.
+- `exportConfigurationAsYAML()` MUST serialize the full canonical portable set — `version`, `theme` (defaulting to `auto`), `sidebarOpen`, `tabsExpanded`, `sidebarWidgets`, and `screens` — with leading comment keys — into a single YAML document, matching the JSON export field-for-field; `exportConfigurationToYAMLFile()` downloads it as `liebe-<YYYY-MM-DD>.yaml`, and `copyYAMLToClipboard()` writes it to the clipboard.
 
 #### Scenario: YAML contains the whole dashboard
 
@@ -250,8 +258,11 @@ export interface DashboardConfig {
   theme?: 'light' | 'dark' | 'auto'
   sidebarOpen?: boolean
   tabsExpanded?: boolean
+  sidebarWidgets?: WidgetConfig[]
 }
 ```
+
+These six fields are the canonical portable contract: `exportConfiguration` (JSON) and `exportConfigurationAsYAML` serialize exactly this set, and the import paths validate these fields via `dashboardConfigSchema` while tolerating unknown extra keys (`.passthrough()`) for forward compatibility.
 
 Screens form a recursive tree (`src/store/types.ts:27`):
 
@@ -312,7 +323,7 @@ export interface DashboardState {
 }
 ```
 
-Note the divergence: `gridResolution`, `mode`, `currentScreenId`, `configuration`, and `sidebarWidgets` live in state but are NOT fields of `DashboardConfig`, so they are not part of the shared YAML. `mode` is persisted separately under `liebe-mode`.
+Note the divergence: `gridResolution`, `mode`, `currentScreenId`, and `configuration` live in state but are NOT fields of `DashboardConfig`, so they are not part of the shared YAML. `mode` is persisted separately under `liebe-mode`; the top-level `gridResolution` is reset to the 12×8 default on load. `sidebarWidgets` IS a portable field and does travel with the document.
 
 ### API Surface
 
@@ -320,7 +331,7 @@ Note the divergence: `gridResolution`, `mode`, `currentScreenId`, `configuration
 
 | Action                                                      | Effect                                       | Dirty           |
 | ----------------------------------------------------------- | -------------------------------------------- | --------------- |
-| `setMode(mode)`                                             | set mode; async-persist to `liebe-mode`      | ✓               |
+| `setMode(mode)`                                             | set mode; async-persist to `liebe-mode`      | —               |
 | `setCurrentScreen(id)`                                      | set `currentScreenId`                        | —               |
 | `addScreen(screen, parentId?)`                              | append top-level or into parent's children   | ✓               |
 | `removeScreen(id)`                                          | recursive delete; null current if matched    | ✓               |
@@ -329,7 +340,7 @@ Note the divergence: `gridResolution`, `mode`, `currentScreenId`, `configuration
 | `addGridItem/updateGridItem/removeGridItem`                 | grid item CRUD                               | ✓               |
 | `reorderGrid(id)`                                           | compact-pack items                           | ✓               |
 | `setTheme(theme)`                                           | set theme                                    | ✓               |
-| `setGridResolution(res)`                                    | set resolution                               | ✓               |
+| `setGridResolution(res)`                                    | set top-level resolution (device-local)      | —               |
 | `toggleSidebar/toggleTabsExpanded`                          | set-or-invert                                | ✓               |
 | `updateSidebarWidgets/addSidebarWidget/removeSidebarWidget` | widget list CRUD                             | ✓               |
 | `loadConfiguration(config)`                                 | replace tree/theme/sidebar; mode→view; clean | resets to false |
@@ -359,18 +370,14 @@ Storage keys (`src/store/persistence.ts:7`): `liebe-config`, `liebe-mode`, `lieb
 ## Constraints
 
 - **Radix Theme, no custom CSS** — theme is applied through the Radix `Theme` `appearance` prop, not bespoke stylesheets.
-- **Single-file portability** — a configuration MUST remain fully described by one `DashboardConfig` document so it can be exported/shared as one YAML (or JSON) file; anything not in `DashboardConfig` (mode, grid resolution, sidebar widgets, current screen) does not travel with that file.
+- **Single-file portability** — a configuration MUST remain fully described by one `DashboardConfig` document so it can be exported/shared as one YAML (or JSON) file; anything not in `DashboardConfig` (mode, top-level grid resolution, current screen) does not travel with that file.
 - **localStorage budget** — persistence targets a ~5 MB `localStorage` budget; `getStorageInfo` warns at 90 %.
 - **Store-only mutation** — components MUST NOT mutate store state directly; all writes go through `dashboardActions`.
 - **Backward compatibility on load** — older on-disk shapes MUST continue to load via migration rather than being rejected.
 
 ## Open Questions
 
-- **Import validation is shallow and trusts untyped input.** `parseConfigurationFromFile`/`importConfigurationFromFile` only check that `version` is truthy and `screens` is an array, then cast the parsed YAML/JSON to `DashboardConfig`. Individual `ScreenConfig`/`GridItem` fields are never validated, so a malformed-but-array `screens` payload from an untrusted file is loaded as-is. `zod` (`^3.24.2`) is a project dependency but is not imported anywhere in `src/` — schema validation of imported configurations is available but unused. Recursive schema validation of the full config (screens, nested children, grid items with bounds) is planned in [0002-repo-hygiene](../../changes/0002-repo-hygiene.md).
-- **`exportConfigurationAsYAML` drops `tabsExpanded`.** The YAML export serializes `version`, `theme`, `sidebarOpen`, and `screens`, but omits `tabsExpanded` even though it is part of `DashboardConfig` and is included in the JSON export. Whether this is intentional is unclear.
-- **`gridResolution` is state-only.** `loadConfiguration` always resets `gridResolution` to the 12×8 default and `exportConfiguration` never emits it, so a per-dashboard grid resolution is not actually persisted or shared. Only per-screen `grid.resolution` round-trips.
 - **`StoreActions` interface is stale.** The exported `StoreActions` type (`src/store/types.ts:72`) omits several actions that exist on `dashboardActions` (sidebar/tabs/widget toggles, `reorderGrid`) and types `updateScreen` more broadly than the implementation, which only patches `name`/`slug`.
-- **`setMode` marks the config dirty.** Toggling view/edit sets `isDirty` true (triggering a full config auto-save) in addition to writing `liebe-mode`, so a mode switch rewrites `liebe-config` even though mode is not part of that document.
 
 ## References
 
@@ -385,6 +392,7 @@ Storage keys (`src/store/persistence.ts:7`): `liebe-config`, `liebe-mode`, `lieb
 
 ## Changelog
 
-| Date       | Change                                                     | Document |
-| ---------- | ---------------------------------------------------------- | -------- |
-| 2026-07-18 | Initial spec created (baseline of existing implementation) | —        |
+| Date       | Change                                                                                                                                                          | Document                                               |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| 2026-07-18 | Initial spec created (baseline of existing implementation)                                                                                                      | —                                                      |
+| 2026-07-18 | Canonical portable contract: `sidebarWidgets` now portable, YAML carries `tabsExpanded`/`sidebarWidgets`, `setMode`/top-level `setGridResolution` stop dirtying | [0004](../../changes/0004-portable-config-contract.md) |

--- a/src/store/__tests__/portable-config-contract.test.ts
+++ b/src/store/__tests__/portable-config-contract.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { dashboardStore, dashboardActions } from '../dashboardStore'
+import {
+  exportConfigurationAsYAML,
+  importConfigurationFromFile,
+  saveDashboardConfig,
+} from '../persistence'
+import type { DashboardConfig, DashboardState, GridItem, WidgetConfig } from '../types'
+
+// Mock localStorage so import/save paths don't touch a real store.
+const localStorageMock = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+  length: 0,
+  key: vi.fn(),
+}
+Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+
+// The canonical portable set (see DashboardConfig / docs/specs/dashboard-config).
+// A dashboard whose portable fields are all non-default, so a dropped field
+// would show up as a round-trip mismatch.
+const richGridItem: GridItem = {
+  id: 'item-1',
+  type: 'entity',
+  entityId: 'light.kitchen',
+  x: 1,
+  y: 2,
+  width: 3,
+  height: 2,
+  config: { showName: true },
+}
+
+const richWidgets: WidgetConfig[] = [
+  { id: 'w1', type: 'clock', position: 0 },
+  { id: 'w2', type: 'weather', position: 1, config: { entity: 'weather.home' } },
+]
+
+const richState: DashboardState = {
+  mode: 'view',
+  screens: [
+    {
+      id: 'screen-1',
+      name: 'Living Room',
+      slug: 'living-room',
+      type: 'grid',
+      grid: {
+        resolution: { columns: 12, rows: 8 },
+        items: [richGridItem],
+      },
+    },
+  ],
+  currentScreenId: 'screen-1',
+  configuration: { version: '1.0.0', screens: [], theme: 'auto' },
+  gridResolution: { columns: 12, rows: 8 },
+  theme: 'dark',
+  isDirty: false,
+  sidebarOpen: true,
+  tabsExpanded: true,
+  sidebarWidgets: richWidgets,
+}
+
+// Exactly the fields DashboardConfig / exportConfiguration must carry.
+const PORTABLE_FIELDS = [
+  'version',
+  'screens',
+  'theme',
+  'sidebarOpen',
+  'tabsExpanded',
+  'sidebarWidgets',
+] as const
+
+describe('portable configuration contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dashboardStore.setState(() => ({ ...richState }))
+  })
+
+  describe('exportConfiguration serializes exactly the canonical set', () => {
+    it('emits every portable field and no device-local field', () => {
+      const config = dashboardActions.exportConfiguration()
+      expect(Object.keys(config).sort()).toEqual([...PORTABLE_FIELDS].sort())
+      // Device-local state must never leak into the portable document.
+      expect(config).not.toHaveProperty('mode')
+      expect(config).not.toHaveProperty('gridResolution')
+      expect(config).not.toHaveProperty('currentScreenId')
+    })
+  })
+
+  describe('JSON round-trip: export -> import -> deep-equal', () => {
+    it('reproduces every portable field', async () => {
+      const exported = dashboardActions.exportConfiguration()
+      const file = new File([JSON.stringify(exported, null, 2)], 'config.json', {
+        type: 'application/json',
+      })
+
+      // Mutate the live store away from the exported values before importing, so
+      // a no-op import can't accidentally pass.
+      dashboardStore.setState((s) => ({
+        ...s,
+        theme: 'light',
+        sidebarOpen: false,
+        tabsExpanded: false,
+        sidebarWidgets: [],
+        screens: [],
+      }))
+
+      await importConfigurationFromFile(file)
+
+      const reExported = dashboardActions.exportConfiguration()
+      expect(reExported).toEqual(exported)
+      for (const field of PORTABLE_FIELDS) {
+        expect(reExported[field]).toEqual(exported[field])
+      }
+    })
+  })
+
+  describe('YAML round-trip: export -> import -> deep-equal', () => {
+    it('reproduces every portable field', async () => {
+      const exported = dashboardActions.exportConfiguration()
+      const yamlStr = exportConfigurationAsYAML()
+
+      // YAML must carry the same portable fields as JSON.
+      expect(yamlStr).toContain('version:')
+      expect(yamlStr).toContain('theme:')
+      expect(yamlStr).toContain('sidebarOpen:')
+      expect(yamlStr).toContain('tabsExpanded:')
+      expect(yamlStr).toContain('sidebarWidgets:')
+      expect(yamlStr).toContain('screens:')
+
+      const file = new File([yamlStr], 'config.yaml', { type: 'application/x-yaml' })
+
+      dashboardStore.setState((s) => ({
+        ...s,
+        theme: 'light',
+        sidebarOpen: false,
+        tabsExpanded: false,
+        sidebarWidgets: [],
+        screens: [],
+      }))
+
+      await importConfigurationFromFile(file)
+
+      const reExported = dashboardActions.exportConfiguration()
+      expect(reExported).toEqual(exported)
+      for (const field of PORTABLE_FIELDS) {
+        expect(reExported[field]).toEqual(exported[field])
+      }
+    })
+  })
+
+  describe('JSON and YAML exports agree', () => {
+    it('carry the same portable fields', async () => {
+      const jsonConfig = dashboardActions.exportConfiguration()
+
+      const yamlStr = exportConfigurationAsYAML()
+      const yamlFile = new File([yamlStr], 'config.yaml', { type: 'application/x-yaml' })
+      await importConfigurationFromFile(yamlFile)
+      const fromYaml = dashboardActions.exportConfiguration()
+
+      expect(fromYaml).toEqual(jsonConfig)
+    })
+  })
+
+  describe('backward compatibility with existing exports', () => {
+    it('imports a current-version config lacking the newly-added fields', async () => {
+      // A pre-contract export: no tabsExpanded, no sidebarWidgets.
+      const legacy: DashboardConfig = {
+        version: '1.0.0',
+        screens: richState.screens,
+        theme: 'dark',
+        sidebarOpen: true,
+      }
+      const file = new File([JSON.stringify(legacy)], 'legacy.json', {
+        type: 'application/json',
+      })
+
+      await expect(importConfigurationFromFile(file)).resolves.toBeUndefined()
+      expect(dashboardStore.state.screens).toHaveLength(1)
+      expect(dashboardStore.state.theme).toBe('dark')
+      // The current (non-default) widgets are preserved in memory via the `??`
+      // fallback since the legacy file omits sidebarWidgets.
+      expect(dashboardStore.state.sidebarWidgets).toEqual(richWidgets)
+    })
+
+    it('persists the resolved portable config (not the raw legacy import) to liebe-config', async () => {
+      // A pre-contract export omitting sidebarWidgets. The store already holds
+      // non-default widgets that the fallback must preserve AND persist.
+      const legacy: DashboardConfig = {
+        version: '1.0.0',
+        screens: richState.screens,
+        theme: 'dark',
+        sidebarOpen: true,
+      }
+      const file = new File([JSON.stringify(legacy)], 'legacy.json', {
+        type: 'application/json',
+      })
+
+      await importConfigurationFromFile(file)
+
+      const configCall = localStorageMock.setItem.mock.calls.find(([key]) => key === 'liebe-config')
+      expect(configCall).toBeDefined()
+      const persisted = JSON.parse(configCall![1] as string) as DashboardConfig
+      // Reloading from this persisted value must restore the same widgets, so it
+      // MUST contain the resolved fallback rather than the legacy shape.
+      expect(persisted.sidebarWidgets).toEqual(richWidgets)
+      expect(persisted.tabsExpanded).toBe(richState.tabsExpanded)
+    })
+  })
+})
+
+describe('dirty tracking follows the portable contract', () => {
+  const baseWidget: WidgetConfig = { id: 'w', type: 'clock', position: 0 }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dashboardStore.setState(() => ({
+      ...richState,
+      isDirty: false,
+      sidebarWidgets: [baseWidget],
+    }))
+  })
+
+  // Every portable-field mutation MUST set isDirty.
+  const portableMutations: Array<[string, () => void]> = [
+    [
+      'addScreen',
+      () => dashboardActions.addScreen({ id: 's2', name: 'S2', slug: 's2', type: 'grid' }),
+    ],
+    ['updateScreen', () => dashboardActions.updateScreen('screen-1', { name: 'Renamed' })],
+    ['clearScreen', () => dashboardActions.clearScreen('screen-1')],
+    [
+      'addGridItem',
+      () => dashboardActions.addGridItem('screen-1', { ...richGridItem, id: 'item-2' }),
+    ],
+    ['updateGridItem', () => dashboardActions.updateGridItem('screen-1', 'item-1', { width: 4 })],
+    ['removeGridItem', () => dashboardActions.removeGridItem('screen-1', 'item-1')],
+    ['reorderGrid', () => dashboardActions.reorderGrid('screen-1')],
+    ['setTheme', () => dashboardActions.setTheme('light')],
+    ['toggleSidebar', () => dashboardActions.toggleSidebar(false)],
+    ['toggleTabsExpanded', () => dashboardActions.toggleTabsExpanded(false)],
+    ['updateSidebarWidgets', () => dashboardActions.updateSidebarWidgets([])],
+    [
+      'addSidebarWidget',
+      () => dashboardActions.addSidebarWidget({ id: 'w2', type: 'weather', position: 1 }),
+    ],
+    ['removeSidebarWidget', () => dashboardActions.removeSidebarWidget('w')],
+    ['removeScreen', () => dashboardActions.removeScreen('screen-1')],
+  ]
+
+  it.each(portableMutations)('%s sets isDirty', (_name, mutate) => {
+    expect(dashboardStore.state.isDirty).toBe(false)
+    mutate()
+    expect(dashboardStore.state.isDirty).toBe(true)
+  })
+
+  // Device-local mutations MUST NOT mark the portable config dirty.
+  it('setMode does not set isDirty', () => {
+    expect(dashboardStore.state.isDirty).toBe(false)
+    dashboardActions.setMode('edit')
+    expect(dashboardStore.state.mode).toBe('edit')
+    expect(dashboardStore.state.isDirty).toBe(false)
+  })
+
+  it('top-level setGridResolution does not set isDirty', () => {
+    expect(dashboardStore.state.isDirty).toBe(false)
+    dashboardActions.setGridResolution({ columns: 6, rows: 4 })
+    expect(dashboardStore.state.gridResolution).toEqual({ columns: 6, rows: 4 })
+    expect(dashboardStore.state.isDirty).toBe(false)
+  })
+
+  it('toggling mode writes liebe-mode but never rewrites liebe-config', async () => {
+    // The auto-save loop only writes liebe-config when isDirty is true; a mode
+    // toggle leaving isDirty false therefore never rewrites the portable config.
+    dashboardStore.setState((s) => ({ ...s, isDirty: false }))
+    localStorageMock.setItem.mockClear()
+
+    dashboardActions.setMode('edit')
+
+    // Replicate the persistence subscription's save-if-dirty gate.
+    if (dashboardStore.state.isDirty) {
+      saveDashboardConfig(dashboardActions.exportConfiguration())
+    }
+
+    // setMode persists the raw mode via a deferred dynamic import; let it flush.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(dashboardStore.state.isDirty).toBe(false)
+    // liebe-mode IS updated, liebe-config is NOT rewritten.
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('liebe-mode', 'edit')
+    expect(localStorageMock.setItem).not.toHaveBeenCalledWith('liebe-config', expect.anything())
+  })
+})

--- a/src/store/configSchema.ts
+++ b/src/store/configSchema.ts
@@ -91,6 +91,17 @@ const screenConfigSchema: z.ZodType<ScreenConfigInput> = z.lazy(() =>
     .passthrough()
 )
 
+// Sidebar widgets are part of the portable config. Validate their shape (mirrors
+// `WidgetConfig` in ./types.ts) while staying tolerant of unknown extra fields.
+const widgetConfigSchema = z
+  .object({
+    id: z.string(),
+    type: z.enum(['clock', 'weather', 'quick-controls']),
+    position: z.number().int().nonnegative(),
+    config: z.record(z.unknown()).optional(),
+  })
+  .passthrough()
+
 export const dashboardConfigSchema = z
   .object({
     // Require a dot-separated numeric version (e.g. "1.0.0") so downstream
@@ -103,6 +114,7 @@ export const dashboardConfigSchema = z
     theme: z.enum(['light', 'dark', 'auto']).optional(),
     sidebarOpen: z.boolean().optional(),
     tabsExpanded: z.boolean().optional(),
+    sidebarWidgets: z.array(widgetConfigSchema).optional(),
   })
   .passthrough()
 

--- a/src/store/dashboardStore.ts
+++ b/src/store/dashboardStore.ts
@@ -42,10 +42,12 @@ export const dashboardStore = new Store<DashboardState>(initialState)
 
 export const dashboardActions = {
   setMode: (mode: DashboardMode) => {
+    // Mode is device-local: it is persisted separately under `liebe-mode` and is
+    // NOT part of the portable DashboardConfig, so it MUST NOT mark the config
+    // dirty (that would rewrite `liebe-config` on every view/edit toggle).
     dashboardStore.setState((state) => ({
       ...state,
       mode,
-      isDirty: true,
     }))
     // Import is deferred to avoid circular dependency
     import('./persistence').then(({ saveDashboardMode }) => {
@@ -273,10 +275,12 @@ export const dashboardActions = {
   },
 
   setGridResolution: (resolution: GridResolution) => {
+    // Top-level `gridResolution` is device-local: it is not part of the portable
+    // DashboardConfig (only per-screen `grid.resolution` round-trips), so it MUST
+    // NOT mark the config dirty. `loadConfiguration` resets it to the default.
     dashboardStore.setState((state) => ({
       ...state,
       gridResolution: resolution,
-      isDirty: true,
     }))
   },
 
@@ -291,18 +295,21 @@ export const dashboardActions = {
       theme: config.theme || 'auto',
       sidebarOpen: config.sidebarOpen ?? state.sidebarOpen,
       tabsExpanded: config.tabsExpanded ?? state.tabsExpanded,
+      sidebarWidgets: config.sidebarWidgets ?? state.sidebarWidgets,
       isDirty: false,
     }))
   },
 
   exportConfiguration: (): DashboardConfig => {
     const state = dashboardStore.state
+    // Serialize exactly the canonical portable set (see DashboardConfig).
     return {
       version: state.configuration.version,
       screens: state.screens,
       theme: state.theme,
       sidebarOpen: state.sidebarOpen,
       tabsExpanded: state.tabsExpanded,
+      sidebarWidgets: state.sidebarWidgets,
     }
   },
 

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -239,8 +239,12 @@ export const importConfigurationFromFile = (file: File): Promise<void> => {
         // Load the configuration
         dashboardActions.loadConfiguration(migratedConfig)
 
-        // Save to localStorage
-        saveDashboardConfig(migratedConfig)
+        // Persist the RESOLVED portable config, not the raw import. When an
+        // imported file omits an optional portable field (e.g. `sidebarWidgets`
+        // from a pre-contract export), `loadConfiguration` fills it from the
+        // current store state; exporting after load captures that fallback so a
+        // reload restores the same portable state instead of dropping it.
+        saveDashboardConfig(dashboardActions.exportConfiguration())
 
         resolve()
       } catch (error) {
@@ -269,14 +273,19 @@ export const importConfigurationFromFile = (file: File): Promise<void> => {
 
 // Export configuration as YAML string
 export const exportConfigurationAsYAML = (): string => {
-  const config = dashboardActions.exportConfiguration()
+  // Serialize exactly the canonical portable set (see DashboardConfig), matching
+  // the JSON export so YAML and JSON round-trip to identical state.
+  const { version, theme, sidebarOpen, tabsExpanded, sidebarWidgets, screens } =
+    dashboardActions.exportConfiguration()
   const yamlConfig = {
     '# Liebe Dashboard Configuration': null,
     '# Generated': new Date().toISOString(),
-    version: config.version,
-    theme: config.theme || 'auto',
-    sidebarOpen: config.sidebarOpen,
-    screens: config.screens,
+    version,
+    theme: theme || 'auto',
+    sidebarOpen,
+    tabsExpanded,
+    sidebarWidgets,
+    screens,
   }
 
   return yaml.dump(yamlConfig, {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -37,12 +37,17 @@ export interface ScreenConfig {
   }
 }
 
+// Canonical portable configuration contract. These are exactly the fields that
+// travel with a shared/exported dashboard (JSON + YAML) and whose mutation marks
+// the config dirty. Device-local state (`mode`, top-level `gridResolution`) is
+// deliberately excluded — see docs/specs/dashboard-config/index.md.
 export interface DashboardConfig {
   version: string
   screens: ScreenConfig[]
   theme?: 'light' | 'dark' | 'auto'
   sidebarOpen?: boolean
   tabsExpanded?: boolean
+  sidebarWidgets?: WidgetConfig[]
 }
 
 export type DashboardMode = 'view' | 'edit'


### PR DESCRIPTION
## Summary

Implements docs/changes/0004-portable-config-contract.md: one canonical set of portable dashboard-configuration fields, followed consistently by `DashboardConfig`, the JSON export, the YAML export, import, and dirty-tracking.

**Canonical portable set** (adopted from the change doc's default proposal): `version`, `screens`, `theme`, `sidebarOpen`, `tabsExpanded`, `sidebarWidgets`.
**Device-local** (excluded from the portable document; never marks it dirty): `mode` (persisted under `liebe-mode`) and top-level `gridResolution` (per-screen `grid.resolution` still round-trips).

- `src/store/types.ts` — `DashboardConfig` now carries exactly the portable set (adds `sidebarWidgets`), with the contract documented.
- `src/store/dashboardStore.ts` — `exportConfiguration` serializes exactly that set; `setMode` and top-level grid-resolution changes no longer mark the config dirty.
- `src/store/persistence.ts` — YAML export now includes the previously-omitted `tabsExpanded` plus `sidebarWidgets`; imports persist the resolved config so omitted optional fields keep fallback values across reloads.
- `src/store/configSchema.ts` — zod schema extended to the canonical set (still tolerant of extras).
- No version bump needed: the portable shape only gained optional fields, so existing current-version JSON/YAML exports remain importable; `checkVersionCompatibility` untouched.
- New `portable-config-contract.test.ts` — JSON/YAML round-trip deep-equality on every portable field; dirty-tracking coverage (every portable mutation sets `isDirty`; mode toggle and top-level gridResolution do not).
- `docs/specs/dashboard-config/index.md` — Requirements updated to the canonical set; resolved Open Questions removed.

Marks change 0004 complete (change doc, `docs/index.yml`, `docs/index.md`).

## Related Change

docs/changes/0004-portable-config-contract.md (final implementing PR)

## Testing

- [x] `npm test` — 517 passed, 2 pre-existing skips
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — enforced by CI on this PR