### PR TITLE
test(panel): give the custom-element test a module-loading timeout

### DIFF
--- a/src/__tests__/panel.test.ts
+++ b/src/__tests__/panel.test.ts
@@ -13,23 +13,33 @@ describe('LiebePanel custom element', () => {
     vi.useRealTimers()
   })
 
-  it('mounts a shadow root whose React container is tagged data-liebe-root', async () => {
-    await import('../panel')
+  // `import('../panel')` pulls the whole application module graph — React, Radix
+  // Themes, react-grid-layout and their CSS — through Vitest's transform. That
+  // costs ~1s in isolation and several times more under full-suite worker
+  // contention, so the 5s default timeout fails this test in CI while it passes
+  // when the file is run alone. The budget is generous on purpose: it is sized
+  // for module loading, not for the assertions, and still catches a real hang.
+  it(
+    'mounts a shadow root whose React container is tagged data-liebe-root',
+    { timeout: 30_000 },
+    async () => {
+      await import('../panel')
 
-    const { elementName } = getPanelConfig()
-    expect(customElements.get(elementName)).toBeTruthy()
+      const { elementName } = getPanelConfig()
+      expect(customElements.get(elementName)).toBeTruthy()
 
-    const panel = document.createElement(elementName)
-    document.body.appendChild(panel)
-    try {
-      const container = panel.shadowRoot?.querySelector('[data-liebe-root]') as HTMLElement | null
-      // Contract with resolvePanelPortalContainer: the tagged div is the
-      // React root that in-panel portals target.
-      expect(container).not.toBeNull()
-      expect(container?.style.height).toBe('100%')
-      expect(container?.parentNode).toBe(panel.shadowRoot)
-    } finally {
-      panel.remove()
+      const panel = document.createElement(elementName)
+      document.body.appendChild(panel)
+      try {
+        const container = panel.shadowRoot?.querySelector('[data-liebe-root]') as HTMLElement | null
+        // Contract with resolvePanelPortalContainer: the tagged div is the
+        // React root that in-panel portals target.
+        expect(container).not.toBeNull()
+        expect(container?.style.height).toBe('100%')
+        expect(container?.parentNode).toBe(panel.shadowRoot)
+      } finally {
+        panel.remove()
+      }
     }
-  })
+  )
 })


### PR DESCRIPTION
## Summary

`src/__tests__/panel.test.ts` fails on `main` under the full test suite, while passing when its file is run alone. This gives it a timeout sized for what it actually does.

## Cause

Cost, not a hang. The test's assertions are trivial — the expense is `await import('../panel')`, which pulls the entire application module graph (React, Radix Themes, react-grid-layout, and their CSS) through Vitest's transform.

Measured in isolation with a warm cache: **~987ms**. Under 61-file parallel worker contention that multiplies past the 5s default, and the test times out at ~5073ms. That is also why it looks flaky — it passes standalone (3.9s) and fails in CI, purely on transform contention.

## Fix

An explicit 30s timeout on this one test, rather than raising `testTimeout` globally — a global bump would weaken hang detection for the other 794 tests to fix one. The budget is sized for module loading rather than the assertions, and still fails loudly on a genuine deadlock.

## Testing

Full suite before: `1 failed | 794 passed`, `Test Files 1 failed | 60 passed`.
Full suite after: **`61 passed (61)` files, `795 passed | 2 skipped (797)` tests, 0 failed.**

- `npm run lint` passes (tsc, eslint, prettier).

No production code changes — test file only.
