### PR TITLE
feat(storybook): scaffold the component workshop with fixtures and first stories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ pnpm-lock.yaml
 /public/build
 dist/
 .vite-temp/
+storybook-static/
 
 # Development
 .DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 **/build
 **/public
 coverage/
+storybook-static/
 pnpm-lock.yaml
 routeTree.gen.ts
 .tailscale/

--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -1,10 +1,16 @@
 import { useLayoutEffect, useMemo, type CSSProperties, type ReactNode } from 'react'
 import type { Decorator } from '@storybook/react-vite'
+import { useGlobals } from 'storybook/preview-api'
 import { HomeAssistantProvider } from '~/contexts/HomeAssistantContext'
 import { LiebeThemeProvider } from '~/components/LiebeThemeProvider'
 import { dashboardStore } from '~/store/dashboardStore'
 import { entityStore } from '~/store/entityStore'
-import { getTheme, resolveAppearance, type ThemeAppearance } from '~/theme/themeRegistry'
+import {
+  DEFAULT_THEME_ID,
+  getTheme,
+  resolveAppearance,
+  type ThemeAppearance,
+} from '~/theme/themeRegistry'
 import type { LiebeStoryParameters } from '~/test/fixtures'
 import { gridConfig } from '../app/utils/responsive'
 import { createMockHass } from './mockHass'
@@ -123,11 +129,27 @@ export const withServiceCalls: Decorator = (Story, context) => (
  * Wraps every story in the panel's provider shell and stamps the theming
  * engine's contract attributes (`data-liebe-theme`, `data-appearance`) so
  * scoped theme rules have the same hooks they get in the panel.
+ *
+ * Single-appearance themes force their appearance, and the forced value is
+ * written back into the toolbar global so the control shows what is actually
+ * rendered instead of a choice the theme cannot honour.
+ *
+ * `useGlobals` is Storybook's own hook for reading and writing toolbar state,
+ * and a decorator is where Storybook expects it — hence the rules-of-hooks
+ * exemption below, which the react-hooks plugin cannot infer from the name.
  */
-export const withProviders: Decorator = (Story, context) => {
-  const themeId = String(context.globals.theme ?? 'default')
-  const requested = (context.globals.appearance as ThemeAppearance | undefined) ?? 'dark'
-  const appearance = resolveAppearance(getTheme(themeId), requested)
+export const withProviders: Decorator = (Story) => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const [globals, updateGlobals] = useGlobals()
+
+  const themeId = String(globals.theme ?? DEFAULT_THEME_ID)
+  const theme = getTheme(themeId)
+  const requested = (globals.appearance as ThemeAppearance | undefined) ?? 'dark'
+  const appearance = resolveAppearance(theme, requested)
+
+  if (appearance !== requested) {
+    updateGlobals({ appearance })
+  }
 
   return (
     <LiebeThemeProvider appearance={appearance}>

--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -1,0 +1,221 @@
+import { useLayoutEffect, useMemo, type CSSProperties, type ReactNode } from 'react'
+import type { Decorator } from '@storybook/react-vite'
+import { HomeAssistantProvider } from '~/contexts/HomeAssistantContext'
+import { LiebeThemeProvider } from '~/components/LiebeThemeProvider'
+import { dashboardStore } from '~/store/dashboardStore'
+import { entityStore } from '~/store/entityStore'
+import { getTheme, resolveAppearance, type ThemeAppearance } from '~/theme/themeRegistry'
+import type { LiebeStoryParameters } from '~/test/fixtures'
+import { gridConfig } from '../app/utils/responsive'
+import { createMockHass } from './mockHass'
+
+/** Width the grid-cell decorator pretends the dashboard container has. */
+const STORY_CONTAINER_WIDTH = 1200
+
+const EMPTY_PARAMETERS: LiebeStoryParameters = {}
+
+function readLiebeParameters(parameters: Record<string, unknown>): LiebeStoryParameters {
+  return (parameters.liebe as LiebeStoryParameters | undefined) ?? EMPTY_PARAMETERS
+}
+
+/* ------------------------------------------------------------------ *
+ * Store seeding
+ * ------------------------------------------------------------------ */
+
+function seedStores(liebe: LiebeStoryParameters) {
+  const { entities = [], connected = true, initialLoading = false, mode = 'view' } = liebe
+
+  // Written straight to the store rather than through `entityStoreActions`:
+  // `setConnected` debounces disconnects by 500ms, which would make a
+  // "Disconnected" story render its connected state first.
+  entityStore.setState((state) => ({
+    ...state,
+    entities: Object.fromEntries(entities.map((entity) => [entity.entity_id, entity])),
+    isConnected: connected,
+    isInitialLoading: initialLoading,
+    lastError: null,
+    staleEntities: new Set<string>(),
+  }))
+
+  // `dashboardActions.setMode` persists to localStorage; a story's mode is not
+  // a user preference, so set the store field directly.
+  dashboardStore.setState((state) => ({ ...state, mode }))
+}
+
+function resetStores() {
+  entityStore.setState((state) => ({
+    ...state,
+    entities: {},
+    isConnected: false,
+    isInitialLoading: true,
+    staleEntities: new Set<string>(),
+  }))
+  dashboardStore.setState((state) => ({ ...state, mode: 'view' }))
+}
+
+function StoreSeed({ liebe, children }: { liebe: LiebeStoryParameters; children: ReactNode }) {
+  // Seeding in a layout effect keeps the brief first render against the empty
+  // store off-screen, and avoids mutating a store during React's render phase.
+  useLayoutEffect(() => {
+    seedStores(liebe)
+    return resetStores
+  }, [liebe])
+
+  return <>{children}</>
+}
+
+/**
+ * Seeds the entity and dashboard stores from the story's `liebe` parameter, so
+ * cards read their state through the same hooks they use in the panel — no
+ * card-side test props.
+ */
+export const withStoreSeed: Decorator = (Story, context) => (
+  <StoreSeed liebe={readLiebeParameters(context.parameters)}>
+    <Story />
+  </StoreSeed>
+)
+
+/* ------------------------------------------------------------------ *
+ * Service-call interception
+ * ------------------------------------------------------------------ */
+
+function ServiceCallHost({
+  liebe,
+  children,
+}: {
+  liebe: LiebeStoryParameters
+  children: ReactNode
+}) {
+  const { entities, serviceCall, serviceCallError } = liebe
+
+  const hass = useMemo(
+    () =>
+      createMockHass({
+        entities,
+        fail: serviceCall === 'error',
+        failureMessage: serviceCallError,
+      }),
+    [entities, serviceCall, serviceCallError]
+  )
+
+  return <HomeAssistantProvider hass={hass}>{children}</HomeAssistantProvider>
+}
+
+/**
+ * Supplies a network-free `hass` so service calls are logged as Storybook
+ * actions instead of reaching a WebSocket.
+ *
+ * Note for error stories: `HassService` retries a failing call three times with
+ * 1s/2s/4s backoff, so a card's error state appears roughly seven seconds after
+ * the interaction — that is the panel's real behavior, not a workshop artifact.
+ */
+export const withServiceCalls: Decorator = (Story, context) => (
+  <ServiceCallHost liebe={readLiebeParameters(context.parameters)}>
+    <Story />
+  </ServiceCallHost>
+)
+
+/* ------------------------------------------------------------------ *
+ * Providers (theme + appearance toolbar)
+ * ------------------------------------------------------------------ */
+
+/**
+ * Wraps every story in the panel's provider shell and stamps the theming
+ * engine's contract attributes (`data-liebe-theme`, `data-appearance`) so
+ * scoped theme rules have the same hooks they get in the panel.
+ */
+export const withProviders: Decorator = (Story, context) => {
+  const themeId = String(context.globals.theme ?? 'default')
+  const requested = (context.globals.appearance as ThemeAppearance | undefined) ?? 'dark'
+  const appearance = resolveAppearance(getTheme(themeId), requested)
+
+  return (
+    <LiebeThemeProvider appearance={appearance}>
+      <div
+        data-liebe-theme={themeId}
+        data-appearance={appearance}
+        style={{
+          background: 'var(--color-background)',
+          color: 'var(--gray-12)',
+          minHeight: '100vh',
+          padding: 'var(--space-4)',
+        }}
+      >
+        <Story />
+      </div>
+    </LiebeThemeProvider>
+  )
+}
+
+/* ------------------------------------------------------------------ *
+ * Grid cell
+ * ------------------------------------------------------------------ */
+
+export interface GridCellArgs {
+  /** Column span, in grid columns. */
+  gridWidth: number
+  /** Row span, in grid rows. */
+  gridHeight: number
+}
+
+export const gridCellArgTypes = {
+  gridWidth: {
+    name: 'grid width',
+    description: 'Column span of the grid cell the card is rendered in',
+    control: { type: 'range' as const, min: 1, max: gridConfig.desktop.columns, step: 1 },
+    table: { category: 'Grid cell' },
+  },
+  gridHeight: {
+    name: 'grid height',
+    description: 'Row span of the grid cell the card is rendered in',
+    control: { type: 'range' as const, min: 1, max: gridConfig.desktop.rows, step: 1 },
+    table: { category: 'Grid cell' },
+  },
+}
+
+/**
+ * Cell geometry, mirroring `GridLayoutSection` + react-grid-layout: the row
+ * height is `containerWidth / columns`, and a span of `n` covers `n` tracks
+ * plus the `n - 1` gaps between them.
+ */
+export function gridCellSize(width: number, height: number) {
+  const { columns, margin, containerPadding } = gridConfig.desktop
+  const [gapX, gapY] = margin
+  const rowHeight = Math.floor(STORY_CONTAINER_WIDTH / columns)
+  const columnWidth =
+    (STORY_CONTAINER_WIDTH - gapX * (columns - 1) - containerPadding[0] * 2) / columns
+
+  return {
+    width: width * columnWidth + (width - 1) * gapX,
+    height: height * rowHeight + (height - 1) * gapY,
+    gapX,
+    gapY,
+  }
+}
+
+/**
+ * Renders a card story inside a fixed-size cell with real grid metrics, so
+ * every layout tier is reachable from the `grid width`/`grid height` controls.
+ */
+export const withGridCell: Decorator = (Story, context) => {
+  const { gridWidth = 2, gridHeight = 2 } = context.args as Partial<GridCellArgs>
+  const { width, height, gapX } = gridCellSize(gridWidth, gridHeight)
+
+  return (
+    <div
+      className="grid-item"
+      style={
+        {
+          width,
+          height,
+          // The grid gap as a token so token-driven layout work can consume it
+          // from the workshop exactly as it will from the panel.
+          '--liebe-grid-gap': `${gapX}px`,
+          display: 'grid',
+        } as CSSProperties
+      }
+    >
+      <Story />
+    </div>
+  )
+}

--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useMemo, type CSSProperties, type ReactNode } from 'react'
+import { useEffect, useLayoutEffect, useMemo, type CSSProperties, type ReactNode } from 'react'
 import type { Decorator } from '@storybook/react-vite'
 import { useGlobals } from 'storybook/preview-api'
 import { HomeAssistantProvider } from '~/contexts/HomeAssistantContext'
@@ -40,6 +40,9 @@ function seedStores(liebe: LiebeStoryParameters) {
     isConnected: connected,
     isInitialLoading: initialLoading,
     lastError: null,
+    // Every derived field is written explicitly: `...state` would otherwise
+    // carry a previous story's subscriptions and staleness into this one.
+    subscribedEntities: new Set<string>(),
     staleEntities: new Set<string>(),
   }))
 
