### PR TITLE
fix(camera): style the stream surface focus ring instead of the UA ring

### DIFF
--- a/src/components/CameraCard/CameraCard.css
+++ b/src/components/CameraCard/CameraCard.css
@@ -36,20 +36,26 @@
    (pressing ESC to leave the zoom is the usual one), every later tap keeps the
    ring until the card unmounts. Hence "sometimes, and it goes away on a
    re-render". Replace the UA ring with the Radix focus token, and drop it for
-   pointer-only focus. */
+   pointer-only focus.
+   Ordered so the ring is the FALLBACK, not the enhancement: a browser without
+   :focus-visible support drops the `:not(:focus-visible)` rule as invalid and
+   keeps the plain `:focus` ring, rather than being left with no keyboard focus
+   indicator at all. */
 .camera-stream-surface:focus {
-  outline: none;
-}
-
-.camera-stream-surface:focus-visible {
   outline: 2px solid var(--focus-8);
   /* Inset so the ring is not clipped by the card's overflow: hidden. */
   outline-offset: -2px;
 }
 
+.camera-stream-surface:focus:not(:focus-visible) {
+  outline: none;
+}
+
 /* In zoom the surface IS the viewport, so a ring hugging the screen edges is
    pure noise — the always-visible "Click or press ESC to exit" hint is the
-   affordance there. */
+   affordance there. Both selectors, so the ring stays suppressed where
+   :focus-visible is unsupported too. */
+.camera-stream-surface-fullscreen:focus,
 .camera-stream-surface-fullscreen:focus-visible {
   outline: none;
 }

--- a/src/components/CameraCard/CameraCard.css
+++ b/src/components/CameraCard/CameraCard.css
@@ -29,6 +29,31 @@
   }
 }
 
