### PR TITLE
refactor(lint): enable stateful react-hooks v7 rules

### DIFF
--- a/app/utils/__tests__/responsive.test.ts
+++ b/app/utils/__tests__/responsive.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useMediaQuery } from '../responsive'
+
+// Controllable matchMedia so we can flip match state and fire change events.
+function setupMatchMedia() {
+  const matchState = new Map<string, boolean>()
+  const listeners = new Map<string, Set<(e: { matches: boolean }) => void>>()
+
+  window.matchMedia = vi.fn((query: string) => {
+    if (!listeners.has(query)) listeners.set(query, new Set())
+    return {
+      get matches() {
+        return matchState.get(query) ?? false
+      },
+      media: query,
+      addEventListener: (_event: string, cb: (e: { matches: boolean }) => void) =>
+        listeners.get(query)!.add(cb),
+      removeEventListener: (_event: string, cb: (e: { matches: boolean }) => void) =>
+        listeners.get(query)!.delete(cb),
+    } as unknown as MediaQueryList
+  }) as unknown as typeof window.matchMedia
+
+  return {
+    set(query: string, matches: boolean) {
+      matchState.set(query, matches)
+      listeners.get(query)?.forEach((cb) => cb({ matches }))
+    },
+    listenerCount(query: string) {
+      return listeners.get(query)?.size ?? 0
+    },
+  }
+}
+
+const QUERY = '(max-width: 600px)'
+
+describe('useMediaQuery', () => {
+  let originalMatchMedia: typeof window.matchMedia
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia
+  })
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia
+  })
+
+  it('returns the current match and updates reactively on change events', () => {
+    const mm = setupMatchMedia()
+    mm.set(QUERY, false)
+
+    const { result } = renderHook(() => useMediaQuery(QUERY))
+    expect(result.current).toBe(false)
+
+    act(() => mm.set(QUERY, true))
+    expect(result.current).toBe(true)
+
+    act(() => mm.set(QUERY, false))
+    expect(result.current).toBe(false)
+  })
+
+  it('re-syncs when the query prop changes', () => {
+    const mm = setupMatchMedia()
+    const wide = '(min-width: 1024px)'
+    const narrow = '(max-width: 480px)'
+    mm.set(wide, true)
+    mm.set(narrow, false)
+
+    const { result, rerender } = renderHook(({ q }: { q: string }) => useMediaQuery(q), {
+      initialProps: { q: wide },
+    })
+    expect(result.current).toBe(true)
+
+    rerender({ q: narrow })
+    expect(result.current).toBe(false)
+  })
+
+  it('unsubscribes from the previous query on unmount', () => {
+    const mm = setupMatchMedia()
+    mm.set(QUERY, false)
+
+    const { unmount } = renderHook(() => useMediaQuery(QUERY))
+    expect(mm.listenerCount(QUERY)).toBe(1)
+
+    unmount()
+    expect(mm.listenerCount(QUERY)).toBe(0)
+  })
+})

--- a/app/utils/responsive.ts
+++ b/app/utils/responsive.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback, useSyncExternalStore } from 'react'
 
 export const breakpoints = {
   mobile: 480,
@@ -60,31 +60,23 @@ export function useBreakpoint(): Breakpoint {
 }
 
 export function useMediaQuery(query: string): boolean {
-  const [matches, setMatches] = useState(() => {
-    // Default to false for SSR
-    if (typeof window === 'undefined') return false
-    return window.matchMedia(query).matches
-  })
+  // Subscribe to the media query as an external store so the value stays in
+  // sync (including when `query` changes) without calling setState in an effect.
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      const mediaQuery = window.matchMedia(query)
+      mediaQuery.addEventListener('change', onChange)
+      return () => mediaQuery.removeEventListener('change', onChange)
+    },
+    [query]
+  )
 