@@ -54,6 +57,8 @@ function resetStores() {
     entities: {},
     isConnected: false,
     isInitialLoading: true,
+    lastError: null,
+    subscribedEntities: new Set<string>(),
     staleEntities: new Set<string>(),
   }))
   dashboardStore.setState((state) => ({ ...state, mode: 'view' }))
@@ -147,9 +152,15 @@ export const withProviders: Decorator = (Story) => {
   const requested = (globals.appearance as ThemeAppearance | undefined) ?? 'dark'
   const appearance = resolveAppearance(theme, requested)
 
-  if (appearance !== requested) {
-    updateGlobals({ appearance })
-  }
+  // Syncing the toolbar is a side effect on Storybook's global state: doing it
+  // inline would be a state update during render, which React warns about and
+  // which can re-enter this decorator.
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useEffect(() => {
+    if (appearance !== requested) {
+      updateGlobals({ appearance })
+    }
+  }, [appearance, requested, updateGlobals])
 
   return (
     <LiebeThemeProvider appearance={appearance}>

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,20 @@
+import type { StorybookConfig } from '@storybook/react-vite'
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(ts|tsx)'],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {
+      builder: {
+        // Keep the workshop off the panel's Vite config — see
+        // .storybook/vite.config.ts.
+        viteConfigPath: '.storybook/vite.config.ts',
+      },
+    },
+  },
+  core: {
+    disableTelemetry: true,
+  },
+}
+
+export default config