+/* The stream surface is a role=button (tap toggles the in-place zoom), so a
+   pointer tap focuses it too. Chrome then paints its UA ring — `outline: auto`,
+   which reads as a white border over the dark stream — and its :focus-visible
+   heuristic makes that ring STICKY: once any keyboard interaction has happened
+   (pressing ESC to leave the zoom is the usual one), every later tap keeps the
+   ring until the card unmounts. Hence "sometimes, and it goes away on a
+   re-render". Replace the UA ring with the Radix focus token, and drop it for
+   pointer-only focus. */
+.camera-stream-surface:focus {
+  outline: none;
+}
+
+.camera-stream-surface:focus-visible {
+  outline: 2px solid var(--focus-8);
+  /* Inset so the ring is not clipped by the card's overflow: hidden. */
+  outline-offset: -2px;
+}
+
+/* In zoom the surface IS the viewport, so a ring hugging the screen edges is
+   pure noise — the always-visible "Click or press ESC to exit" hint is the
+   affordance there. */
+.camera-stream-surface-fullscreen:focus-visible {
+  outline: none;
+}
+
 .camera-control-button {
   position: relative;
   width: 2.5em;

--- a/src/components/CameraCard/__tests__/CameraCard.test.tsx
+++ b/src/components/CameraCard/__tests__/CameraCard.test.tsx
@@ -560,6 +560,27 @@ describe('CameraCard', () => {
       expect(host.getAttribute('data-fit')).toBe('cover')
     })
 
+    // The surface is a role=button, so a tap focuses it and Chrome paints its
+    // UA focus ring (a white border over the dark stream) — stickily, once any
+    // keyboard interaction has flipped :focus-visible on. These classes carry
+    // the CSS that replaces that ring with the Radix one in the card and drops
+    // it entirely in fullscreen, where the surface fills the viewport.
+    it('marks the stream surface so its focus ring is styled, and flags fullscreen', () => {
+      renderCard()
+      const host = getStreamHost()
+      const streamContainer = host.parentElement as HTMLElement
+
+      expect(streamContainer).toHaveClass('camera-stream-surface')
+      expect(streamContainer).not.toHaveClass('camera-stream-surface-fullscreen')
+
+      fireEvent.click(host)
+      expect(streamContainer).toHaveClass('camera-stream-surface')
+      expect(streamContainer).toHaveClass('camera-stream-surface-fullscreen')
+
+      fireEvent.click(host)
+      expect(streamContainer).not.toHaveClass('camera-stream-surface-fullscreen')
+    })
+
     it('keeps the exact same stream element instance across toggles (no remount)', () => {
       renderCard()
       const host = getStreamHost()

--- a/src/components/CameraCard/index.tsx
+++ b/src/components/CameraCard/index.tsx
@@ -402,6 +402,7 @@ function CameraCardComponent({
           {supportsStream ? (
             <div
               ref={streamContainerRef}
+              className={`camera-stream-surface${isFullscreen ? ' camera-stream-surface-fullscreen' : ''}`}
               role={videoClickable ? 'button' : undefined}
               tabIndex={videoClickable ? 0 : undefined}
               aria-label={videoClickable ? `Toggle fullscreen for ${friendlyName}` : undefined}

--- a/tests/e2e/camera-stream.spec.ts
+++ b/tests/e2e/camera-stream.spec.ts
@@ -195,6 +195,7 @@ async function expectVideoPlaying(page: Page, timeout: number): Promise<void> {
 // serialized form (and stays correct under either theme) rather than pinned to a
 // literal rgb().
 async function readSurfaceOutline(page: Page): Promise<{
+  focused: boolean
   focusVisible: boolean
   outlineStyle: string
   outlineWidth: string
@@ -213,6 +214,7 @@ async function readSurfaceOutline(page: Page): Promise<{
     const focusColor = getComputedStyle(probe).color
     probe.remove()
     return {
+      focused: surface.matches(':focus'),
       focusVisible: surface.matches(':focus-visible'),
       outlineStyle,
       outlineWidth,
@@ -546,6 +548,9 @@ test('seeded camera card plays the synthetic stream and survives fullscreen', as
   // behind, which must show no ring at all. (The keyboard leg is asserted after
   // transition 4, once ESC has flipped :focus-visible on.)
   const ringAfterTap = await readSurfaceOutline(page)
+  // Focused is asserted explicitly: without it an UNfocused surface would
+  // satisfy the two checks below, proving nothing about the pointer-focus rule.
+  expect(ringAfterTap.focused, 'a tap leaves the surface focused').toBe(true)
   expect(ringAfterTap.focusVisible, 'a tap does not make the surface :focus-visible').toBe(false)
   expect(ringAfterTap.outlineStyle, 'no focus ring on the card after a pointer tap').toBe('none')
 

--- a/tests/e2e/camera-stream.spec.ts
+++ b/tests/e2e/camera-stream.spec.ts
@@ -186,6 +186,23 @@ async function expectVideoPlaying(page: Page, timeout: number): Promise<void> {
     .toBe(true)
 }
 
+// Read the focus state and the resolved outline of the clickable stream surface
+// (the role=button container). `outlineStyle` is 'auto' only for Chrome's
+// unstyled UA focus ring — the white border this guards against.
+async function readSurfaceOutline(
+  page: Page
+): Promise<{ focusVisible: boolean; outlineStyle: string }> {
+  return page.evaluate(() => {
+    const panel = (window as unknown as PanelWindow).__liebePanel
+    const surface = panel?.shadowRoot?.querySelector('.camera-stream-surface')
+    if (!surface) throw new Error('camera stream surface not found')
+    return {
+      focusVisible: surface.matches(':focus-visible'),
+      outlineStyle: getComputedStyle(surface).outlineStyle,
+    }
+  })
+}
+
 // Coordinates over Home Assistant's own chrome (its left sidebar) — NOT over the
 // panel content. Before fullscreen a topmost hit-test here lands in HA's
 // <ha-sidebar>; while the in-place fullscreen overlay is open the overlay must
@@ -576,6 +593,32 @@ test('seeded camera card plays the synthetic stream and survives fullscreen', as
     continuity[continuity.length - 1].currentTime,
     'currentTime keeps advancing across the toggles'
   ).toBeGreaterThan(continuity[0].currentTime)
+
+  // --- Focus-ring assertion -------------------------------------------------
+  // The stream surface is a role=button, so a tap focuses it, and the ESC in
+  // transition 4 flipped Chrome's :focus-visible heuristic on — exactly the
+  // state that used to leave the UA ring (`outline-style: auto`, painted white
+  // over the dark stream) stuck on the card and on the overlay for every later
+  // tap. The ring must now be the styled Radix one while the card is in the
+  // grid...
+  const ringInCard = await readSurfaceOutline(page)
+  expect(ringInCard.focusVisible, 'the stream surface is keyboard-focused after ESC').toBe(true)
+  expect(ringInCard.outlineStyle, 'no raw UA focus ring on the card').not.toBe('auto')
+  expect(ringInCard.outlineStyle, 'styled focus ring while keyboard-focused in the card').toBe(
+    'solid'
+  )
+  // ...and absent entirely in fullscreen, where the surface fills the viewport.
+  await page.locator('ha-camera-stream').click()
+  await expect(exitHint, 'fullscreen overlay reopens for the focus-ring check').toBeVisible({
+    timeout: 15_000,
+  })
+  const ringInFullscreen = await readSurfaceOutline(page)
+  expect(ringInFullscreen.focusVisible, 'still :focus-visible in fullscreen').toBe(true)
+  expect(ringInFullscreen.outlineStyle, 'no focus ring around the fullscreen overlay').toBe('none')
+  await page.keyboard.press('Escape')
+  await expect(exitHint, 'fullscreen overlay closes after the focus-ring check').toBeHidden({
+    timeout: 15_000,
+  })
 
   // 9. No fatal console errors or unhandled rejections across the whole flow
   // (benign HA/player startup noise filtered by the collector).

--- a/tests/e2e/camera-stream.spec.ts
+++ b/tests/e2e/camera-stream.spec.ts
@@ -186,19 +186,39 @@ async function expectVideoPlaying(page: Page, timeout: number): Promise<void> {
     .toBe(true)
 }
 
-// Read the focus state and the resolved outline of the clickable stream surface
-// (the role=button container). `outlineStyle` is 'auto' only for Chrome's
-// unstyled UA focus ring — the white border this guards against.
-async function readSurfaceOutline(
-  page: Page
-): Promise<{ focusVisible: boolean; outlineStyle: string }> {
+// Read the focus state and the fully resolved outline of the clickable stream
+// surface (the role=button container). `outlineStyle` is 'auto' only for
+// Chrome's unstyled UA focus ring — the white border this guards against. The
+// width/offset/color come along so a regression to a clipped (offset 0), hairline,
+// or off-token ring fails too. `focusColor` resolves --focus-8 through a probe
+// element parented to the surface, so the expected color is compared in the same
+// serialized form (and stays correct under either theme) rather than pinned to a
+// literal rgb().
+async function readSurfaceOutline(page: Page): Promise<{
+  focusVisible: boolean
+  outlineStyle: string
+  outlineWidth: string
+  outlineOffset: string
+  outlineColor: string
+  focusColor: string
+}> {
   return page.evaluate(() => {
     const panel = (window as unknown as PanelWindow).__liebePanel
     const surface = panel?.shadowRoot?.querySelector('.camera-stream-surface')
     if (!surface) throw new Error('camera stream surface not found')
+    const { outlineStyle, outlineWidth, outlineOffset, outlineColor } = getComputedStyle(surface)
+    const probe = document.createElement('span')
+    probe.style.color = 'var(--focus-8)'
+    surface.appendChild(probe)
+    const focusColor = getComputedStyle(probe).color
+    probe.remove()
     return {
       focusVisible: surface.matches(':focus-visible'),
-      outlineStyle: getComputedStyle(surface).outlineStyle,
+      outlineStyle,
+      outlineWidth,
+      outlineOffset,
+      outlineColor,
+      focusColor,
     }
   })
 }
@@ -521,6 +541,14 @@ test('seeded camera card plays the synthetic stream and survives fullscreen', as
   await expectVideoPlaying(page, 30_000)
   continuity.push(await sampleContinuity(page)) // checkpoint 2: letterbox-closed
 
+  // Focus ring, pointer-only leg: transitions 1-2 were both taps, so the
+  // surface is focused but NOT :focus-visible — the state a plain tap leaves
+  // behind, which must show no ring at all. (The keyboard leg is asserted after
+  // transition 4, once ESC has flipped :focus-visible on.)
+  const ringAfterTap = await readSurfaceOutline(page)
+  expect(ringAfterTap.focusVisible, 'a tap does not make the surface :focus-visible').toBe(false)
+  expect(ringAfterTap.outlineStyle, 'no focus ring on the card after a pointer tap').toBe('none')
+
   // 7. TRANSITION 3 (reopen): the ESC path shares the same in-place overlay, but
   // the key handler wiring is only exercised in a real browser. Reopen first.
   await page.locator('ha-camera-stream').click()
@@ -604,9 +632,21 @@ test('seeded camera card plays the synthetic stream and survives fullscreen', as
   const ringInCard = await readSurfaceOutline(page)
   expect(ringInCard.focusVisible, 'the stream surface is keyboard-focused after ESC').toBe(true)
   expect(ringInCard.outlineStyle, 'no raw UA focus ring on the card').not.toBe('auto')
-  expect(ringInCard.outlineStyle, 'styled focus ring while keyboard-focused in the card').toBe(
-    'solid'
-  )
+  expect(
+    {
+      style: ringInCard.outlineStyle,
+      width: ringInCard.outlineWidth,
+      // Negative: an outward ring would be clipped by the card's overflow.
+      offset: ringInCard.outlineOffset,
+      color: ringInCard.outlineColor,
+    },
+    'the full styled focus ring while keyboard-focused in the card'
+  ).toEqual({
+    style: 'solid',
+    width: '2px',
+    offset: '-2px',
+    color: ringInCard.focusColor,
+  })
   // ...and absent entirely in fullscreen, where the surface fills the viewport.
   await page.locator('ha-camera-stream').click()
   await expect(exitHint, 'fullscreen overlay reopens for the focus-ring check').toBeVisible({


### PR DESCRIPTION
## Summary

The camera card sometimes kept a white border after being tapped, and it disappeared again on an unrelated re-render.

**Cause.** The clickable stream surface is a `role="button"` with `tabIndex=0`, so a pointer tap focuses it and Chrome paints its default focus ring — `outline: auto`, which renders white over the dark stream. Chrome's `:focus-visible` heuristic is what makes it look intermittent: it stays off for a plain mouse click, but any keyboard interaction flips it on for the focused element and it then sticks. Pressing **ESC to leave the in-app zoom** is the everyday trigger, so every tap after that keeps the ring — around the card in the grid, and around the whole viewport-filling overlay in zoom. It "goes away on a re-render" only when the card actually unmounts (grid or screen change), which destroys the focused node.

Measured against the dockerized HA instance:

```
after mouse click  outline: none      focusVisible: false
after ESC exit     outline: auto 1px  focusVisible: true   ← white ring appears
mouse click #2     outline: auto 1px  focusVisible: true   ← sticks, now around the zoom overlay
```

It persisted unchanged through 30 s of stream re-renders, so it is not transient.

**Fix.** Replace the UA ring with an intentional one, in `CameraCard.css`:

- no ring for pointer-only focus (`:focus`)
- a `2px solid var(--focus-8)` ring while keyboard-focused in the grid, with `outline-offset: -2px` so the card's `overflow: hidden` cannot clip it
- no ring at all in zoom, where the surface fills the viewport and the always-visible "Click or press ESC to exit" hint is the affordance

Keyboard accessibility is preserved: tabbing to the surface still shows a ring in the grid.

## Testing

- [x] All tests pass locally (`npx vitest run`)
- [x] Linting passes (`npm run lint` — tsc + eslint + prettier)
- [x] TypeScript checks pass (included in `npm run lint`)
- [x] Tested in Home Assistant (dockerized e2e instance, real Chromium)

Unit test covers the surface classes across a zoom toggle. The e2e spec asserts the resolved outline right after its existing ESC transition — `outlineStyle !== 'auto'` (and `solid`) in the card, `none` in zoom. Reverting just the CSS makes that assertion fail (`Expected: not "auto"`), so the guard is real.

```
Test Files  61 passed (61)
     Tests  795 passed | 2 skipped (797)

✓  1 [chromium] › tests/e2e/camera-stream.spec.ts:335:1 › seeded camera card plays the synthetic stream and survives fullscreen (9.9s)
```

## Notes

`codex review` could not be run as part of pre-PR self-review: the account is over its usage limit until Jul 28.

Unrelated leftover spotted while investigating, not touched here: `src/styles/app.css:35` has `.using-mouse * { outline: none !important }`, but nothing anywhere adds the `using-mouse` class — dead code, and likely a vestige of an earlier attempt at this same problem.
