### PR TITLE
refactor(lint): enable structural react-hooks v7 rules

### DIFF
--- a/docs/changes/0003-reenable-react-hooks-rules.md
+++ b/docs/changes/0003-reenable-react-hooks-rules.md
@@ -75,9 +75,9 @@ Each of the five rules MUST end enabled (at least at `warn`, target `error`) in 
 
 ## Tasks
 
-- [ ] Group A: enable `react-hooks/refs`, `react-hooks/static-components`, `react-hooks/incompatible-library`; fix all violations
-  - [ ] Violation inventory committed to the PR description
-  - [ ] Fixes + any justified suppressions
+- [x] Group A: enable `react-hooks/refs`, `react-hooks/static-components`, `react-hooks/incompatible-library`; fix all violations
+  - [x] Violation inventory committed to the PR description
+  - [x] Fixes + any justified suppressions
 - [ ] Group B: enable `react-hooks/set-state-in-effect`, `react-hooks/preserve-manual-memoization`; fix all violations; revisit stale `exhaustive-deps` suppressions
 
 ## Open Questions

--- a/docs/specs/architecture/index.md
+++ b/docs/specs/architecture/index.md
@@ -128,16 +128,16 @@ This subsection is the project's standing testing and quality bar; other specs l
 
 ### Linting & Formatting
 
-- ESLint MUST use the flat-config file `eslint.config.js` (ESLint 9), composing `@eslint/js` recommended, `@typescript-eslint` recommended (type-aware via `parserOptions.project`), `eslint-plugin-react` recommended, and `eslint-plugin-react-hooks` recommended, with `eslint-config-prettier` last to disable stylistic conflicts (`eslint.config.js:1-78`).
+- ESLint MUST use the flat-config file `eslint.config.js` (ESLint 9), composing `@eslint/js` recommended, `@typescript-eslint` recommended (type-aware via `parserOptions.project`), `eslint-plugin-react` recommended, and `eslint-plugin-react-hooks` recommended, with `eslint-config-prettier` last to disable stylistic conflicts (`eslint.config.js:1-80`).
 - Prettier MUST enforce: no semicolons, single quotes, 2-space tabs, `es5` trailing commas, 100-char print width, always-parenthesized arrow params (`.prettierrc`).
 - The pre-commit hook MUST run `lint-staged`, which runs `eslint --fix` + `prettier --write` on staged `*.{ts,tsx}` and `prettier --write` on staged `*.{json,md,yml,yaml}` (`.husky/pre-commit`, `package.json` `lint-staged`).
 - Generated and build output (`*.gen.ts`, `dist/`, `.output/`, `.tanstack/`, `.nitro/`, `.vite-temp/`, `node_modules/`) MUST be excluded from linting (`eslint.config.js` `ignores`).
 
-#### Scenario: React Compiler rules are intentionally off
+#### Scenario: React Compiler rules are enabled incrementally
 
 - **GIVEN** `eslint-plugin-react-hooks` v7 ships experimental React Compiler rules
 - **WHEN** ESLint runs
-- **THEN** `react-hooks/refs`, `static-components`, `set-state-in-effect`, `incompatible-library`, and `preserve-manual-memoization` are explicitly disabled (`eslint.config.js:53-59`), to be enabled gradually as the codebase is refactored.
+- **THEN** the structural rules `react-hooks/refs`, `react-hooks/static-components`, and `react-hooks/incompatible-library` are enabled at `error` (change 0003 Group A), while `react-hooks/set-state-in-effect` and `react-hooks/preserve-manual-memoization` remain disabled pending change 0003 Group B (`eslint.config.js:36-42`).
 
 ### Deployment
 
@@ -206,7 +206,7 @@ Build-mode branching is entirely `NODE_ENV`/`--mode`-driven:
 ## Open Questions
 
 - **`sharp` in runtime dependencies.** `sharp@^0.34.3` is listed under `dependencies` (not `devDependencies`) in `package.json`, but the shipped panel is a browser IIFE and cannot use a native Node image library. It appears to be dead/misplaced for the panel build; whether any tooling path needs it is unverified.