--- a/.storybook/mockHass.ts
+++ b/.storybook/mockHass.ts
@@ -1,0 +1,77 @@
+import { action } from 'storybook/actions'
+import type { Connection } from 'home-assistant-js-websocket'
+import type { HomeAssistant } from '~/contexts/HomeAssistantContext'
+import type { HassEntity } from '~/store/entityTypes'
+
+/**
+ * A `hass` object that never touches the network.
+ *
+ * Every service call is logged as a Storybook action and then resolves (or
+ * rejects, for error stories) locally, so cards exercise their real
+ * `useServiceCall` → `hassService` path — including optimistic UI — without a
+ * WebSocket. See docs/specs/storybook/index.md, "Entity data mocking".
+ */
+export interface MockHassOptions {
+  entities?: HassEntity[]
+  fail?: boolean
+  failureMessage?: string
+}
+
+const noop = () => {}
+
+function createMockConnection(): Connection {
+  return {
+    subscribeEvents: () => Promise.resolve(noop),
+    subscribeMessage: () => Promise.resolve(noop),
+    sendMessagePromise: () => Promise.resolve(undefined),
+    addEventListener: noop,
+    removeEventListener: noop,
+    close: noop,
+    reconnect: () => Promise.resolve(),
+    suspend: noop,
+    ping: () => Promise.resolve(),
+    socket: { readyState: 1, close: noop },
+    haVersion: '2026.7.0',
+    connected: true,
+  } as unknown as Connection
+}
+
+export function createMockHass({
+  entities = [],
+  fail = false,
+  failureMessage = 'Service call failed (Storybook mock)',
+}: MockHassOptions = {}): HomeAssistant {
+  const logServiceCall = action('callService')
+  const logWebSocket = action('callWS')
+
+  const states: HomeAssistant['states'] = {}
+  for (const entity of entities) {
+    states[entity.entity_id] = entity as HomeAssistant['states'][string]
+  }
+
+  return {
+    states,
+    callService: (domain, service, serviceData) => {
+      logServiceCall({ domain, service, serviceData })
+      return fail ? Promise.reject(new Error(failureMessage)) : Promise.resolve()
+    },
+    callWS: <T>(message: Record<string, unknown>) => {
+      logWebSocket(message)
+      return Promise.resolve(undefined as T)
+    },
+    connection: createMockConnection(),
+    user: { name: 'Storybook', id: 'storybook-user', is_admin: true },
+    themes: {},
+    language: 'en',
+    config: {
+      latitude: 52.52,
+      longitude: 13.405,
+      elevation: 34,
+      unit_system: { length: 'km', mass: 'kg', temperature: '°C', volume: 'L' },
+      location_name: 'Home',
+      time_zone: 'Europe/Berlin',
+      components: [],
+      version: '2026.7.0',
+    },
+  }
+}

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,0 +1,65 @@
+import type { Preview } from '@storybook/react-vite'
+import { DEFAULT_THEME_ID, listThemes } from '~/theme/themeRegistry'
+import { withProviders, withServiceCalls, withStoreSeed } from './decorators'
+
+// The same style set the panel injects (src/panel.ts) — imported here directly
+// because the panel entry also registers the custom element and starts the
+// Home Assistant connection, neither of which may run in the preview.
+import '@radix-ui/themes/styles.css'
+import 'react-grid-layout/css/styles.css'
+import 'react-resizable/css/styles.css'
+import '~/styles/app.css'
+
+const preview: Preview = {
+  // Outermost first: providers wrap the mock connection, which wraps the
+  // seeded stores, which wrap the (opt-in) grid cell.
+  decorators: [withProviders, withServiceCalls, withStoreSeed],
+  parameters: {
+    // The provider decorator paints the themed ground and supplies the
+    // padding; Storybook's default `padded` layout would frame every story
+    // with an unthemed white margin.
+    layout: 'fullscreen',
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+    options: {
+      storySort: {
+        order: ['Shell', 'Cards'],
+      },
+    },
+  },
+  globalTypes: {
+    theme: {
+      description: 'Liebe theme',
+      toolbar: {
+        title: 'Theme',
+        icon: 'paintbrush',
+        // Registry-driven: themes registered by later changes show up here
+        // with no workshop changes.
+        items: listThemes().map(({ id, label }) => ({ value: id, title: label })),
+        dynamicTitle: true,
+      },
+    },
+    appearance: {
+      description: 'Dark or light appearance (forced for single-appearance themes)',
+      toolbar: {
+        title: 'Appearance',
+        icon: 'mirror',
+        items: [
+          { value: 'dark', title: 'Dark', icon: 'moon' },
+          { value: 'light', title: 'Light', icon: 'sun' },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+  initialGlobals: {
+    theme: DEFAULT_THEME_ID,
+    appearance: 'dark',
+  },
+}
+
+export default preview

--- a/.storybook/vite.config.ts
+++ b/.storybook/vite.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vite'
+import { resolve } from 'path'
+
+/**
+ * Storybook's own Vite config.
+ *
+ * Deliberately separate from the repo's `vite.config.ts`: that config carries
+ * the TanStack Start plugin and the dev-panel plugin (which rebuilds
+ * `panel.js` on every file change), neither of which the workshop wants.
+ * `.storybook/main.ts` points the builder here so the panel build is untouched.
+ *
+ * The React plugin is contributed by `@storybook/react-vite`; all this file
+ * owns is the project's `~/*` path alias.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      '~': resolve(__dirname, '../src'),
+    },
+  },
+  server: {
+    // Workspace convention: the dev server must be reachable over Tailscale.
+    host: '0.0.0.0',
+    allowedHosts: true,
+  },
+})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -686,7 +686,8 @@ When creating new entity card components:
 
 2. **Register in `src/components/cardRegistry.ts`**
    - Add the domain → component entry to `domainToCard`; `GridView` dispatches through `getCardForEntity`, so a domain missing from the registry silently falls through to the fallback card
-   - Register any presentation variants via `registerCardVariant` (or the component's static `variants` map) rather than a switch inside the card — `getCardVariant` is a read-only lookup and cannot register anything
+   - Declare any presentation variants as a static `variants` map on the component (`Object.assign(MyCard, { variants: { ... } })`) rather than a switch inside the card — `getCardVariant` is a read-only lookup and cannot register anything
+   - **Do not import `cardRegistry` from a card module.** `registerCardVariant` still exists for consumers outside the card graph, but calling it from a card closes the cycle `cardRegistry` → every card → `CardConfig` → that card → `cardRegistry`, which crashes with a temporal-dead-zone error in any bundle whose entry reaches a card before the registry (this is what broke the Storybook build; the panel bundle survived it only by accident of entry order). Type-only imports (`import type { CardProps }`) are erased and are fine.
 
 3. **Update the EntityBrowser** (`src/components/EntitiesBrowserTab.tsx`)
    - Add the domain to `SUPPORTED_DOMAINS` there — it is a local constant in that file, not part of `cardRegistry.ts` — so the browser offers the domain

--- a/docs/changes/0009-storybook-setup.md
+++ b/docs/changes/0009-storybook-setup.md
@@ -36,20 +36,21 @@ The [storybook spec](../specs/storybook/index.md) owns the workshop's observable
 
 ## Design Decisions
 
-- **Vite builder, own config** — reuses `~/*` aliases; does not touch the panel build (spec requirement). Pin the current stable Storybook major at implementation time and record it here.
+- **Vite builder, own config** — reuses `~/*` aliases; does not touch the panel build (spec requirement). **Pinned to Storybook 10** (`^10.5.4`, the current stable major), on Vite 7 / React 19. `.storybook/main.ts` sets `framework.options.builder.viteConfigPath` to a dedicated `.storybook/vite.config.ts`, because Storybook otherwise loads the repo's root Vite config — which carries the TanStack Start plugin and the dev-panel plugin that rebuilds `panel.js` on every change.
+- **The card registry must not be reachable from a card's module graph.** Standing up the workshop exposed a latent cycle (`cardRegistry` → every card → `CardConfig` → `WeatherCard` → `cardRegistry`) that crashes with a temporal-dead-zone error in any bundle whose entry reaches a card before the registry; the panel bundle only survived it by accident of entry order. Cards therefore declare presentation variants as a static `variants` map on the component (which `getCardVariant` already reads) instead of calling `registerCardVariant` at module scope.
 - **Fixtures as shared infrastructure** — entity factories live outside `.storybook/` (e.g. `src/test/fixtures/`) so Vitest can adopt them; stories and unit tests converge on one mock shape over time.
 - **Publishing path** — extend the existing Pages deploy (single artifact: panel at root, workshop under `/storybook/`) rather than a second workflow.
 - **No visual regression yet** — per spec Open Questions; theme gallery stories carry manual review until the theming work proves the need.
 
 ## Tasks
 
-- [ ] **PR 1 — Storybook scaffold + fixtures + first stories**
-  - [ ] Add Storybook (react-vite framework), `.storybook/main.ts` + `preview.tsx`, npm scripts; verify `~/*` alias resolution
-  - [ ] Extract/verify side-effect-free provider entry for preview use
-  - [ ] Entity fixture factories for all currently supported domains (`src/test/fixtures/`)
-  - [ ] Store-seeding + service-call-interception decorators; appearance toolbar; grid-cell decorator
-  - [ ] Stories: `GridCard` shell (all states) + `LightCard`, `ClimateCard`, `SensorCard`, `BinarySensorCard` (state matrix per spec)
-  - [ ] Coverage exclusions for stories/fixtures/.storybook; lint/prettier config extended to new files
+- [x] **PR 1 — Storybook scaffold + fixtures + first stories**
+  - [x] Add Storybook (react-vite framework), `.storybook/main.ts` + `preview.tsx`, npm scripts; verify `~/*` alias resolution
+  - [x] Extract/verify side-effect-free provider entry for preview use
+  - [x] Entity fixture factories for all currently supported domains (`src/test/fixtures/`)
+  - [x] Store-seeding + service-call-interception decorators; appearance toolbar; grid-cell decorator
+  - [x] Stories: `GridCard` shell (all states) + `LightCard`, `ClimateCard`, `SensorCard`, `BinarySensorCard` (state matrix per spec)
+  - [x] Coverage exclusions for stories/fixtures/.storybook; lint/prettier config extended to new files
 - [ ] **PR 2 — Full card coverage**
   - [ ] Stories for `CoverCard`, `FanCard`, `ButtonCard`, `WeatherCard` (all 4 variants), `CameraCard` (mock stream states), all 5 input helper cards, `TextCard`, `Separator`
   - [ ] a11y addon enabled globally; audit and record violations as issues (fixes out of scope)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import tsParser from '@typescript-eslint/parser'
 import tsPlugin from '@typescript-eslint/eslint-plugin'
 import reactPlugin from 'eslint-plugin-react'
 import reactHooksPlugin from 'eslint-plugin-react-hooks'
+import storybookPlugin from 'eslint-plugin-storybook'
 import prettierConfig from 'eslint-config-prettier'
 
 export default [
@@ -62,6 +63,8 @@ export default [
       'no-undef': 'off',
     },
   },
+  // Storybook's own rules for `*.stories.tsx` and `.storybook/` config files.
+  ...storybookPlugin.configs['flat/recommended'],
   {
     ignores: [
       'node_modules/',
@@ -74,6 +77,7 @@ export default [
       '.nitro/',
       '.vite-temp/',
       '.tailscale/',
+      'storybook-static/',
     ],
   },
   prettierConfig,

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
       "devDependencies": {
         "@eslint/js": "^9.30.0",
         "@playwright/test": "^1.57.0",
+        "@storybook/react-vite": "10.5.4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
         "@testing-library/user-event": "^14.6.1",
@@ -50,10 +51,12 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-storybook": "10.5.4",
         "husky": "^9.1.7",
         "jsdom": "^27.3.0",
         "lint-staged": "^16.1.2",
         "prettier": "^3.6.2",
+        "storybook": "10.5.4",
         "typescript": "^5.9.3",
         "vite": "^7.2.7",
         "vite-tsconfig-paths": "^6.0.1",
@@ -597,6 +600,40 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
@@ -610,7 +647,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -628,7 +664,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -646,7 +681,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -664,7 +698,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -682,7 +715,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -700,7 +732,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -718,7 +749,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -736,7 +766,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -754,7 +783,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -772,7 +800,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -790,7 +817,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -808,7 +834,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -826,7 +851,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -844,7 +868,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -862,7 +885,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -880,7 +902,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -898,7 +919,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -916,7 +936,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -934,7 +953,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -952,7 +970,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -970,7 +987,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1005,7 +1021,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1023,7 +1038,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1041,7 +1055,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1059,15 +1072,14 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1401,6 +1413,26 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.7.0.tgz",
+      "integrity": "sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^13.0.1",
+        "react-docgen-typescript": "^2.2.2"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.3.x",
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1459,6 +1491,25 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@oozcitak/dom": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-2.0.2.tgz",
@@ -1506,6 +1557,663 @@
       "engines": {
         "node": ">=20.0"
       }
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.127.0.tgz",
+      "integrity": "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.127.0.tgz",
+      "integrity": "sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.127.0.tgz",
+      "integrity": "sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.127.0.tgz",
+      "integrity": "sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.127.0.tgz",
+      "integrity": "sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.127.0.tgz",
+      "integrity": "sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.127.0.tgz",
+      "integrity": "sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.127.0.tgz",
+      "integrity": "sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.127.0.tgz",
+      "integrity": "sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.127.0.tgz",
+      "integrity": "sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.127.0.tgz",
+      "integrity": "sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.127.0.tgz",
+      "integrity": "sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.127.0.tgz",
+      "integrity": "sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.127.0.tgz",
+      "integrity": "sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.127.0.tgz",
+      "integrity": "sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.127.0.tgz",
+      "integrity": "sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.127.0.tgz",
+      "integrity": "sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.127.0.tgz",
+      "integrity": "sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.127.0.tgz",
+      "integrity": "sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.127.0.tgz",
+      "integrity": "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.24.2.tgz",
+      "integrity": "sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.24.2.tgz",
+      "integrity": "sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.24.2.tgz",
+      "integrity": "sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.24.2.tgz",
+      "integrity": "sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.24.2.tgz",
+      "integrity": "sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.24.2.tgz",
+      "integrity": "sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.24.2.tgz",
+      "integrity": "sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.24.2.tgz",
+      "integrity": "sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.24.2.tgz",
+      "integrity": "sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.24.2.tgz",
+      "integrity": "sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.24.2.tgz",
+      "integrity": "sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.24.2.tgz",
+      "integrity": "sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.24.2.tgz",
+      "integrity": "sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.24.2.tgz",
+      "integrity": "sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.24.2.tgz",
+      "integrity": "sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.24.2.tgz",
+      "integrity": "sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.24.2.tgz",
+      "integrity": "sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.2",
+        "@emnapi/runtime": "1.11.2",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.24.2.tgz",
+      "integrity": "sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.24.2.tgz",
+      "integrity": "sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@playwright/test": {
       "version": "1.61.1",
@@ -3514,6 +4222,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.44.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.1.tgz",
@@ -3800,6 +4551,224 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@storybook/builder-vite": {
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.5.4.tgz",
+      "integrity": "sha512-eXdgow+brSzZrG3CnG18YwxZwEYNAZIh2G5qKwNoZf0uk2ZCPgLRQwtVAcd7BiiEDGnXUHm9pycAS+UiF4F4Mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/csf-plugin": "10.5.4",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.5.4",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@storybook/csf-plugin": {
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.5.4.tgz",
+      "integrity": "sha512-DSp5Z/eZlRnKq0KrKLJE6uoYf/Ysc+FP0Z5DVTGnOrie+z3tC0lNi9I4RB++EXkJeUDS9/4dxvJZVSWjhLlXxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unplugin": "^2.3.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "esbuild": "*",
+        "rollup": "*",
+        "storybook": "^10.5.4",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "esbuild": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/csf-plugin/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@storybook/csf-plugin/node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/@storybook/global": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/global/-/global-5.0.0.tgz",
+      "integrity": "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@storybook/icons": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-2.1.0.tgz",
+      "integrity": "sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@storybook/react": {
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.5.4.tgz",
+      "integrity": "sha512-tOxfVgbYcaVsArN8XTDkJfdsnsnHh1LxjRHVpJ/N+VEkz4FveK/XH3jOLV0YqgrG8yXza7+CteDP4FfPVQY/mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/react-dom-shim": "10.5.4",
+        "react-docgen": "^8.0.2",
+        "react-docgen-typescript": "^2.2.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.4",
+        "typescript": ">= 4.9.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-dom-shim": {
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.5.4.tgz",
+      "integrity": "sha512-YdlppEOReg8MvTECRNuf79gu2zL83JqKDHIR/65eS0M6y+ue9pkpfjYo7hZVIcyOcRd9npBDXMdt2kC92bCuaA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.4"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-vite": {
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.5.4.tgz",
+      "integrity": "sha512-iw7EAA98n30vpf+ZSy2Ll4Ne7oyZ/lS6W22u5Sp5UOI2oAkYuklxIWjRIKGqpY0BHP+GqaGYtUGMZQnBqgul2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",
+        "@rollup/pluginutils": "^5.0.2",
+        "@storybook/builder-vite": "10.5.4",
+        "@storybook/react": "10.5.4",
+        "empathic": "^2.0.0",
+        "magic-string": "^0.30.0",
+        "react-docgen": "^8.0.2",
+        "resolve": "^1.22.8",
+        "tsconfig-paths": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.4",
+        "typescript": ">= 4.9.x",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-vite/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/@tabler/icons": {
       "version": "3.34.0",
@@ -4381,20 +5350,19 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
-      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
         "@types/aria-query": "^5.0.1",
         "aria-query": "5.3.0",
-        "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.9",
         "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
         "pretty-format": "^27.0.2"
       },
       "engines": {
@@ -4470,13 +5438,23 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4547,6 +5525,13 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/doctrine": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
+      "integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4630,6 +5615,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
+      "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -5042,6 +6034,13 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@webcontainer/env": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@webcontainer/env/-/env-1.1.1.tgz",
+      "integrity": "sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -5319,6 +6318,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ast-v8-to-istanbul": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
@@ -5479,6 +6491,22 @@
       "license": "MIT",
       "optional": true,
       "peer": true
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -5664,6 +6692,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -5944,9 +6982,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5980,12 +7018,52 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -6003,6 +7081,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
@@ -6087,8 +7178,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6110,6 +7200,16 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
       "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
       "license": "ISC"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/entities": {
       "version": "8.0.0",
@@ -6325,10 +7425,9 @@
       "version": "0.25.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
       "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6525,6 +7624,227 @@
         "node": "*"
       }
     },
+    "node_modules/eslint-plugin-storybook": {
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-10.5.4.tgz",
+      "integrity": "sha512-IEG6GK9iMKH45WxiBUoDu3AajUyz+AcRXsLRkwnsNz9TwzZI6tbyHgdZ1Tkvs2RXOovYUYYksNpbtnmY746LAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "^8.60.0",
+        "@typescript-eslint/utils": "^8.60.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8",
+        "storybook": "^10.5.4"
+      }
+    },
+    "node_modules/eslint-plugin-storybook/node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-plugin-storybook/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-storybook/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-plugin-storybook/node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-storybook/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-plugin-storybook/node_modules/@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-plugin-storybook/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-storybook/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-storybook/node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-storybook/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-storybook/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-plugin-storybook/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -6719,6 +8039,20 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -7069,6 +8403,63 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globalthis": {
@@ -7627,6 +9018,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -7693,6 +9100,25 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-map": {
@@ -7900,6 +9326,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isbot": {
       "version": "5.1.28",
       "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.28.tgz",
@@ -8084,6 +9526,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
@@ -8624,6 +10073,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -8648,7 +10104,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9368,6 +10823,26 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -9543,6 +11018,25 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -9577,6 +11071,75 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/oxc-parser": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.127.0.tgz",
+      "integrity": "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.127.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.127.0",
+        "@oxc-parser/binding-android-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-x64": "0.127.0",
+        "@oxc-parser/binding-freebsd-x64": "0.127.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.127.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.127.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.127.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.127.0"
+      }
+    },
+    "node_modules/oxc-resolver": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.24.2.tgz",
+      "integrity": "sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.24.2",
+        "@oxc-resolver/binding-android-arm64": "11.24.2",
+        "@oxc-resolver/binding-darwin-arm64": "11.24.2",
+        "@oxc-resolver/binding-darwin-x64": "11.24.2",
+        "@oxc-resolver/binding-freebsd-x64": "11.24.2",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.24.2",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.24.2",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.24.2",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.24.2",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-x64-musl": "11.24.2",
+        "@oxc-resolver/binding-openharmony-arm64": "11.24.2",
+        "@oxc-resolver/binding-wasm32-wasi": "11.24.2",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.24.2",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.24.2"
       }
     },
     "node_modules/parent-module": {
@@ -9647,11 +11210,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -9802,7 +11402,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9818,7 +11417,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9829,7 +11427,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9842,8 +11439,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -10153,6 +11749,86 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-docgen": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-8.0.3.tgz",
+      "integrity": "sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/traverse": "^7.28.0",
+        "@babel/types": "^7.28.2",
+        "@types/babel__core": "^7.20.5",
+        "@types/babel__traverse": "^7.20.7",
+        "@types/doctrine": "^0.0.9",
+        "@types/resolve": "^1.20.2",
+        "doctrine": "^3.0.0",
+        "resolve": "^1.22.1",
+        "strip-indent": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.9.0 || >=22"
+      }
+    },
+    "node_modules/react-docgen-typescript": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.4.0.tgz",
+      "integrity": "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">= 4.3.x"
+      }
+    },
+    "node_modules/react-docgen/node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/react-docgen/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/react-docgen/node_modules/strip-indent": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+      "integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
@@ -10334,6 +12010,33 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/recast": {
+      "version": "0.23.12",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.12.tgz",
+      "integrity": "sha512-dEWRjcINDu/F4l2dYx57ugBtD7HV9KXESyxhzw/MqWLeglJrsjJKqACPyUPg+6AF8mIgm+Zi0dZ3ACoIg+QtpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/recast/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/redent": {
@@ -10558,6 +12261,19 @@
       "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.8.1.tgz",
       "integrity": "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==",
       "license": "MIT"
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -10969,6 +12685,153 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/storybook": {
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.5.4.tgz",
+      "integrity": "sha512-bmLxPsxVSPnbeiZqYQpozyNOiJXfk+pf7WfHZflvPkwT6Y+rvYz3Cj/D6H4Kf2jHpuDNiMXBKO3yawLN2OWirg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/icons": "^2.0.2",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/user-event": "^14.6.1",
+        "@vitest/expect": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@webcontainer/env": "^1.1.1",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0 || ^0.28.0",
+        "jsonc-parser": "^3.3.1",
+        "open": "^10.2.0",
+        "oxc-parser": "^0.127.0",
+        "oxc-resolver": "^11.19.1",
+        "recast": "^0.23.5",
+        "semver": "^7.7.3",
+        "use-sync-external-store": "^1.5.0",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "storybook": "dist/bin/dispatcher.js"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "prettier": "^2 || ^3",
+        "vite-plus": "^0.1.15 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/storybook/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/string-argv": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -11107,6 +12970,16 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -11214,6 +13087,13 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -11280,6 +13160,16 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
       "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11366,9 +13256,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11376,6 +13266,16 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/tsconfck": {
@@ -11397,6 +13297,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tslib": {
@@ -12771,6 +14686,22 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "e2e:ha:up": "docker compose -f ha/docker-compose.yml up -d --wait",
     "e2e:ha:down": "docker compose -f ha/docker-compose.yml down -v",
     "e2e:full": "npm run build:ha:prod && npm run e2e:ha:up && npm run e2e",
-    "prepare": "husky"
+    "prepare": "husky",
+    "storybook": "storybook dev -p 6006 --host 0.0.0.0 --no-open",
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
@@ -60,6 +62,7 @@
   "devDependencies": {
     "@eslint/js": "^9.30.0",
     "@playwright/test": "^1.57.0",
+    "@storybook/react-vite": "^10.5.4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@testing-library/user-event": "^14.6.1",
@@ -74,10 +77,12 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-storybook": "^10.5.4",
     "husky": "^9.1.7",
     "jsdom": "^27.3.0",
     "lint-staged": "^16.1.2",
     "prettier": "^3.6.2",
+    "storybook": "^10.5.4",
     "typescript": "^5.9.3",
     "vite": "^7.2.7",
     "vite-tsconfig-paths": "^6.0.1",

--- a/src/components/BinarySensorCard.stories.tsx
+++ b/src/components/BinarySensorCard.stories.tsx
@@ -1,0 +1,102 @@
+import type { ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { BinarySensorCard } from './BinarySensorCard'
+import { asUnavailable, createBinarySensorEntity } from '~/test/fixtures'
+import { gridCellArgTypes, withGridCell, type GridCellArgs } from '../../.storybook/decorators'
+
+const entityId = 'binary_sensor.front_door'
+
+type BinarySensorCardStoryProps = ComponentProps<typeof BinarySensorCard> & GridCellArgs
+
+const meta: Meta<BinarySensorCardStoryProps> = {
+  title: 'Cards/BinarySensorCard',
+  component: BinarySensorCard,
+  decorators: [withGridCell],
+  argTypes: {
+    ...gridCellArgTypes,
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium', 'large'] },
+  },
+  args: {
+    entityId,
+    size: 'medium',
+    gridWidth: 2,
+    gridHeight: 2,
+  },
+  parameters: {
+    liebe: { entities: [createBinarySensorEntity()] },
+  },
+}
+
+export default meta
+type Story = StoryObj<BinarySensorCardStoryProps>
+
+/** Closed door — the device class picks the "off" icon. */
+export const Off: Story = {
+  parameters: { liebe: { entities: [createBinarySensorEntity({ state: 'off' })] } },
+}
+
+/** Open door — amber surface, "on" icon, and the state pill. */
+export const On: Story = {
+  parameters: { liebe: { entities: [createBinarySensorEntity({ state: 'on' })] } },
+}
+
+/** A different device class swaps the icon pair without any card change. */
+export const MotionDetected: Story = {
+  parameters: {
+    liebe: {
+      entities: [
+        createBinarySensorEntity({
+          entity_id: entityId,
+          state: 'on',
+          attributes: { friendly_name: 'Hallway Motion', device_class: 'motion' },
+        }),
+      ],
+    },
+  },
+}
+
+/** No device class at all falls back to the generic circle icons. */
+export const WithoutDeviceClass: Story = {
+  parameters: {
+    liebe: {
+      entities: [
+        createBinarySensorEntity({
+          entity_id: entityId,
+          state: 'on',
+          attributes: { friendly_name: 'Generic Contact', device_class: undefined },
+        }),
+      ],
+    },
+  },
+}
+
+export const Unavailable: Story = {
+  parameters: { liebe: { entities: [asUnavailable(createBinarySensorEntity())] } },
+}
+
+export const Loading: Story = {
+  parameters: { liebe: { entities: [], initialLoading: true } },
+}
+
+/**
+ * Read-only card — no service-call path — so its error story is the
+ * disconnected state reached through `useEntity`.
+ */
+export const Disconnected: Story = {
+  parameters: { liebe: { entities: [createBinarySensorEntity()], connected: false } },
+}
+
+/**
+ * An entity id that is not in the store. `useEntity` cannot tell "not loaded
+ * yet" from "does not exist", so the card holds its skeleton indefinitely
+ * rather than reporting the entity as missing.
+ */
+export const UnknownEntity: Story = {
+  parameters: { liebe: { entities: [] } },
+}
+
+/** Edit mode exposes the delete affordance. */
+export const EditMode: Story = {
+  args: { onDelete: () => {} },
+  parameters: { liebe: { entities: [createBinarySensorEntity()], mode: 'edit' } },
+}

--- a/src/components/ClimateCard.stories.tsx
+++ b/src/components/ClimateCard.stories.tsx
@@ -1,0 +1,124 @@
+import type { ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { ClimateCard } from './ClimateCard'
+import { asUnavailable, createClimateEntity } from '~/test/fixtures'
+import { gridCellArgTypes, withGridCell, type GridCellArgs } from '../../.storybook/decorators'
+
+const entityId = 'climate.hallway'
+
+type ClimateCardStoryProps = ComponentProps<typeof ClimateCard> & GridCellArgs
+
+const meta: Meta<ClimateCardStoryProps> = {
+  title: 'Cards/ClimateCard',
+  component: ClimateCard,
+  decorators: [withGridCell],
+  argTypes: {
+    ...gridCellArgTypes,
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium', 'large'] },
+  },
+  args: {
+    entityId,
+    size: 'medium',
+    gridWidth: 4,
+    gridHeight: 5,
+  },
+  parameters: {
+    liebe: { entities: [createClimateEntity()] },
+  },
+}
+
+export default meta
+type Story = StoryObj<ClimateCardStoryProps>
+
+/**
+ * Resting state for a thermostat: mode `off`, no target arc, no temperature
+ * controls — climate never publishes a literal `on`/`off` pair the way a light
+ * does, so this is the domain's inactive equivalent.
+ */
+export const Idle: Story = {
+  parameters: {
+    liebe: {
+      entities: [
+        createClimateEntity({ state: 'off', attributes: { hvac_action: 'off', temperature: 21 } }),
+      ],
+    },
+  },
+}
+
+/** Actively heating: orange target arc, `heating` action, ± controls live. */
+export const Heating: Story = {
+  parameters: { liebe: { entities: [createClimateEntity()] } },
+}
+
+/** Cooling, driven purely by the fixture's mode and action. */
+export const Cooling: Story = {
+  parameters: {
+    liebe: {
+      entities: [
+        createClimateEntity({
+          state: 'cool',
+          attributes: {
+            hvac_action: 'cooling',
+            current_temperature: 26.5,
+            temperature: 22,
+          },
+        }),
+      ],
+    },
+  },
+}
+
+/** Heat/cool range mode — two draggable set points on one arc. */
+export const HeatCoolRange: Story = {
+  parameters: {
+    liebe: {
+      entities: [
+        createClimateEntity({
+          state: 'heat_cool',
+          attributes: {
+            hvac_action: 'idle',
+            target_temp_low: 19,
+            target_temp_high: 24,
+            temperature: undefined,
+          },
+        }),
+      ],
+    },
+  },
+}
+
+export const Unavailable: Story = {
+  args: { gridHeight: 2 },
+  parameters: { liebe: { entities: [asUnavailable(createClimateEntity())] } },
+}
+
+export const Loading: Story = {
+  args: { gridHeight: 3 },
+  parameters: { liebe: { entities: [], initialLoading: true } },
+}
+
+/**
+ * Every service call fails, so changing the HVAC mode surfaces the card's error
+ * border. `HassService` retries three times with 1s/2s/4s backoff before the
+ * error lands.
+ */
+export const ServiceCallFailure: Story = {
+  parameters: {
+    liebe: {
+      entities: [createClimateEntity()],
+      serviceCall: 'error',
+      serviceCallError: 'climate.set_hvac_mode is not available',
+    },
+  },
+}
+
+export const Disconnected: Story = {
+  args: { gridHeight: 2 },
+  parameters: { liebe: { entities: [createClimateEntity()], connected: false } },
+}
+
+/** Edit mode hides the temperature and HVAC-mode controls. */
+export const EditMode: Story = {
+  args: { onDelete: () => {}, gridHeight: 4 },
+  parameters: { liebe: { entities: [createClimateEntity()], mode: 'edit' } },
+}

--- a/src/components/GridCard.stories.tsx
+++ b/src/components/GridCard.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Flex, Text } from '@radix-ui/themes'
+import { SunIcon } from '@radix-ui/react-icons'
+import { GridCardWithComponents as GridCard, type GridCardProps } from './GridCard'
+import { gridCellArgTypes, withGridCell, type GridCellArgs } from '../../.storybook/decorators'
+
+function SampleContents({ label = 'Living Room' }: { label?: string }) {
+  return (
+    <Flex direction="column" align="center" justify="center" gap="2">
+      <GridCard.Icon>
+        <SunIcon width={20} height={20} />
+      </GridCard.Icon>
+      <GridCard.Title>{label}</GridCard.Title>
+      <GridCard.Status>
+        <Text size="1">OFF</Text>
+      </GridCard.Status>
+    </Flex>
+  )
+}
+
+/**
+ * The card shell every entity card renders inside: surface, state borders,
+ * edit-mode affordances, and the `Icon` / `Title` / `Controls` / `Status`
+ * anatomy parts.
+ */
+type GridCardStoryProps = GridCardProps & GridCellArgs
+
+const meta: Meta<GridCardStoryProps> = {
+  title: 'Shell/GridCard',
+  component: GridCard,
+  decorators: [withGridCell],
+  argTypes: {
+    ...gridCellArgTypes,
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium', 'large'] },
+  },
+  args: {
+    gridWidth: 2,
+    gridHeight: 2,
+    size: 'medium',
+    children: <SampleContents />,
+  },
+}
+
+export default meta
+type Story = StoryObj<GridCardStoryProps>
+
+/** Resting state: no entity activity, view mode. */
+export const Default: Story = {}
+
+/** Active entity — the shell tints itself with the accent surface. */
+export const On: Story = {
+  args: { isOn: true },
+}
+
+/** A pending service call: spinner in the icon slot, wait cursor, pulse border. */
+export const Loading: Story = {
+  args: { isLoading: true },
+}
+
+/** A failed service call — red border, and the failure text as the tooltip. */
+export const ErrorState: Story = {
+  args: { isError: true, title: 'Failed to call service light.turn_on' },
+}
+
+/** Entity reported `unavailable`: dotted border and a dimmed surface. */
+export const Unavailable: Story = {
+  args: { isUnavailable: true },
+}
+
+/** Edit mode with the card selected — the blue selection surface. */
+export const SelectedInEditMode: Story = {
+  args: { isSelected: true, onSelect: () => {} },
+  parameters: { liebe: { mode: 'edit' } },
+}
+
+/** Edit mode affordances: configure and delete buttons. */
+export const EditModeActions: Story = {
+  args: { hasConfiguration: true, onConfigure: () => {}, onDelete: () => {} },
+  parameters: { liebe: { mode: 'edit' } },
+}
+
+/** Transparent cards drop the surface entirely in view mode (used by `TextCard`). */
+export const Transparent: Story = {
+  args: { transparent: true },
+}
+
+/** Every size the shell supports, side by side. */
+export const Sizes: Story = {
+  args: { gridWidth: 6, gridHeight: 2 },
+  render: (args) => (
+    <Flex gap="4" align="start">
+      {(['small', 'medium', 'large'] as const).map((size) => (
+        <div key={size} style={{ width: 160 }}>
+          <GridCard {...args} size={size}>
+            <SampleContents label={size} />
+          </GridCard>
+        </div>
+      ))}
+    </Flex>
+  ),
+}

--- a/src/components/LiebeThemeProvider.tsx
+++ b/src/components/LiebeThemeProvider.tsx
@@ -1,0 +1,45 @@
+import { Theme } from '@radix-ui/themes'
+import type { ReactNode } from 'react'
+import { useCameraFullscreenActive, CAMERA_FULLSCREEN_Z_INDEX } from '~/store/cameraFullscreenStore'
+
+export interface LiebeThemeProviderProps {
+  children: ReactNode
+  /**
+   * Resolved appearance for the Radix `Theme`. The panel leaves this undefined
+   * (Radix then inherits from the surrounding document); the Storybook preview
+   * passes the appearance chosen in the toolbar.
+   */
+  appearance?: 'dark' | 'light'
+}
+
+/**
+ * The panel's provider shell, importable in isolation.
+ *
+ * This is deliberately free of bootstrap side effects (no custom-element
+ * registration, no router, no Home Assistant connection) so surfaces that are
+ * not the panel — today the Storybook preview — can render components inside
+ * exactly the same provider stack the panel uses. See
+ * docs/specs/storybook/index.md ("Global decorators & toolbar").
+ */
+export function LiebeThemeProvider({ children, appearance }: LiebeThemeProviderProps) {
+  // This is the ROOT Theme (data-is-root-theme="true"), so it establishes a
+  // stacking context (`position: relative; z-index: 0`) that would otherwise
+  // cap the camera card's in-place fullscreen overlay below Home Assistant's
+  // chrome. While any camera overlay is open, lift this ancestor's stacking so
+  // the overlay paints over HA's header/sidebar — WITHOUT moving the stream
+  // node. See docs/changes/0008-camera-fullscreen-no-dom-move.md.
+  const cameraFullscreenActive = useCameraFullscreenActive()
+
+  return (
+    <Theme
+      appearance={appearance}
+      style={
+        cameraFullscreenActive
+          ? { position: 'relative', zIndex: CAMERA_FULLSCREEN_Z_INDEX }
+          : undefined
+      }
+    >
+      {children}
+    </Theme>
+  )
+}

--- a/src/components/LightCard.stories.tsx
+++ b/src/components/LightCard.stories.tsx
@@ -1,0 +1,100 @@
+import type { ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { LightCard } from './LightCard'
+import { asUnavailable, createLightEntity } from '~/test/fixtures'
+import { gridCellArgTypes, withGridCell, type GridCellArgs } from '../../.storybook/decorators'
+
+const entityId = 'light.living_room'
+
+type LightCardStoryProps = ComponentProps<typeof LightCard> & GridCellArgs
+
+const meta: Meta<LightCardStoryProps> = {
+  title: 'Cards/LightCard',
+  component: LightCard,
+  decorators: [withGridCell],
+  argTypes: {
+    ...gridCellArgTypes,
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium', 'large'] },
+  },
+  args: {
+    entityId,
+    size: 'medium',
+    gridWidth: 2,
+    gridHeight: 2,
+  },
+  parameters: {
+    liebe: { entities: [createLightEntity()] },
+  },
+}
+
+export default meta
+type Story = StoryObj<LightCardStoryProps>
+
+/** Resting state. Clicking the card calls `light.turn_on`. */
+export const Off: Story = {
+  parameters: {
+    liebe: { entities: [createLightEntity({ state: 'off', attributes: { brightness: 0 } })] },
+  },
+}
+
+/** Active state with the brightness slider — dragging commits `light.turn_on`. */
+export const On: Story = {
+  parameters: { liebe: { entities: [createLightEntity()] } },
+}
+
+/** A light without `supported_color_modes` renders no brightness control. */
+export const OnWithoutBrightness: Story = {
+  parameters: {
+    liebe: {
+      entities: [
+        createLightEntity({
+          attributes: { supported_color_modes: ['onoff'], supported_features: 0, brightness: 255 },
+        }),
+      ],
+    },
+  },
+}
+
+export const Unavailable: Story = {
+  parameters: { liebe: { entities: [asUnavailable(createLightEntity())] } },
+}
+
+/** First load: the store is still filling, so the card shows its skeleton. */
+export const Loading: Story = {
+  parameters: { liebe: { entities: [], initialLoading: true } },
+}
+
+/**
+ * The card's reachable error state: every service call fails, so toggling the
+ * light surfaces `ERROR`. `HassService` retries three times with 1s/2s/4s
+ * backoff, so the error appears a few seconds after the click.
+ */
+export const ServiceCallFailure: Story = {
+  parameters: {
+    liebe: {
+      entities: [createLightEntity({ state: 'off' })],
+      serviceCall: 'error',
+      serviceCallError: 'light.turn_on is not available',
+    },
+  },
+}
+
+/** Connection lost — the card falls back to the disconnected error display. */
+export const Disconnected: Story = {
+  parameters: { liebe: { entities: [createLightEntity()], connected: false } },
+}
+
+/**
+ * An entity id that is not in the store. `useEntity` cannot tell "not loaded
+ * yet" from "does not exist", so the card holds its skeleton indefinitely
+ * rather than reporting the entity as missing.
+ */
+export const UnknownEntity: Story = {
+  parameters: { liebe: { entities: [] } },
+}
+
+/** Edit mode hides the controls and exposes configure/delete affordances. */
+export const EditMode: Story = {
+  args: { onDelete: () => {} },
+  parameters: { liebe: { entities: [createLightEntity()], mode: 'edit' } },
+}

--- a/src/components/PanelApp.tsx
+++ b/src/components/PanelApp.tsx
@@ -1,9 +1,8 @@
-import { Theme } from '@radix-ui/themes'
 import { dashboardActions, dashboardStore } from '~/store/dashboardStore'
-import { useCameraFullscreenActive, CAMERA_FULLSCREEN_Z_INDEX } from '~/store/cameraFullscreenStore'
 import { useEffect } from 'react'
 import { RouterProvider } from '@tanstack/react-router'
 import { router } from '~/router'
+import { LiebeThemeProvider } from './LiebeThemeProvider'
 
 export function PanelApp() {
   useEffect(() => {
@@ -15,23 +14,9 @@ export function PanelApp() {
     }
   }, [])
 
-  // This is the ROOT Theme (data-is-root-theme="true"), so it establishes a
-  // stacking context (`position: relative; z-index: 0`) that would otherwise
-  // cap the camera card's in-place fullscreen overlay below Home Assistant's
-  // chrome. While any camera overlay is open, lift this ancestor's stacking so
-  // the overlay paints over HA's header/sidebar — WITHOUT moving the stream
-  // node. See docs/changes/0008-camera-fullscreen-no-dom-move.md.
-  const cameraFullscreenActive = useCameraFullscreenActive()
-
   return (
-    <Theme
-      style={
-        cameraFullscreenActive
-          ? { position: 'relative', zIndex: CAMERA_FULLSCREEN_Z_INDEX }
-          : undefined
-      }
-    >
+    <LiebeThemeProvider>
       <RouterProvider router={router} />
-    </Theme>
+    </LiebeThemeProvider>
   )
 }

--- a/src/components/SensorCard.stories.tsx
+++ b/src/components/SensorCard.stories.tsx
@@ -1,0 +1,115 @@
+import type { ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { SensorCard } from './SensorCard'
+import { asUnavailable, createSensorEntity } from '~/test/fixtures'
+import { gridCellArgTypes, withGridCell, type GridCellArgs } from '../../.storybook/decorators'
+
+const entityId = 'sensor.living_room_temperature'
+
+type SensorCardStoryProps = ComponentProps<typeof SensorCard> & GridCellArgs
+
+const meta: Meta<SensorCardStoryProps> = {
+  title: 'Cards/SensorCard',
+  component: SensorCard,
+  decorators: [withGridCell],
+  argTypes: {
+    ...gridCellArgTypes,
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium', 'large'] },
+  },
+  args: {
+    entityId,
+    size: 'medium',
+    gridWidth: 2,
+    gridHeight: 2,
+  },
+  parameters: {
+    liebe: { entities: [createSensorEntity()] },
+  },
+}
+
+export default meta
+type Story = StoryObj<SensorCardStoryProps>
+
+/**
+ * A typical reading. A numeric sensor has no on/off pair, so its two
+ * representative states are a typical and an extreme value.
+ */
+export const TypicalValue: Story = {
+  parameters: { liebe: { entities: [createSensorEntity()] } },
+}
+
+/** An extreme reading — the value formatter rounds to one decimal here. */
+export const ExtremeValue: Story = {
+  parameters: {
+    liebe: { entities: [createSensorEntity({ state: '-18.75' })] },
+  },
+}
+
+/** Power device class: values at or above 1000 are rescaled to kW. */
+export const PowerInKilowatts: Story = {
+  parameters: {
+    liebe: {
+      entities: [
+        createSensorEntity({
+          entity_id: entityId,
+          state: '2450',
+          attributes: {
+            friendly_name: 'House Power',
+            device_class: 'power',
+            unit_of_measurement: 'W',
+          },
+        }),
+      ],
+    },
+  },
+}
+
+/** A non-numeric sensor renders its raw state, upper-cased. */
+export const TextualState: Story = {
+  parameters: {
+    liebe: {
+      entities: [
+        createSensorEntity({
+          entity_id: entityId,
+          state: 'charging',
+          attributes: {
+            friendly_name: 'Phone Battery State',
+            device_class: undefined,
+            unit_of_measurement: undefined,
+          },
+        }),
+      ],
+    },
+  },
+}
+
+export const Unavailable: Story = {
+  parameters: { liebe: { entities: [asUnavailable(createSensorEntity())] } },
+}
+
+export const Loading: Story = {
+  parameters: { liebe: { entities: [], initialLoading: true } },
+}
+
+/**
+ * The sensor card is read-only — it has no service-call path — so its error
+ * story is the disconnected state it reaches through `useEntity`.
+ */
+export const Disconnected: Story = {
+  parameters: { liebe: { entities: [createSensorEntity()], connected: false } },
+}
+
+/**
+ * An entity id that is not in the store. `useEntity` cannot tell "not loaded
+ * yet" from "does not exist", so the card holds its skeleton indefinitely
+ * rather than reporting the entity as missing.
+ */
+export const UnknownEntity: Story = {
+  parameters: { liebe: { entities: [] } },
+}
+
+/** Edit mode exposes the delete affordance. */
+export const EditMode: Story = {
+  args: { onDelete: () => {} },
+  parameters: { liebe: { entities: [createSensorEntity()], mode: 'edit' } },
+}

--- a/src/components/WeatherCard/index.tsx
+++ b/src/components/WeatherCard/index.tsx
@@ -1,7 +1,6 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { CardConfig } from '../CardConfig'
 import { dashboardActions, useDashboardStore } from '~/store'
-import { registerCardVariant } from '../cardRegistry'
 import type { CardProps } from '../cardRegistry'
 import type { GridItem } from '~/store/types'
 import type { CSSProperties } from 'react'
@@ -9,17 +8,6 @@ import { WeatherCardDefault } from './WeatherCardDefault'
 import { WeatherCardMinimal } from './WeatherCardMinimal'
 import { WeatherCardModern } from './WeatherCardModern'
 import { WeatherCardDetailed } from './WeatherCardDetailed'
-
-// Register weather card variants - do this inside a component to avoid initialization issues
-let variantsRegistered = false
-function registerWeatherVariants() {
-  if (!variantsRegistered) {
-    registerCardVariant('weather', 'minimal', WeatherCardMinimal)
-    registerCardVariant('weather', 'modern', WeatherCardModern)
-    registerCardVariant('weather', 'detailed', WeatherCardDetailed)
-    variantsRegistered = true
-  }
-}
 
 interface WeatherCardConfig {
   preset?: 'default' | 'detailed' | 'minimal' | 'modern'
@@ -233,11 +221,6 @@ export function getWeatherBackground(condition: string): string | null {
 
 // Main WeatherCard that handles variant selection based on config
 export function WeatherCard(props: CardProps) {
-  // Register variants on first render
-  useEffect(() => {
-    registerWeatherVariants()
-  }, [])
-
   const [configOpen, setConfigOpen] = useState(false)
   const screens = useDashboardStore((state) => state.screens)
   const currentScreenId = useDashboardStore((state) => state.currentScreenId)
@@ -307,7 +290,20 @@ export function WeatherCard(props: CardProps) {
   )
 }
 
-// Assign default dimensions
+// Default dimensions and the card's presentation variants.
+//
+// The variants are attached statically rather than pushed into the registry via
+// `registerCardVariant`: importing `cardRegistry` from here made the module
+// graph circular (`cardRegistry` → every card → `CardConfig` → `WeatherCard` →
+// `cardRegistry`), which crashes with a temporal-dead-zone error in any bundle
+// whose entry reaches a card before the registry. `getCardVariant` reads
+// `card.variants`, so lookups are unchanged — and the variants are now
+// registered before the first render instead of after it.
 Object.assign(WeatherCard, {
   defaultDimensions: { width: 4, height: 3 },
+  variants: {
+    minimal: WeatherCardMinimal,
+    modern: WeatherCardModern,
+    detailed: WeatherCardDetailed,
+  },
 })

--- a/src/components/__tests__/LiebeThemeProvider.test.tsx
+++ b/src/components/__tests__/LiebeThemeProvider.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { LiebeThemeProvider } from '../LiebeThemeProvider'
+import {
+  cameraFullscreenStore,
+  enterCameraFullscreen,
+  exitCameraFullscreen,
+} from '~/store/cameraFullscreenStore'
+
+function getRootTheme(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-is-root-theme="true"]') as HTMLElement
+}
+
+describe('LiebeThemeProvider', () => {
+  beforeEach(() => {
+    cameraFullscreenStore.setState(() => 0)
+  })
+
+  it('renders children inside the root Radix Theme', () => {
+    const { container, getByTestId } = render(
+      <LiebeThemeProvider>
+        <span data-testid="child" />
+      </LiebeThemeProvider>
+    )
+
+    expect(getRootTheme(container)).toBeInTheDocument()
+    expect(getByTestId('child')).toBeInTheDocument()
+  })
+
+  it('leaves the appearance to the surrounding document when none is given', () => {
+    const { container } = render(
+      <LiebeThemeProvider>
+        <span />
+      </LiebeThemeProvider>
+    )
+
+    // Radix stamps the resolved appearance as a class; with no explicit
+    // appearance the panel inherits, so neither class is forced.
+    const theme = getRootTheme(container)
+    expect(theme.classList.contains('dark')).toBe(false)
+    expect(theme.classList.contains('light')).toBe(false)
+  })
+
+  it('applies an explicit appearance to the root Theme', () => {
+    const { container } = render(
+      <LiebeThemeProvider appearance="light">
+        <span />
+      </LiebeThemeProvider>
+    )
+
+    expect(getRootTheme(container).classList.contains('light')).toBe(true)
+  })
+
+  it('lifts the root Theme stacking while a camera overlay is open', () => {
+    const { container } = render(
+      <LiebeThemeProvider>
+        <span />
+      </LiebeThemeProvider>
+    )
+    const theme = getRootTheme(container)
+
+    expect(theme.style.zIndex).toBe('')
+
+    act(() => enterCameraFullscreen())
+    expect(theme.style.position).toBe('relative')
+    expect(theme.style.zIndex).toBe('99999')
+
+    act(() => exitCameraFullscreen())
+    expect(theme.style.zIndex).toBe('')
+  })
+})

--- a/src/components/__tests__/cardRegistry.test.ts
+++ b/src/components/__tests__/cardRegistry.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import {
+  domainToCard,
+  getCardForDomain,
+  getCardForEntity,
+  getCardVariant,
+  getCardVariants,
+  registerCardVariant,
+} from '../cardRegistry'
+import { WeatherCard } from '../WeatherCard'
+import { WeatherCardMinimal } from '../WeatherCard/WeatherCardMinimal'
+import { WeatherCardModern } from '../WeatherCard/WeatherCardModern'
+import { WeatherCardDetailed } from '../WeatherCard/WeatherCardDetailed'
+
+describe('cardRegistry', () => {
+  it('resolves a card by domain and by entity id', () => {
+    expect(getCardForDomain('weather')).toBe(WeatherCard)
+    expect(getCardForEntity('weather.home')).toBe(WeatherCard)
+    expect(getCardForEntity('media_player.tv')).toBeUndefined()
+  })
+
+  describe('weather variants', () => {
+    it('are available without the card ever rendering', () => {
+      // The variants are attached to the component statically, so a consumer
+      // that only ever asks the registry (the entity browser, card config)
+      // sees them before the first WeatherCard mounts. Registering them from
+      // inside the component instead required `WeatherCard` to import
+      // `cardRegistry`, which closed a circular import.
+      expect(getCardVariants('weather').sort()).toEqual(['detailed', 'minimal', 'modern'])
+      expect(getCardVariant('weather', 'minimal')).toBe(WeatherCardMinimal)
+      expect(getCardVariant('weather', 'modern')).toBe(WeatherCardModern)
+      expect(getCardVariant('weather', 'detailed')).toBe(WeatherCardDetailed)
+    })
+
+    it('does not report a variant the card never declared', () => {
+      expect(getCardVariant('weather', 'nope')).toBeUndefined()
+    })
+  })
+
+  describe('registerCardVariant', () => {
+    const registered: Array<[string, string]> = []
+
+    afterEach(() => {
+      for (const [domain, name] of registered.splice(0)) {
+        delete domainToCard[domain]?.variants?.[name]
+      }
+    })
+
+    it('adds a variant to a registered card', () => {
+      const Variant = () => null
+      registerCardVariant('sensor', 'compact', Variant)
+      registered.push(['sensor', 'compact'])
+
+      expect(getCardVariant('sensor', 'compact')).toBe(Variant)
+    })
+
+    it('ignores a domain that has no card', () => {
+      registerCardVariant('media_player', 'compact', () => null)
+
+      expect(getCardVariants('media_player')).toEqual([])
+    })
+  })
+})

--- a/src/test/fixtures/entities.ts
+++ b/src/test/fixtures/entities.ts
@@ -136,7 +136,7 @@ export function createCoverEntity(overrides: EntityOverrides = {}): HassEntity {
       device_class: 'blind',
       current_position: 70,
       current_tilt_position: 40,
-      // OPEN | CLOSE | SET_POSITION | STOP | OPEN_TILT | CLOSE_TILT | SET_TILT_POSITION
+      // OPEN | CLOSE | SET_POSITION | STOP | OPEN_TILT | CLOSE_TILT | SET_TILT_POSITION | STOP_TILT
       supported_features: 255,
     },
     overrides

--- a/src/test/fixtures/entities.ts
+++ b/src/test/fixtures/entities.ts
@@ -1,0 +1,318 @@
+/**
+ * `HassEntity` factories, one per domain Liebe currently supports.
+ *
+ * Shared infrastructure: the Storybook preview seeds the entity store with
+ * these, and the Vitest suite is expected to migrate onto them over time so
+ * stories and unit tests converge on a single mock shape (see
+ * docs/specs/storybook/index.md, "Entity data mocking"). Excluded from coverage
+ * scope — this is development tooling, not product code.
+ */
+import type { EntityAttributes, HassEntity } from '~/store/entityTypes'
+
+/** Frozen timestamp so fixtures are deterministic across renders and snapshots. */
+export const FIXTURE_TIMESTAMP = '2026-07-25T12:00:00.000Z'
+
+export interface EntityOverrides {
+  entity_id?: string
+  state?: string
+  attributes?: EntityAttributes
+  last_changed?: string
+  last_updated?: string
+  context?: HassEntity['context']
+}
+
+/**
+ * Build an entity from a domain default plus overrides. `attributes` is merged
+ * shallowly onto the domain defaults, so a story can change one attribute
+ * without restating the rest.
+ */
+function buildEntity(base: HassEntity, overrides: EntityOverrides = {}): HassEntity {
+  const { attributes, ...rest } = overrides
+  return {
+    ...base,
+    ...rest,
+    attributes: { ...base.attributes, ...attributes },
+  }
+}
+
+function entity(
+  entityId: string,
+  state: string,
+  attributes: EntityAttributes,
+  overrides: EntityOverrides = {}
+): HassEntity {
+  return buildEntity(
+    {
+      entity_id: entityId,
+      state,
+      attributes,
+      last_changed: FIXTURE_TIMESTAMP,
+      last_updated: FIXTURE_TIMESTAMP,
+      context: { id: 'fixture-context', parent_id: null, user_id: null },
+    },
+    overrides
+  )
+}
+
+export function createLightEntity(overrides: EntityOverrides = {}): HassEntity {
+  return entity(
+    'light.living_room',
+    'on',
+    {
+      friendly_name: 'Living Room',
+      brightness: 204,
+      color_mode: 'brightness',
+      supported_color_modes: ['brightness'],
+      supported_features: 0,
+    },
+    overrides
+  )
+}
+
+export function createSwitchEntity(overrides: EntityOverrides = {}): HassEntity {
+  return entity(
+    'switch.coffee_machine',
+    'off',
+    { friendly_name: 'Coffee Machine', device_class: 'outlet' },
+    overrides
+  )
+}
+
+export function createClimateEntity(overrides: EntityOverrides = {}): HassEntity {
+  return entity(
+    'climate.hallway',
+    'heat',
+    {
+      friendly_name: 'Hallway Thermostat',
+      current_temperature: 19.5,
+      temperature: 21,
+      min_temp: 7,
+      max_temp: 35,
+      target_temp_step: 0.5,
+      temperature_unit: '°C',
+      current_humidity: 44,
+      hvac_modes: ['off', 'heat', 'cool', 'heat_cool', 'auto'],
+      hvac_action: 'heating',
+      fan_modes: ['auto', 'low', 'high'],
+      fan_mode: 'auto',
+      preset_modes: ['home', 'away', 'eco'],
+      preset_mode: 'home',
+      // SUPPORT_TARGET_TEMPERATURE | SUPPORT_TARGET_TEMPERATURE_RANGE
+      supported_features: 3,
+    },
+    overrides
+  )
+}
+
+export function createSensorEntity(overrides: EntityOverrides = {}): HassEntity {
+  return entity(
+    'sensor.living_room_temperature',
+    '21.4',
+    {
+      friendly_name: 'Living Room Temperature',
+      device_class: 'temperature',
+      state_class: 'measurement',
+      unit_of_measurement: '°C',
+    },
+    overrides
+  )
+}
+
+export function createBinarySensorEntity(overrides: EntityOverrides = {}): HassEntity {
+  return entity(
+    'binary_sensor.front_door',
+    'off',
+    { friendly_name: 'Front Door', device_class: 'door' },
+    overrides
+  )
+}
+
+export function createCoverEntity(overrides: EntityOverrides = {}): HassEntity {
+  return entity(
+    'cover.living_room_blinds',
+    'open',
+    {
+      friendly_name: 'Living Room Blinds',
+      device_class: 'blind',
+      current_position: 70,
+      current_tilt_position: 40,
+      // OPEN | CLOSE | SET_POSITION | STOP | OPEN_TILT | CLOSE_TILT | SET_TILT_POSITION
+      supported_features: 255,
+    },
+    overrides
+  )
+}
+
+export function createFanEntity(overrides: EntityOverrides = {}): HassEntity {
+  return entity(
+    'fan.bedroom',
+    'on',
+    {
+      friendly_name: 'Bedroom Fan',
+      percentage: 66,
+      percentage_step: 33.333333,
+      preset_modes: ['auto', 'sleep', 'boost'],
+      preset_mode: 'auto',
+      oscillating: false,
+      direction: 'forward',
+      // SET_SPEED | OSCILLATE | DIRECTION
+      supported_features: 7,
+    },
+    overrides
+  )
+}
+
+export function createCameraEntity(overrides: EntityOverrides = {}): HassEntity {
+  return entity(
+    'camera.driveway',
+    'idle',
+    {
+      friendly_name: 'Driveway',
+      entity_picture: '/api/camera_proxy/camera.driveway',
+      frontend_stream_type: 'hls',
+      // SUPPORT_STREAM
+      supported_features: 2,
+    },
+    overrides
+  )
+}
+
+export function createWeatherEntity(overrides: EntityOverrides = {}): HassEntity {
+  return entity(
+    'weather.home',
+    'partlycloudy',
+    {
+      friendly_name: 'Home',
+      temperature: 22.3,
+      temperature_unit: '°C',
+      humidity: 51,
+      pressure: 1014,
+      pressure_unit: 'hPa',
+      wind_speed: 11.5,
+      wind_speed_unit: 'km/h',
+      wind_bearing: 220,
+      visibility: 16,
+      visibility_unit: 'km',
+      forecast: [
+        { datetime: '2026-07-26T12:00:00+00:00', condition: 'sunny', temperature: 26, templow: 15 },
+        { datetime: '2026-07-27T12:00:00+00:00', condition: 'rainy', temperature: 19, templow: 13 },
+        {
+          datetime: '2026-07-28T12:00:00+00:00',
+          condition: 'cloudy',
+          temperature: 21,
+          templow: 14,
+        },
+      ],
+    },
+    overrides
+  )
+}
+
+export function createInputBooleanEntity(overrides: EntityOverrides = {}): HassEntity {
+  return entity(
+    'input_boolean.guest_mode',
+    'off',
+    { friendly_name: 'Guest Mode', editable: true },
+    overrides
+  )
+}
+
+export function createInputNumberEntity(overrides: EntityOverrides = {}): HassEntity {
+  return entity(
+    'input_number.target_humidity',
+    '45',
+    {
+      friendly_name: 'Target Humidity',
+      min: 0,
+      max: 100,
+      step: 1,
+      mode: 'slider',
+      unit_of_measurement: '%',
+      editable: true,
+    },
+    overrides
+  )
+}
+
+export function createInputSelectEntity(overrides: EntityOverrides = {}): HassEntity {
+  return entity(
+    'input_select.house_mode',
+    'Home',
+    {
+      friendly_name: 'House Mode',
+      options: ['Home', 'Away', 'Night', 'Vacation'],
+      editable: true,
+    },
+    overrides
+  )
+}
+
+export function createInputTextEntity(overrides: EntityOverrides = {}): HassEntity {
+  return entity(
+    'input_text.doorbell_message',
+    'Please leave parcels at the side door',
+    { friendly_name: 'Doorbell Message', min: 0, max: 255, mode: 'text', editable: true },
+    overrides
+  )
+}
+
+export function createInputDateTimeEntity(overrides: EntityOverrides = {}): HassEntity {
+  return entity(
+    'input_datetime.wake_up',
+    '2026-07-26 06:30:00',
+    {
+      friendly_name: 'Wake Up',
+      has_date: true,
+      has_time: true,
+      year: 2026,
+      month: 7,
+      day: 26,
+      hour: 6,
+      minute: 30,
+      second: 0,
+      timestamp: 1785040200,
+      editable: true,
+    },
+    overrides
+  )
+}
+
+/** Every domain factory, keyed by the domain it serves. */
+export const entityFactories = {
+  light: createLightEntity,
+  switch: createSwitchEntity,
+  climate: createClimateEntity,
+  sensor: createSensorEntity,
+  binary_sensor: createBinarySensorEntity,
+  cover: createCoverEntity,
+  fan: createFanEntity,
+  camera: createCameraEntity,
+  weather: createWeatherEntity,
+  input_boolean: createInputBooleanEntity,
+  input_number: createInputNumberEntity,
+  input_select: createInputSelectEntity,
+  input_text: createInputTextEntity,
+  input_datetime: createInputDateTimeEntity,
+} as const satisfies Record<string, (overrides?: EntityOverrides) => HassEntity>
+
+export type FixtureDomain = keyof typeof entityFactories
+
+/** Build the default entity for a domain. */
+export function createEntityForDomain(
+  domain: FixtureDomain,
+  overrides: EntityOverrides = {}
+): HassEntity {
+  return entityFactories[domain](overrides)
+}
+
+/** One default entity per supported domain — a whole-screen fixture set. */
+export function createAllDomainEntities(): HassEntity[] {
+  return (Object.keys(entityFactories) as FixtureDomain[]).map((domain) =>
+    createEntityForDomain(domain)
+  )
+}
+
+/** Mark any fixture unavailable without restating its attributes. */
+export function asUnavailable(base: HassEntity): HassEntity {
+  return { ...base, state: 'unavailable' }
+}

--- a/src/test/fixtures/index.ts
+++ b/src/test/fixtures/index.ts
@@ -1,0 +1,2 @@
+export * from './entities'
+export * from './storyParameters'

--- a/src/test/fixtures/storyParameters.ts
+++ b/src/test/fixtures/storyParameters.ts
@@ -1,0 +1,28 @@
+/**
+ * The `liebe` story parameter — the contract between a story and the workshop
+ * decorators that seed the stores and intercept service calls.
+ *
+ * Lives beside the entity fixtures (shared infrastructure, excluded from
+ * coverage) rather than inside `.storybook/` so stories colocated with
+ * components can import it without reaching across the repo root.
+ */
+import type { HassEntity } from '~/store/entityTypes'
+
+export interface LiebeStoryParameters {
+  /** Entities seeded into the entity store before the story renders. */
+  entities?: HassEntity[]
+  /** Whether the entity store reports a live Home Assistant connection. Default `true`. */
+  connected?: boolean
+  /** Whether the entity store is still doing its first load. Default `false`. */
+  initialLoading?: boolean
+  /** Dashboard mode the story renders in. Default `'view'`. */
+  mode?: 'view' | 'edit'
+  /**
+   * How intercepted service calls resolve. `'error'` makes every call reject,
+   * which is how control cards reach their error state through their normal
+   * hooks. Default `'success'`.
+   */
+  serviceCall?: 'success' | 'error'
+  /** Message the rejected service call fails with. */
+  serviceCallError?: string
+}

--- a/src/theme/__tests__/themeRegistry.test.ts
+++ b/src/theme/__tests__/themeRegistry.test.ts
@@ -16,10 +16,19 @@ describe('themeRegistry', () => {
     expect(listThemes()).toEqual([{ id: 'default', label: 'Default', appearances: 'both' }])
   })
 
-  it('hands out a copy so callers cannot mutate the registry', () => {
+  it('hands out a copy of the list so callers cannot add to the registry', () => {
     const themes = listThemes()
     themes.push(darkOnly)
     expect(listThemes()).toHaveLength(1)
+  })
+
+  it('freezes each definition so a caller cannot repoint a theme', () => {
+    const theme = getTheme(DEFAULT_THEME_ID)!
+    // The type still allows the write; the freeze is what makes it fail.
+    expect(() => {
+      theme.appearances = 'dark-only'
+    }).toThrow(TypeError)
+    expect(resolveAppearance(getTheme(DEFAULT_THEME_ID), 'light')).toBe('light')
   })
 
   it('looks a theme up by id', () => {

--- a/src/theme/__tests__/themeRegistry.test.ts
+++ b/src/theme/__tests__/themeRegistry.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DEFAULT_THEME_ID,
+  getTheme,
+  listThemes,
+  resolveAppearance,
+  supportsAppearanceChoice,
+  type ThemeDefinition,
+} from '../themeRegistry'
+
+const darkOnly: ThemeDefinition = { id: 'lcars', label: 'LCARS', appearances: 'dark-only' }
+const lightOnly: ThemeDefinition = { id: 'paper', label: 'Paper', appearances: 'light-only' }
+
+describe('themeRegistry', () => {
+  it('registers exactly the built-in themes that exist today', () => {
+    expect(listThemes()).toEqual([{ id: 'default', label: 'Default', appearances: 'both' }])
+  })
+
+  it('hands out a copy so callers cannot mutate the registry', () => {
+    const themes = listThemes()
+    themes.push(darkOnly)
+    expect(listThemes()).toHaveLength(1)
+  })
+
+  it('looks a theme up by id', () => {
+    expect(getTheme(DEFAULT_THEME_ID)).toEqual({
+      id: 'default',
+      label: 'Default',
+      appearances: 'both',
+    })
+  })
+
+  it('returns undefined for an unregistered id', () => {
+    expect(getTheme('lcars')).toBeUndefined()
+  })
+
+  describe('resolveAppearance', () => {
+    it('honours the request for a both-appearance theme', () => {
+      const theme = getTheme(DEFAULT_THEME_ID)
+      expect(resolveAppearance(theme, 'dark')).toBe('dark')
+      expect(resolveAppearance(theme, 'light')).toBe('light')
+    })
+
+    it('forces dark for a dark-only theme', () => {
+      expect(resolveAppearance(darkOnly, 'light')).toBe('dark')
+    })
+
+    it('forces light for a light-only theme', () => {
+      expect(resolveAppearance(lightOnly, 'dark')).toBe('light')
+    })
+
+    it('keeps the request for an unknown theme', () => {
+      expect(resolveAppearance(undefined, 'light')).toBe('light')
+    })
+  })
+
+  describe('supportsAppearanceChoice', () => {
+    it('is interactive for a both-appearance theme and for an unknown theme', () => {
+      expect(supportsAppearanceChoice(getTheme(DEFAULT_THEME_ID))).toBe(true)
+      expect(supportsAppearanceChoice(undefined)).toBe(true)
+    })
+
+    it('is forced for single-appearance themes', () => {
+      expect(supportsAppearanceChoice(darkOnly)).toBe(false)
+      expect(supportsAppearanceChoice(lightOnly)).toBe(false)
+    })
+  })
+})

--- a/src/theme/themeRegistry.ts
+++ b/src/theme/themeRegistry.ts
@@ -1,0 +1,62 @@
+/**
+ * Minimal built-in theme registry.
+ *
+ * A theme is data — an id, a human label, and which appearances it supports
+ * (see docs/specs/theming/index.md, "Theme model"). Only `default` exists
+ * today; the Storybook theme toolbar enumerates this registry rather than a
+ * hardcoded list, so themes registered by later changes appear in the workshop
+ * with no workshop changes. Change 0012 adopts this module as the runtime
+ * registry and extends each entry with its CSS payload.
+ */
+
+/** Appearances a theme is able to render in. */
+export type ThemeAppearanceSupport = 'both' | 'dark-only' | 'light-only'
+
+/** A resolved appearance — what the Radix `Theme` is actually rendered with. */
+export type ThemeAppearance = 'dark' | 'light'
+
+export interface ThemeDefinition {
+  /** Stable identifier, stamped as `data-liebe-theme` by the theming engine. */
+  id: string
+  /** Human-readable name shown in pickers and the Storybook toolbar. */
+  label: string
+  /** Which appearances this theme provides token sets for. */
+  appearances: ThemeAppearanceSupport
+}
+
+export const DEFAULT_THEME_ID = 'default'
+
+const builtInThemes: ThemeDefinition[] = [
+  { id: DEFAULT_THEME_ID, label: 'Default', appearances: 'both' },
+]
+
+/** All registered themes, in registration order. */
+export function listThemes(): ThemeDefinition[] {
+  return [...builtInThemes]
+}
+
+/** Look up a single theme, or `undefined` when the id is not registered. */
+export function getTheme(id: string): ThemeDefinition | undefined {
+  return builtInThemes.find((theme) => theme.id === id)
+}
+
+/**
+ * Resolve the appearance a theme renders in.
+ *
+ * Single-appearance themes force theirs, which is what lets the appearance
+ * control be shown as forced rather than lying about the rendered result. An
+ * unknown theme (`undefined`) keeps the requested appearance.
+ */
+export function resolveAppearance(
+  theme: ThemeDefinition | undefined,
+  requested: ThemeAppearance
+): ThemeAppearance {
+  if (theme?.appearances === 'dark-only') return 'dark'
+  if (theme?.appearances === 'light-only') return 'light'
+  return requested
+}
+
+/** Whether the appearance control should be interactive for this theme. */
+export function supportsAppearanceChoice(theme: ThemeDefinition | undefined): boolean {
+  return theme === undefined || theme.appearances === 'both'
+}

--- a/src/theme/themeRegistry.ts
+++ b/src/theme/themeRegistry.ts
@@ -26,9 +26,13 @@ export interface ThemeDefinition {
 
 export const DEFAULT_THEME_ID = 'default'
 
-const builtInThemes: ThemeDefinition[] = [
-  { id: DEFAULT_THEME_ID, label: 'Default', appearances: 'both' },
-]
+// Frozen: `listThemes`/`getTheme` hand out the stored records themselves, so a
+// caller mutating one would change appearance resolution for every other
+// caller. Freezing keeps the registry the single source of truth without
+// cloning on every lookup.
+const builtInThemes: readonly ThemeDefinition[] = Object.freeze([
+  Object.freeze<ThemeDefinition>({ id: DEFAULT_THEME_ID, label: 'Default', appearances: 'both' }),
+])
 
 /** All registered themes, in registration order. */
 export function listThemes(): ThemeDefinition[] {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
-  "include": ["**/*.ts", "**/*.tsx"],
+  // TypeScript's globs skip dot-directories, so the Storybook config files are
+  // listed explicitly — without them `tsc` and eslint (which needs the file to
+  // be in the project) both ignore `.storybook/`.
+  "include": ["**/*.ts", "**/*.tsx", ".storybook/**/*.ts", ".storybook/**/*.tsx"],
   "compilerOptions": {
     "strict": true,
     "esModuleInterop": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -91,9 +91,14 @@ function panelPlugin() {
     async configureServer(server: ViteDevServer) {
       await buildPanel()
       server.watcher.on('change', async (file: string) => {
-        // Tests and Storybook stories never reach the panel bundle, so editing
-        // one must not trigger a panel rebuild.
-        if (file.includes('src/') && !file.includes('.test.') && !file.includes('.stories.')) {
+        // Tests, test helpers/fixtures, and Storybook stories never reach the
+        // panel bundle, so editing one must not trigger a panel rebuild.
+        if (
+          file.includes('src/') &&
+          !file.includes('src/test/') &&
+          !file.includes('.test.') &&
+          !file.includes('.stories.')
+        ) {
           await buildPanel()
           server.ws.send({
             type: 'full-reload',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,19 @@ import react from '@vitejs/plugin-react'
 import { resolve } from 'path'
 import { build } from 'vite'
 
+// Path fragments that only ever belong to tests, test helpers, or Storybook.
+// None of them reach the panel bundle, so editing one must not trigger a panel
+// rebuild. Keep this in sync with the coverage `exclude` list in
+// vitest.config.ts — both encode the same "this is test-only" judgement.
+const NON_PANEL_SOURCES = [
+  'src/test/',
+  'src/test-utils/',
+  'src/testUtils/',
+  'test-setup.ts',
+  '.test.',
+  '.stories.',
+]
+
 function panelPlugin() {
   let panelContent = ''
   let cssContent = ''
@@ -91,13 +104,9 @@ function panelPlugin() {
     async configureServer(server: ViteDevServer) {
       await buildPanel()
       server.watcher.on('change', async (file: string) => {
-        // Tests, test helpers/fixtures, and Storybook stories never reach the
-        // panel bundle, so editing one must not trigger a panel rebuild.
         if (
           file.includes('src/') &&
-          !file.includes('src/test/') &&
-          !file.includes('.test.') &&
-          !file.includes('.stories.')
+          !NON_PANEL_SOURCES.some((fragment) => file.includes(fragment))
         ) {
           await buildPanel()
           server.ws.send({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -91,7 +91,9 @@ function panelPlugin() {
     async configureServer(server: ViteDevServer) {
       await buildPanel()
       server.watcher.on('change', async (file: string) => {
-        if (file.includes('src/') && !file.includes('.test.')) {
+        // Tests and Storybook stories never reach the panel bundle, so editing
+        // one must not trigger a panel rebuild.
+        if (file.includes('src/') && !file.includes('.test.') && !file.includes('.stories.')) {
           await buildPanel()
           server.ws.send({
             type: 'full-reload',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,12 @@ export default defineConfig({
         '**/test-setup.ts',
         'src/test-utils/**',
         'src/testUtils/**',
+        // Storybook is development tooling: stories, the workshop config, and
+        // the decorators/fixtures they rely on never ship in the panel bundle,
+        // so they must not inflate the denominator or fall under the patch
+        // gate. See docs/changes/0009-storybook-setup.md.
+        '**/*.stories.tsx',
+        '.storybook/**',
         // Build output, generated code, and config files
         'dist/**',
         '**/*.gen.ts',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,7 +35,9 @@ export default defineConfig({
         // the decorators/fixtures they rely on never ship in the panel bundle,
         // so they must not inflate the denominator or fall under the patch
         // gate. See docs/changes/0009-storybook-setup.md.
-        '**/*.stories.tsx',
+        // `.storybook/main.ts` loads `*.stories.@(ts|tsx)`, so both extensions
+        // have to be excluded.
+        '**/*.stories.{ts,tsx}',
         '.storybook/**',
         // Build output, generated code, and config files
         'dist/**',


### PR DESCRIPTION
## Summary

Stands up the component workshop specified in `docs/specs/storybook/index.md`, the first task of `docs/changes/0009-storybook-setup.md`. Storybook 10 on the Vite builder, entity fixture factories, store-seeding and service-call-interception decorators, a registry-driven appearance/theme toolbar, and the first story set.

## What's here

- **Storybook 10** (`^10.5.4`) with `@storybook/react-vite`, `.storybook/main.ts` + `preview.tsx`, and a dedicated `.storybook/vite.config.ts`. The dedicated config matters: Storybook otherwise loads the repo root Vite config, which carries the TanStack Start plugin and the dev-panel plugin that rebuilds `panel.js` on every change.
- **Side-effect-free provider entry** — `LiebeThemeProvider` extracts the panel's Radix `Theme` shell (including the camera-fullscreen stacking lift from `docs/changes/0008-camera-fullscreen-no-dom-move.md`) so the preview renders components in exactly the panel's provider stack without importing custom-element registration, the router, or the HA connection. `PanelApp` now consumes it, so panel behavior is unchanged.
- **Entity fixture factories** for every currently supported domain, in `src/test/fixtures/` — deliberately outside `.storybook/` so Vitest can adopt the same mock shape over time.
- **Decorators**: store seeding, service-call interception, grid-cell sizing, and an appearance toolbar backed by a minimal theme registry (`src/theme/themeRegistry.ts`) containing only `default`. The theming engine change adopts and extends that same module as the runtime registry, so later themes appear in the toolbar with no workshop changes.
- **Stories**: `GridCard` shell across its states, plus `LightCard`, `ClimateCard`, `SensorCard`, and `BinarySensorCard` state matrices.
- **Coverage exclusions** for `*.stories.tsx` and `.storybook/**`; fixtures already fall under the existing `src/test/**` exclusion. Product code stays in the denominator.

## Latent circular dependency, found and fixed

Standing up the workshop exposed a real cycle that the panel bundle survived only by accident of entry order: `cardRegistry` → every card → `CardConfig` → `WeatherCard` → `cardRegistry`. Any bundle whose entry reaches a card before the registry crashes with a temporal-dead-zone error — which is exactly what broke the first Storybook build.

`WeatherCard` now declares its presentation variants as a static `variants` map on the component (which `getCardVariant` already reads) instead of calling `registerCardVariant` at module scope. `registerCardVariant` still exists for consumers outside the card graph. `AGENTS.md` records the constraint so the next card author doesn't reintroduce it.

## Testing

- `npm test` — 64 files, 815 passed, 2 skipped
- `npm run lint` — clean (tsc + eslint + prettier)
- `npm run typecheck` — clean
- `npm run build-storybook` — succeeds
- Patch coverage: the two new product modules (`LiebeThemeProvider.tsx`, `themeRegistry.ts`) are at 100% statements/branches/functions; `cardRegistry.ts` stays at 100% lines. The one uncovered line in `PanelApp.tsx` is pre-existing and untouched by this diff.

## Scope

Story coverage for the remaining cards, the a11y addon, the CI build gate, and Pages publishing are the follow-up tasks in the same change document. The change stays `draft` until its final task lands.