-  useEffect(() => {
-    const mediaQuery = window.matchMedia(query)
+  const getSnapshot = useCallback(() => window.matchMedia(query).matches, [query])
 
-    // Sync state when query changes (useState initializer only runs on mount)
-    setMatches(mediaQuery.matches)
+  // Default to false for SSR (no window).
+  const getServerSnapshot = () => false
 
-    const handleChange = (e: MediaQueryListEvent) => {
-      setMatches(e.matches)
-    }
-
-    // Add listener
-    mediaQuery.addEventListener('change', handleChange)
-
-    return () => {
-      mediaQuery.removeEventListener('change', handleChange)
-    }
-  }, [query])
-
-  return matches
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }
 
 export function useIsMobile(): boolean {

--- a/docs/changes/0003-reenable-react-hooks-rules.md
+++ b/docs/changes/0003-reenable-react-hooks-rules.md
@@ -5,7 +5,7 @@
 Gradually re-enable the five `eslint-plugin-react-hooks` v7 rules that were disabled wholesale during the December 2025 ESLint upgrade, fixing each rule's violations as it is turned on. Anchored to the [Architecture](../specs/architecture/) spec's linting conventions.
 
 **Spec:** [Architecture](../specs/architecture/)
-**Status:** draft
+**Status:** complete
 **Depends On:** —
 
 ## Motivation
@@ -78,11 +78,11 @@ Each of the five rules MUST end enabled (at least at `warn`, target `error`) in 
 - [x] Group A: enable `react-hooks/refs`, `react-hooks/static-components`, `react-hooks/incompatible-library`; fix all violations
   - [x] Violation inventory committed to the PR description
   - [x] Fixes + any justified suppressions
-- [ ] Group B: enable `react-hooks/set-state-in-effect`, `react-hooks/preserve-manual-memoization`; fix all violations; revisit stale `exhaustive-deps` suppressions
+- [x] Group B: enable `react-hooks/set-state-in-effect`, `react-hooks/preserve-manual-memoization`; fix all violations; revisit stale `exhaustive-deps` suppressions
 
 ## Open Questions
 
-- [ ] Final severity: `error` for all five, or keep compiler-preview rules at `warn`? — Default: `error`, matching the zero-warning bar.
+- [x] Final severity: `error` for all five, or keep compiler-preview rules at `warn`? — Resolved: all five are enabled at `error`, matching the zero-warning bar.
 
 ## References
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,5 +19,5 @@
 | ---- | --------------------------------------------------------------------------------- | ------------------------------------------- | -------- | ---------- |
 | 0001 | [Per-Entity Store Selectors](changes/0001-per-entity-store-selectors.md)          | [Entity State](specs/entity-state/)         | complete | —          |
 | 0002 | [Repository Hygiene Bundle](changes/0002-repo-hygiene.md)                         | [Architecture](specs/architecture/)         | complete | —          |
-| 0003 | [Re-enable react-hooks v7 Lint Rules](changes/0003-reenable-react-hooks-rules.md) | [Architecture](specs/architecture/)         | draft    | —          |
+| 0003 | [Re-enable react-hooks v7 Lint Rules](changes/0003-reenable-react-hooks-rules.md) | [Architecture](specs/architecture/)         | complete | —          |
 | 0004 | [Portable Configuration Contract](changes/0004-portable-config-contract.md)       | [Dashboard Config](specs/dashboard-config/) | complete | —          |

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -55,7 +55,7 @@ changes:
     path: changes/0003-reenable-react-hooks-rules.md
     description: Gradually re-enable the five disabled react-hooks v7 lint rules and fix their violations
     spec: architecture
-    status: draft
+    status: complete
     depends_on: []
   - id: '0004'
     name: portable-config-contract

--- a/docs/specs/architecture/index.md
+++ b/docs/specs/architecture/index.md
@@ -128,16 +128,16 @@ This subsection is the project's standing testing and quality bar; other specs l
 
 ### Linting & Formatting
 
-- ESLint MUST use the flat-config file `eslint.config.js` (ESLint 9), composing `@eslint/js` recommended, `@typescript-eslint` recommended (type-aware via `parserOptions.project`), `eslint-plugin-react` recommended, and `eslint-plugin-react-hooks` recommended, with `eslint-config-prettier` last to disable stylistic conflicts (`eslint.config.js:1-80`).
+- ESLint MUST use the flat-config file `eslint.config.js` (ESLint 9), composing `@eslint/js` recommended, `@typescript-eslint` recommended (type-aware via `parserOptions.project`), `eslint-plugin-react` recommended, and `eslint-plugin-react-hooks` recommended, with `eslint-config-prettier` last to disable stylistic conflicts (`eslint.config.js:1-79`).
 - Prettier MUST enforce: no semicolons, single quotes, 2-space tabs, `es5` trailing commas, 100-char print width, always-parenthesized arrow params (`.prettierrc`).
 - The pre-commit hook MUST run `lint-staged`, which runs `eslint --fix` + `prettier --write` on staged `*.{ts,tsx}` and `prettier --write` on staged `*.{json,md,yml,yaml}` (`.husky/pre-commit`, `package.json` `lint-staged`).
 - Generated and build output (`*.gen.ts`, `dist/`, `.output/`, `.tanstack/`, `.nitro/`, `.vite-temp/`, `node_modules/`) MUST be excluded from linting (`eslint.config.js` `ignores`).
 
-#### Scenario: React Compiler rules are enabled incrementally
+#### Scenario: React Compiler rules are enforced
 
 - **GIVEN** `eslint-plugin-react-hooks` v7 ships experimental React Compiler rules
 - **WHEN** ESLint runs
-- **THEN** the structural rules `react-hooks/refs`, `react-hooks/static-components`, and `react-hooks/incompatible-library` are enabled at `error` (change 0003 Group A), while `react-hooks/set-state-in-effect` and `react-hooks/preserve-manual-memoization` remain disabled pending change 0003 Group B (`eslint.config.js:36-42`).
+- **THEN** all five rules — `react-hooks/refs`, `static-components`, `incompatible-library`, `set-state-in-effect`, and `preserve-manual-memoization` — are enabled at `error` (change 0003), so a hooks violation fails the lint gate (`eslint.config.js:36-41`).
 
 ### Deployment
 
@@ -206,7 +206,6 @@ Build-mode branching is entirely `NODE_ENV`/`--mode`-driven:
 ## Open Questions
 
 - **`sharp` in runtime dependencies.** `sharp@^0.34.3` is listed under `dependencies` (not `devDependencies`) in `package.json`, but the shipped panel is a browser IIFE and cannot use a native Node image library. It appears to be dead/misplaced for the panel build; whether any tooling path needs it is unverified.
-- **Partially enabled `react-hooks` rules.** Change 0003 tracks incremental enablement of the five experimental React Compiler rules. Group A (`react-hooks/refs`, `static-components`, `incompatible-library`) is enabled at `error`; the two stateful rules (`set-state-in-effect`, `preserve-manual-memoization`) remain disabled in `eslint.config.js:36-42` pending Group B.
 - **`.env.local` has no application consumer.** Project docs reference `.env.local` (HA URL/credentials) for MCP browser testing, but no application source reads `import.meta.env`/`process.env` for those values — the file is a testing convention only, so its documented `HASS_*` keys are not load-bearing for the build.
 - **Two test-setup files.** `vitest.config.ts` references `./src/test/setup.ts`, but a second file `src/test-setup.ts` also exists at the source root; the latter is not wired into the Vitest config and its status (stale vs. intentional) is unverified.
 - **CI uses `npm install`, not `npm ci`.** The CI workflow (`.github/workflows/ci.yml`) runs `npm install` while the deploy workflow uses `npm ci`; the inconsistency means CI does not strictly honor the lockfile.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,13 +33,12 @@ export default [
       'react/prop-types': 'off',
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
       'no-undef': 'off',
-      // react-hooks v7 rules. Structural rules (change 0003 Group A) are enforced.
-      // The remaining two stateful rules are enabled separately in Group B.
+      // react-hooks v7 rules, all enforced at error (change 0003, Groups A & B).
       'react-hooks/refs': 'error',
       'react-hooks/static-components': 'error',
       'react-hooks/incompatible-library': 'error',
-      'react-hooks/set-state-in-effect': 'off',
-      'react-hooks/preserve-manual-memoization': 'off',
+      'react-hooks/set-state-in-effect': 'error',
+      'react-hooks/preserve-manual-memoization': 'error',
     },
     settings: {
       react: {

--- a/src/components/InputDateTimeCard.tsx
+++ b/src/components/InputDateTimeCard.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useState, useEffect } from 'react'
+import React, { memo, useCallback, useState } from 'react'
 import { Box, Flex, IconButton, Text, TextField } from '@radix-ui/themes'
 import { Archive, Calendar, Check, Clock, Edit2, X } from 'lucide-react'
 import { useEntity } from '../hooks/useEntity'
@@ -31,15 +31,21 @@ export const InputDateTimeCard = memo(function InputDateTimeCard({
   const { entity, isConnected, isLoading: isEntityLoading } = useEntity(entityId)
   const { setValue, loading, error } = useServiceCall()
 
-  const [localValue, setLocalValue] = useState<string>('')
+  const [localValue, setLocalValue] = useState<string>(entity?.state ?? '')
   const [isEditing, setIsEditing] = useState(false)
 
-  // Update local value when entity changes
-  useEffect(() => {
+  // Sync the local value from the entity while the user is not editing. Done
+  // during render (not in an effect) per react-hooks/set-state-in-effect; the
+  // previous-value guards reproduce the old effect's [entity, isEditing] triggers.
+  const [prevEntity, setPrevEntity] = useState(entity)
+  const [prevIsEditing, setPrevIsEditing] = useState(isEditing)
+  if (entity !== prevEntity || isEditing !== prevIsEditing) {
+    setPrevEntity(entity)
+    setPrevIsEditing(isEditing)
     if (entity && !isEditing) {
       setLocalValue(entity.state)
     }
-  }, [entity, isEditing])
+  }
 
   const handleClick = useCallback(() => {
     if (!isEditing) {

--- a/src/components/InputNumberCard.tsx
+++ b/src/components/InputNumberCard.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useState, useEffect } from 'react'
+import React, { memo, useCallback, useState } from 'react'
 import { Box, Flex, IconButton, Text, TextField } from '@radix-ui/themes'
 import { Archive, Hash, Minus, Plus } from 'lucide-react'
 import { useEntity } from '../hooks/useEntity'
@@ -34,15 +34,21 @@ export const InputNumberCard = memo(function InputNumberCard({
   const { entity, isConnected, isLoading: isEntityLoading } = useEntity(entityId)
   const { setValue, loading, error } = useServiceCall()
 
-  const [localValue, setLocalValue] = useState<string>('')
+  const [localValue, setLocalValue] = useState<string>(entity?.state ?? '')
   const [isEditing, setIsEditing] = useState(false)
 
-  // Update local value when entity changes
-  useEffect(() => {
+  // Sync the local value from the entity while the user is not editing. Done
+  // during render (not in an effect) per react-hooks/set-state-in-effect; the
+  // previous-value guards reproduce the old effect's [entity, isEditing] triggers.
+  const [prevEntity, setPrevEntity] = useState(entity)
+  const [prevIsEditing, setPrevIsEditing] = useState(isEditing)
+  if (entity !== prevEntity || isEditing !== prevIsEditing) {
+    setPrevEntity(entity)
+    setPrevIsEditing(isEditing)
     if (entity && !isEditing) {
       setLocalValue(entity.state)
     }
-  }, [entity, isEditing])
+  }
 
   const handleClick = useCallback(() => {
     // Card click is handled by GridCard

--- a/src/components/KeepAlive.tsx
+++ b/src/components/KeepAlive.tsx
@@ -10,38 +10,50 @@ interface KeepAliveProps {
 // Global cache to store portal elements
 const portalCache = new Map<string, HTMLDivElement>()
 
+// Get (or lazily create) the cached portal element for a key. Idempotent: the
+// module-level cache guarantees one element per key, so it is safe to call
+// during render.
+function getOrCreatePortalElement(cacheKey: string): HTMLDivElement | null {
+  if (typeof document === 'undefined') return null
+
+  let element = portalCache.get(cacheKey)
+  if (!element) {
+    element = document.createElement('div')
+    element.style.width = '100%'
+    element.style.height = '100%'
+    portalCache.set(cacheKey, element)
+  }
+  return element
+}
+
 export function KeepAlive({ children, cacheKey, containerRef }: KeepAliveProps) {
-  // Use state instead of ref to track portal element - this triggers re-render when set
-  const [portalElement, setPortalElement] = useState<HTMLDivElement | null>(() => {
-    // Initialize from cache synchronously during initial render
-    return portalCache.get(cacheKey) ?? null
-  })
+  // Resolve the portal element during render (no setState in an effect). The
+  // element is stable per cacheKey, so children keep their state across moves.
+  const [portalElement, setPortalElement] = useState<HTMLDivElement | null>(() =>
+    getOrCreatePortalElement(cacheKey)
+  )
+  const [prevCacheKey, setPrevCacheKey] = useState(cacheKey)
+  if (cacheKey !== prevCacheKey) {
+    setPrevCacheKey(cacheKey)
+    setPortalElement(getOrCreatePortalElement(cacheKey))
+  }
 
   useEffect(() => {
-    // Get or create portal element for this cache key
-    let element = portalCache.get(cacheKey)
+    if (!portalElement) return
 
-    if (!element) {
-      element = document.createElement('div')
-      element.style.width = '100%'
-      element.style.height = '100%'
-      portalCache.set(cacheKey, element)
-    }
-
-    setPortalElement(element)
-
-    // Append portal element to container
-    if (containerRef.current && element) {
-      containerRef.current.appendChild(element)
+    // Append portal element to the current container.
+    const container = containerRef.current
+    if (container) {
+      container.appendChild(portalElement)
     }
 
     return () => {
-      // Remove portal element from current container but don't destroy it
-      if (element && element.parentNode) {
-        element.parentNode.removeChild(element)
+      // Remove portal element from current container but don't destroy it.
+      if (portalElement.parentNode) {
+        portalElement.parentNode.removeChild(portalElement)
       }
     }
-  }, [cacheKey, containerRef])
+  }, [portalElement, containerRef])
 
   // Render children into the cached portal element
   if (!portalElement) return null

--- a/src/components/KeepAlive.tsx
+++ b/src/components/KeepAlive.tsx
@@ -29,13 +29,15 @@ function getOrCreatePortalElement(cacheKey: string): HTMLDivElement | null {
 export function KeepAlive({ children, cacheKey, containerRef }: KeepAliveProps) {
   // Resolve the portal element during render (no setState in an effect). The
   // element is stable per cacheKey, so children keep their state across moves.
+  // getOrCreatePortalElement is idempotent, so deriving the expected element
+  // each render and syncing state only when it changes keeps the value current
+  // without tracking the previous cacheKey.
   const [portalElement, setPortalElement] = useState<HTMLDivElement | null>(() =>
     getOrCreatePortalElement(cacheKey)
   )
-  const [prevCacheKey, setPrevCacheKey] = useState(cacheKey)
-  if (cacheKey !== prevCacheKey) {
-    setPrevCacheKey(cacheKey)
-    setPortalElement(getOrCreatePortalElement(cacheKey))
+  const expectedElement = getOrCreatePortalElement(cacheKey)
+  if (expectedElement !== portalElement) {
+    setPortalElement(expectedElement)
   }
 
   useEffect(() => {

--- a/src/components/__tests__/InputDateTimeCard.test.tsx
+++ b/src/components/__tests__/InputDateTimeCard.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Theme } from '@radix-ui/themes'
+import { InputDateTimeCard } from '../InputDateTimeCard'
+import { useEntity } from '../../hooks/useEntity'
+import { useServiceCall } from '../../hooks/useServiceCall'
+import type { HassEntity } from '~/store/entityTypes'
+
+vi.mock('../../hooks/useEntity', () => ({ useEntity: vi.fn() }))
+vi.mock('../../hooks/useServiceCall', () => ({ useServiceCall: vi.fn() }))
+
+const createEntity = (state: string): HassEntity => ({
+  entity_id: 'input_datetime.test',
+  state,
+  // has_time: false => a plain `date` input, easy to assert on.
+  attributes: { friendly_name: 'Test Date', has_date: true, has_time: false },
+  last_changed: '2023-01-01T00:00:00Z',
+  last_updated: '2023-01-01T00:00:00Z',
+  context: { id: 'test-id', parent_id: null, user_id: null },
+})
+
+function mockEntity(state: string) {
+  vi.mocked(useEntity).mockReturnValue({
+    entity: createEntity(state),
+    isConnected: true,
+    isLoading: false,
+    isStale: false,
+  } as unknown as ReturnType<typeof useEntity>)
+}
+
+// memo()'d like InputNumberCard: toggle a prop to simulate a store-driven
+// re-render while the useEntity mock returns a fresh entity object.
+const card = (isSelected: boolean) => (
+  <Theme>
+    <InputDateTimeCard entityId="input_datetime.test" isSelected={isSelected} />
+  </Theme>
+)
+
+describe('InputDateTimeCard local value sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useServiceCall).mockReturnValue({
+      setValue: vi.fn(),
+      loading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useServiceCall>)
+  })
+
+  it('seeds the edit field with the latest entity state while not editing', async () => {
+    const user = userEvent.setup()
+    mockEntity('2023-01-15')
+    const { rerender, container } = render(card(false))
+
+    // Entity updates while not editing (store-driven re-render).
+    mockEntity('2023-06-20')
+    rerender(card(true))
+
+    // Enter edit mode by clicking the card, then the input reflects the synced value.
+    await user.click(screen.getByText('Test Date'))
+    const input = container.querySelector('input') as HTMLInputElement
+    expect(input).not.toBeNull()
+    expect(input.value).toBe('2023-06-20')
+  })
+})

--- a/src/components/__tests__/InputNumberCard.test.tsx
+++ b/src/components/__tests__/InputNumberCard.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Theme } from '@radix-ui/themes'
+import { InputNumberCard } from '../InputNumberCard'
+import { useEntity } from '../../hooks/useEntity'
+import { useServiceCall } from '../../hooks/useServiceCall'
+import type { HassEntity } from '~/store/entityTypes'
+
+vi.mock('../../hooks/useEntity', () => ({ useEntity: vi.fn() }))
+vi.mock('../../hooks/useServiceCall', () => ({ useServiceCall: vi.fn() }))
+
+const createEntity = (state: string): HassEntity => ({
+  entity_id: 'input_number.test',
+  state,
+  attributes: { friendly_name: 'Test Number', min: 0, max: 100, step: 1 },
+  last_changed: '2023-01-01T00:00:00Z',
+  last_updated: '2023-01-01T00:00:00Z',
+  context: { id: 'test-id', parent_id: null, user_id: null },
+})
+
+function mockEntity(state: string) {
+  vi.mocked(useEntity).mockReturnValue({
+    entity: createEntity(state),
+    isConnected: true,
+    isLoading: false,
+    isStale: false,
+  } as unknown as ReturnType<typeof useEntity>)
+}
+
+// InputNumberCard is memo()'d, so a store-driven update (which re-renders it in
+// the app via useEntity's subscription) is simulated by toggling a prop while
+// the useEntity mock returns a fresh entity object.
+const card = (isSelected: boolean) => (
+  <Theme>
+    <InputNumberCard entityId="input_number.test" isSelected={isSelected} />
+  </Theme>
+)
+
+describe('InputNumberCard local value sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useServiceCall).mockReturnValue({
+      setValue: vi.fn(),
+      loading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useServiceCall>)
+  })
+
+  it('seeds the edit field with the latest entity state while not editing', async () => {
+    const user = userEvent.setup()
+    mockEntity('5')
+    const { rerender } = render(card(false))
+
+    // Entity updates while not editing (store-driven re-render).
+    mockEntity('10')
+    rerender(card(true))
+
+    // Entering edit mode shows the synced value (10), not the stale mount value (5).
+    await user.click(screen.getByText('10'))
+    expect(screen.getByRole('textbox')).toHaveValue('10')
+  })
+
+  it('does not clobber the edited value when the entity updates mid-edit', async () => {
+    const user = userEvent.setup()
+    mockEntity('5')
+    const { rerender } = render(card(false))
+
+    // Enter edit mode and type a new value.
+    await user.click(screen.getByText('5'))
+    const input = screen.getByRole('textbox')
+    await user.clear(input)
+    await user.type(input, '42')
+    expect(input).toHaveValue('42')
+
+    // Entity pushes an update while the user is still editing (store-driven re-render).
+    mockEntity('99')
+    rerender(card(true))
+
+    // The in-progress edit is preserved (not overwritten by the entity state).
+    expect(screen.getByRole('textbox')).toHaveValue('42')
+  })
+})

--- a/src/components/__tests__/KeepAlive.test.tsx
+++ b/src/components/__tests__/KeepAlive.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { useRef } from 'react'
+import { render } from '@testing-library/react'
+import { KeepAlive } from '../KeepAlive'
+
+// Test harness: renders KeepAlive into a container ref, optionally switching
+// between two containers to exercise the move-without-remount behavior.
+function Harness({ cacheKey, useSecond = false }: { cacheKey: string; useSecond?: boolean }) {
+  const first = useRef<HTMLDivElement>(null)
+  const second = useRef<HTMLDivElement>(null)
+  return (
+    <div>
+      <div data-testid="first" ref={first} />
+      <div data-testid="second" ref={second} />
+      <KeepAlive cacheKey={cacheKey} containerRef={useSecond ? second : first}>
+        <span data-testid="child">content</span>
+      </KeepAlive>
+    </div>
+  )
+}
+
+describe('KeepAlive', () => {
+  it('portals children into a cached element inside the target container', () => {
+    const { getByTestId } = render(<Harness cacheKey="k-portal" />)
+
+    const first = getByTestId('first')
+    const child = getByTestId('child')
+
+    // Child renders inside the container's cached portal element.
+    expect(first.contains(child)).toBe(true)
+  })
+
+  it('reuses the same DOM element (keeps children alive) when moved between containers', () => {
+    const { getByTestId, rerender } = render(<Harness cacheKey="k-move" useSecond={false} />)
+
+    const first = getByTestId('first')
+    const second = getByTestId('second')
+    const childBefore = getByTestId('child')
+    const portalEl = childBefore.parentElement
+    expect(first.contains(childBefore)).toBe(true)
+
+    // Switch the container ref: the same portal element (and its children) moves.
+    rerender(<Harness cacheKey="k-move" useSecond={true} />)
+
+    const childAfter = getByTestId('child')
+    expect(second.contains(childAfter)).toBe(true)
+    expect(first.contains(childAfter)).toBe(false)
+    // Same portal element instance was reused, not recreated.
+    expect(childAfter.parentElement).toBe(portalEl)
+  })
+})

--- a/src/hooks/useWebRTC.ts
+++ b/src/hooks/useWebRTC.ts
@@ -494,9 +494,8 @@ export function useWebRTC({ entityId, enabled = true }: UseWebRTCOptions): UseWe
 
   // Initialize WebRTC when conditions are met
   useEffect(() => {
-    // Cleanup if disabled or entity changed
+    // Teardown when disabled is handled by the dedicated teardown effect below.
     if (!enabled) {
-      cleanup()
       return
     }
 
@@ -533,7 +532,7 @@ export function useWebRTC({ entityId, enabled = true }: UseWebRTCOptions): UseWe
       clearTimeout(timer)
       pendingInitRef.current = false
     }
-  }, [enabled, hass, entityId, retryCount, cleanup, initializeWebRTC])
+  }, [enabled, hass, entityId, retryCount, initializeWebRTC])
 
   // Store cleanup function in ref for access in event listener
   useEffect(() => {
@@ -573,12 +572,16 @@ export function useWebRTC({ entityId, enabled = true }: UseWebRTCOptions): UseWe
     }
   }, [enabled, entityId, cleanup])
 
-  // Cleanup on unmount
+  // Tear down the connection when the hook becomes disabled or on unmount.
+  // Teardown runs in the effect-cleanup (not the effect body), so the state
+  // reset inside cleanup() is not a synchronous setState in an effect body
+  // (react-hooks/set-state-in-effect).
   useEffect(() => {
+    if (!enabled) return
     return () => {
       cleanup()
     }
-  }, [cleanup])
+  }, [enabled, cleanup])
 
   return {
     videoRef,


### PR DESCRIPTION
## Summary

Group B of docs/changes/0003-reenable-react-hooks-rules.md — the final PR for the change. Enables `react-hooks/set-state-in-effect` and `react-hooks/preserve-manual-memoization` at `error`; all five react-hooks v7 rules are now enforced with zero violations and zero suppressions added.

Post-merge audit found 5 `set-state-in-effect` violations (the 4 inventoried in the Group A PR, plus one introduced by Group A's own teardown restructure in `useWebRTC`); `preserve-manual-memoization` confirmed at 0.

## Fixes (underlying patterns, no blanket suppressions)

- `app/utils/responsive.ts` — `useMediaQuery` rewritten on `useSyncExternalStore` (no effect at all; re-syncs on query change via snapshot).
- `InputNumberCard.tsx` / `InputDateTimeCard.tsx` — `localValue` syncs from the entity during render with previous-value guards reproducing the old effect's triggers; in-progress edits preserved.
- `KeepAlive.tsx` — cached portal element resolved during render (lazy init + render-time cache-key sync); the effect now only mounts/unmounts the element.
- `useWebRTC.ts` — teardown moved to a dedicated `enabled`-keyed effect's cleanup return (setState in effect-cleanup is allowed); disable/unmount behavior unchanged, validated by the existing reactive-teardown test.
- Stale `exhaustive-deps` sweep: only `CardConfig.tsx:434` remains and is still load-bearing; left in place.

## Completes change 0003

- Change doc: Group B tasks ticked, Open Question resolved (all five rules at `error`, matching the zero-warning bar), **Status → complete**.
- `docs/index.yml` / `docs/index.md`: 0003 → complete.
- Architecture spec: lint scenario now states all five rules enforced; resolved Open Question removed.

## Testing

- [x] `npm test` — 539 passed, 2 pre-existing skips (+8 new tests: responsive, KeepAlive, InputNumberCard, InputDateTimeCard; no existing tests modified)
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run typecheck` — clean
- [x] `npm run build:ha:prod` — passes
- [x] Local Codex review clean; CodeRabbit gated by the PR-level check