-- **Disabled `react-hooks` rules.** Five experimental React Compiler rules are turned off in `eslint.config.js:53-59` with a comment to enable them "gradually as the codebase is refactored." There is no tracked plan or owner for re-enabling them.
+- **Partially enabled `react-hooks` rules.** Change 0003 tracks incremental enablement of the five experimental React Compiler rules. Group A (`react-hooks/refs`, `static-components`, `incompatible-library`) is enabled at `error`; the two stateful rules (`set-state-in-effect`, `preserve-manual-memoization`) remain disabled in `eslint.config.js:36-42` pending Group B.
 - **`.env.local` has no application consumer.** Project docs reference `.env.local` (HA URL/credentials) for MCP browser testing, but no application source reads `import.meta.env`/`process.env` for those values — the file is a testing convention only, so its documented `HASS_*` keys are not load-bearing for the build.
 - **Two test-setup files.** `vitest.config.ts` references `./src/test/setup.ts`, but a second file `src/test-setup.ts` also exists at the source root; the latter is not wired into the Vitest config and its status (stale vs. intentional) is unverified.
 - **CI uses `npm install`, not `npm ci`.** The CI workflow (`.github/workflows/ci.yml`) runs `npm install` while the deploy workflow uses `npm ci`; the inconsistency means CI does not strictly honor the lockfile.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,12 +33,12 @@ export default [
       'react/prop-types': 'off',
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
       'no-undef': 'off',
-      // Disable new experimental React Compiler rules from react-hooks v7
-      // These can be enabled gradually as the codebase is refactored
-      'react-hooks/refs': 'off',
-      'react-hooks/static-components': 'off',
+      // react-hooks v7 rules. Structural rules (change 0003 Group A) are enforced.
+      // The remaining two stateful rules are enabled separately in Group B.
+      'react-hooks/refs': 'error',
+      'react-hooks/static-components': 'error',
+      'react-hooks/incompatible-library': 'error',
       'react-hooks/set-state-in-effect': 'off',
-      'react-hooks/incompatible-library': 'off',
       'react-hooks/preserve-manual-memoization': 'off',
     },
     settings: {

--- a/src/components/BinarySensorCard.tsx
+++ b/src/components/BinarySensorCard.tsx
@@ -1,6 +1,6 @@
 import { Flex, Text } from '@radix-ui/themes'
 import { useEntity } from '~/hooks'
-import { memo, useState, useMemo } from 'react'
+import { createElement, memo, useState, useMemo } from 'react'
 import { SkeletonCard, ErrorDisplay } from './ui'
 import { GridCardWithComponents as GridCard } from './GridCard'
 import { useDashboardStore, dashboardStore, dashboardActions } from '~/store'
@@ -138,7 +138,7 @@ function BinarySensorCardComponent({
                 transition: 'opacity 0.2s ease',
               }}
             >
-              <IconComponent size={iconSize} />
+              {createElement(IconComponent, { size: iconSize })}
             </span>
           </GridCard.Icon>
 

--- a/src/components/CameraCard.tsx
+++ b/src/components/CameraCard.tsx
@@ -409,6 +409,9 @@ function CameraCardComponent({
   const normalContainerRef = useRef<HTMLDivElement>(null)
   const fullscreenContainerRef = useRef<HTMLDivElement>(null)
   const videoElementRef = useRef<HTMLVideoElement | null>(null)
+  // Reactive mirror of videoElementRef for children that render from it
+  // (reading the ref during render is unsafe per react-hooks/refs).
+  const [videoElement, setVideoElement] = useState<HTMLVideoElement | null>(null)
 
   // Get configuration values
   const config = item?.config || {}
@@ -485,6 +488,7 @@ function CameraCardComponent({
     (element: HTMLVideoElement | null) => {
       videoRef(element)
       videoElementRef.current = element
+      setVideoElement(element)
     },
     [videoRef]
   )
@@ -684,11 +688,7 @@ function CameraCardComponent({
 
           {/* Stats display (when enabled) */}
           {showStats && supportsStream && !streamError && (
-            <CameraStats
-              size={size}
-              videoElement={videoElementRef.current}
-              peerConnection={peerConnection}
-            />
+            <CameraStats size={size} videoElement={videoElement} peerConnection={peerConnection} />
           )}
 
           {/* Controls and info container positioned absolutely at bottom left */}
@@ -748,11 +748,7 @@ function CameraCardComponent({
 
         {/* Fullscreen stats display (when enabled) */}
         {showStats && (
-          <CameraStats
-            size="large"
-            videoElement={videoElementRef.current}
-            peerConnection={peerConnection}
-          />
+          <CameraStats size="large" videoElement={videoElement} peerConnection={peerConnection} />
         )}
 
         {/* Fullscreen controls and info container */}

--- a/src/components/EntitiesBrowserTab.tsx
+++ b/src/components/EntitiesBrowserTab.tsx
@@ -339,6 +339,7 @@ export function EntitiesBrowserTab({ screenId, onClose }: EntitiesBrowserTabProp
   const totalEntities = filteredEntities.length
 
   // Initialize virtualizer
+  // eslint-disable-next-line react-hooks/incompatible-library -- TanStack Virtual's useVirtualizer returns functions that cannot be memoized; this is a React Compiler advisory only and the project does not use the compiler, so there is nothing to fix here.
   const virtualizer = useVirtualizer({
     count: filteredEntities.length,
     getScrollElement: () => scrollAreaRef.current,

--- a/src/components/FanCard.tsx
+++ b/src/components/FanCard.tsx
@@ -1,7 +1,7 @@
 import { Flex, Text, Box, IconButton, Select } from '@radix-ui/themes'
 import { Fan, Wind } from 'lucide-react'
 import { useEntity, useServiceCall } from '~/hooks'
-import React, { memo, useCallback, useRef } from 'react'
+import React, { memo, useCallback } from 'react'
 import { SkeletonCard, ErrorDisplay } from './ui'
 import { GridCardWithComponents as GridCard } from './GridCard'
 import { useDashboardStore } from '~/store'
@@ -41,9 +41,6 @@ function FanCardComponent({
   const { loading: isLoading, error, turnOn, turnOff, callService, clearError } = useServiceCall()
   const { mode } = useDashboardStore()
   const isEditMode = mode === 'edit'
-
-  // Only track display state on significant changes (not every render)
-  const prevDisplayRef = useRef({ displayPercentage: 0, selectedButton: '0' })
 
   // No separate loading state - use main card loading
 
@@ -172,12 +169,6 @@ function FanCardComponent({
   }
 
   const selectedButton = getSelectedButton(displayPercentage)
-  if (
-    prevDisplayRef.current.displayPercentage !== displayPercentage ||
-    prevDisplayRef.current.selectedButton !== selectedButton
-  ) {
-    prevDisplayRef.current = { displayPercentage, selectedButton }
-  }
 
   // Determine animation speed class based on percentage
   const getAnimationClass = () => {

--- a/src/components/GridView.tsx
+++ b/src/components/GridView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { createElement, useState, useEffect } from 'react'
 import { Box } from '@radix-ui/themes'
 import { ButtonCard } from './ButtonCard'
 import { TextCard } from './TextCard'
@@ -59,7 +59,7 @@ function EntityCard({
 
   // If we have a card component, render it
   if (CardComponent) {
-    return <CardComponent {...cardProps} />
+    return createElement(CardComponent, cardProps)
   }
 
   // Default to ButtonCard for unmapped entities

--- a/src/components/IconSelect.tsx
+++ b/src/components/IconSelect.tsx
@@ -47,7 +47,11 @@ export const IconSelect: React.FC<IconSelectProps> = ({
     <Popover.Root open={open} onOpenChange={setOpen}>
       <Popover.Trigger>
         <Button variant="soft" color="gray" style={{ gap: '8px' }}>
-          {CurrentIcon ? <CurrentIcon size={20} /> : <Box style={{ width: 20, height: 20 }} />}
+          {CurrentIcon ? (
+            React.createElement(CurrentIcon, { size: 20 })
+          ) : (
+            <Box style={{ width: 20, height: 20 }} />
+          )}
           <Text>{value || buttonLabel}</Text>
         </Button>
       </Popover.Trigger>

--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -1,6 +1,6 @@
 import { Card, Flex, Text, Heading, Grid, Separator, ScrollArea } from '@radix-ui/themes'
 import { useStore } from '@tanstack/react-store'
-import { useMemo } from 'react'
+import { createElement, useMemo } from 'react'
 import { entityStore } from '../../store/entityStore'
 import {
   Cloud,
@@ -137,7 +137,7 @@ export function WeatherWidget({ widget }: WeatherWidgetProps) {
           <Heading size="4" weight="bold">
             Weather
           </Heading>
-          <CurrentWeatherIcon size={24} />
+          {createElement(CurrentWeatherIcon, { size: 24 })}
         </Flex>
 
         {/* Current conditions */}

--- a/src/hooks/__tests__/useWebRTC.test.tsx
+++ b/src/hooks/__tests__/useWebRTC.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useWebRTC } from '../useWebRTC'
+import { HomeAssistantProvider } from '../../contexts/HomeAssistantContext'
+import { createMockHomeAssistant } from '~/testUtils/mockHomeAssistant'
+import type { HomeAssistant } from '../../contexts/HomeAssistantContext'
+
+// Minimal RTCPeerConnection stand-in that lets initializeWebRTC run to the
+// point where the peer connection is created and exposed.
+class MockRTCPeerConnection {
+  static instances: MockRTCPeerConnection[] = []
+  connectionState = 'new'
+  signalingState = 'stable'
+  remoteDescription: unknown = null
+  ontrack: ((e: unknown) => void) | null = null
+  onicecandidate: ((e: unknown) => void) | null = null
+  onconnectionstatechange: (() => void) | null = null
+  constructor() {
+    MockRTCPeerConnection.instances.push(this)
+  }
+  addTransceiver = vi.fn()
+  createOffer = vi.fn().mockResolvedValue({ type: 'offer', sdp: 'mock-sdp' })
+  setLocalDescription = vi.fn().mockResolvedValue(undefined)
+  setRemoteDescription = vi.fn().mockResolvedValue(undefined)
+  addIceCandidate = vi.fn().mockResolvedValue(undefined)
+  close = vi.fn()
+  getStats = vi.fn().mockResolvedValue(new Map())
+}
+
+describe('useWebRTC', () => {
+  let mockHass: HomeAssistant
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <HomeAssistantProvider hass={mockHass}>{children}</HomeAssistantProvider>
+  )
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    MockRTCPeerConnection.instances = []
+    vi.stubGlobal('RTCPeerConnection', MockRTCPeerConnection)
+    mockHass = createMockHomeAssistant()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('exposes the peer connection reactively once it is created', async () => {
+    const { result } = renderHook(() => useWebRTC({ entityId: 'camera.test', enabled: true }), {
+      wrapper,
+    })
+
+    // No connection before a video element is attached.
+    expect(result.current.peerConnection).toBeNull()
+
+    // Attach a video element, then trigger the init effect via retry().
+    await act(async () => {
+      result.current.videoRef({} as unknown as HTMLVideoElement)
+      result.current.retry()
+    })
+    // Advance past the 200ms init debounce and flush the async handshake.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250)
+    })
+
+    // The hook re-rendered and now exposes the live connection (previously this
+    // value was read from a ref during render and could be stale/non-reactive).
+    expect(MockRTCPeerConnection.instances).toHaveLength(1)
+    expect(result.current.peerConnection).toBe(MockRTCPeerConnection.instances[0])
+  })
+
+  it('clears the exposed peer connection when disabled', async () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useWebRTC({ entityId: 'camera.test', enabled }),
+      { wrapper, initialProps: { enabled: true } }
+    )
+
+    await act(async () => {
+      result.current.videoRef({} as unknown as HTMLVideoElement)
+      result.current.retry()
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250)
+    })
+    expect(result.current.peerConnection).not.toBeNull()
+
+    // Disabling tears the connection down; the exposed value must go back to null.
+    await act(async () => {
+      rerender({ enabled: false })
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(result.current.peerConnection).toBeNull()
+  })
+})

--- a/src/hooks/useWebRTC.ts
+++ b/src/hooks/useWebRTC.ts
@@ -47,6 +47,10 @@ export function useWebRTC({ entityId, enabled = true }: UseWebRTCOptions): UseWe
   const [error, setError] = useState<string | null>(null)
   const [retryCount, setRetryCount] = useState(0)
   const [hasFrameWarning, setHasFrameWarning] = useState(false)
+  // Mirror of peerConnectionRef exposed to consumers. Reading the ref during
+  // render is unsafe (react-hooks/refs) and non-reactive; this state updates
+  // when the connection is created/torn down so consumers re-render.
+  const [peerConnection, setPeerConnection] = useState<RTCPeerConnection | null>(null)
   const cleanupRef = useRef<(() => Promise<void>) | null>(null)
   const frameMonitorRef = useRef<{
     lastFrameTime: number
@@ -84,6 +88,7 @@ export function useWebRTC({ entityId, enabled = true }: UseWebRTCOptions): UseWe
 
     // Clear the references immediately to prevent double cleanup
     peerConnectionRef.current = null
+    setPeerConnection(null)
     initializingRef.current = false
     pendingInitRef.current = false
     pendingCandidatesRef.current = []
@@ -298,6 +303,7 @@ export function useWebRTC({ entityId, enabled = true }: UseWebRTCOptions): UseWe
         ],
       })
       peerConnectionRef.current = pc
+      setPeerConnection(pc)
 
       // Add transceivers for receiving video/audio
       pc.addTransceiver('video', { direction: 'recvonly' })
@@ -580,6 +586,6 @@ export function useWebRTC({ entityId, enabled = true }: UseWebRTCOptions): UseWe
     error,
     retry,
     hasFrameWarning,
-    peerConnection: peerConnectionRef.current,
+    peerConnection,
   }
 }


### PR DESCRIPTION
## Summary

Group A of docs/changes/0003-reenable-react-hooks-rules.md: enables the three structural react-hooks v7 rules at `error` and fixes all violations. The two stateful rules (`set-state-in-effect`, `preserve-manual-memoization`) remain off — they land in the follow-up PR that completes the change.

## Violation inventory (audit with all five rules on)

**Group A — fixed here:**
- `react-hooks/refs` (7): `CameraCard.tsx:689,753` (render-time `videoElementRef.current` reads), `FanCard.tsx:176-179` (`prevDisplayRef` render writes), `useWebRTC.ts:583` (ref read returned from render)
- `react-hooks/static-components` (4): `BinarySensorCard.tsx:141`, `GridView.tsx:62`, `IconSelect.tsx:50`, `widgets/WeatherWidget.tsx:140` (dynamically-selected components in JSX element-type position)
- `react-hooks/incompatible-library` (1): `EntitiesBrowserTab.tsx:342` (TanStack Virtual `useVirtualizer`)

**Group B — deferred to the completing PR:** `set-state-in-effect` (4): `app/utils/responsive.ts:73`, `InputDateTimeCard.tsx:40`, `InputNumberCard.tsx:43`, `KeepAlive.tsx:31`. `preserve-manual-memoization`: 0 findings.

## Fixes

- `useWebRTC.ts` / `CameraCard.tsx` — behavioral fix: expose the peer connection / video element via state (set where they're created) instead of render-time ref reads, so consumers re-render reactively; refs kept for imperative use. Covered by new `useWebRTC` tests (reactive exposure + teardown clearing).
- `FanCard.tsx` — removed `prevDisplayRef` block entirely (written but never read; dead code).
- `GridView` / `BinarySensorCard` / `IconSelect` / `WeatherWidget` — render the stable module-level component via `createElement` rather than call-result-in-JSX-position; behavior identical.
- One justified suppression: `EntitiesBrowserTab.tsx` `incompatible-library` on `useVirtualizer` (React Compiler advisory; the project doesn't use the compiler; no fix exists short of dropping the library).

This PR intentionally leaves the 0003 change-doc `Status`, `docs/index.yml`, and `docs/index.md` untouched — the Group B PR flips them.

## Testing

- [x] `npm test` — 508 passed, 2 pre-existing skips (new `useWebRTC` tests included; no existing tests modified)
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run typecheck` — clean
- [x] `npm run build:ha:prod` — passes
- [x] Local Codex review clean; local CodeRabbit CLI rate-limited (PR-level CodeRabbit check gates this PR instead)