### PR TITLE
test(storybook): cover every remaining card and enable the a11y addon

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -5,6 +5,9 @@ const config: StorybookConfig = {
   // Enabled globally so every story is audited by axe as soon as it is opened
   // (spec: "the a11y addon MUST run on all stories").
   addons: ['@storybook/addon-a11y'],
+  // Mock assets the stories serve to themselves (camera frames), so no story
+  // depends on network access.
+  staticDirs: ['./public'],
   framework: {
     name: '@storybook/react-vite',
     options: {

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,6 +2,9 @@ import type { StorybookConfig } from '@storybook/react-vite'
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(ts|tsx)'],
+  // Enabled globally so every story is audited by axe as soon as it is opened
+  // (spec: "the a11y addon MUST run on all stories").
+  addons: ['@storybook/addon-a11y'],
   framework: {
     name: '@storybook/react-vite',
     options: {

--- a/.storybook/mockCameraStream.ts
+++ b/.storybook/mockCameraStream.ts
@@ -47,6 +47,24 @@ class MockHaCameraStream extends HTMLElement {
   #src = MOCK_CAMERA_FRAME
   /** Last rendered inputs, so repeated property writes do not restart the frame. */
   #rendered: string | null = null
+  /**
+   * Whether the card has handed over the fixture yet.
+   *
+   * `HaCameraStream` appends the element (firing `connectedCallback`) in one
+   * layout effect and assigns `stateObj` in the next, so rendering on connect
+   * would run with the DEFAULT behaviour — always `stream`. For a `connecting`
+   * or `error` fixture, that first render starts a frame the very next render
+   * detaches with `replaceChildren()`, and the detached <img> still fires
+   * `load` afterwards: a stream announcement for a configuration that has no
+   * stream.
+   *
+   * Waiting for the fixture is the fix rather than filtering the late event,
+   * because it removes the cause — a superseded image is never created, so
+   * there is nothing left to fire. `#isCurrent` then covers the general case
+   * (a fixture genuinely changing mid-story), which no amount of ordering can
+   * rule out.
+   */
+  #configured = false
 
   // The card assigns `stateObj` (plus `hass`, `muted`, `fitMode`, `controls`,
   // which the mock ignores) as properties in a layout effect.
@@ -54,15 +72,18 @@ class MockHaCameraStream extends HTMLElement {
     const { entity_picture: picture, mock_stream: behavior } = value?.attributes ?? {}
     this.#behavior = BEHAVIORS.find((known) => known === behavior) ?? 'stream'
     this.#src = picture ?? MOCK_CAMERA_FRAME
+    this.#configured = true
     this.#render()
   }
 
+  // Only relevant for an element that was configured while detached; the
+  // ordinary path renders from the `stateObj` write above.
   connectedCallback() {
     this.#render()
   }
 
   #render() {
-    if (!this.isConnected) return
+    if (!this.isConnected || !this.#configured) return
     const inputs = `${this.#behavior}|${this.#src}`
     if (inputs === this.#rendered) return
     this.#rendered = inputs
@@ -77,18 +98,37 @@ class MockHaCameraStream extends HTMLElement {
     root.appendChild(img)
 
     if (this.#behavior === 'error') {
-      // Announce the watch first and break the image a tick later: the card
-      // attaches its `error` listener in response to this event, and an
-      // <img> that already failed never re-fires it.
-      this.#announce()
+      // Both steps are deferred, in this order and for different reasons.
+      //
+      // The announcement waits a task because `stateObj` is assigned from a
+      // layout effect that runs BEFORE the one attaching the card's container
+      // `load` listener — dispatching from inside the setter would fire into
+      // nothing. (The `stream` path needs no such delay: an image's own `load`
+      // is asynchronous already.)
+      //
+      // Breaking the image then waits again, because the card attaches its
+      // `error` listener in response to the announcement, and an <img> that
+      // already failed never re-fires `error`.
       setTimeout(() => {
-        img.src = BROKEN_FRAME
-      }, BREAK_DELAY_MS)
+        if (!this.#isCurrent(img)) return
+        this.#announce()
+        setTimeout(() => {
+          if (!this.#isCurrent(img)) return
+          img.src = BROKEN_FRAME
+        }, BREAK_DELAY_MS)
+      })
       return
     }
 
-    img.addEventListener('load', () => this.#announce())
+    img.addEventListener('load', () => {
+      if (this.#isCurrent(img)) this.#announce()
+    })
     img.src = this.#src
+  }
+
+  /** False once a later render has replaced this image: its events are stale. */
+  #isCurrent(img: HTMLImageElement) {
+    return img.parentNode === this.shadowRoot
   }
 
   // `load` from an <img> does not bubble, so the host re-dispatches it the way

--- a/.storybook/mockCameraStream.ts
+++ b/.storybook/mockCameraStream.ts
@@ -35,6 +35,11 @@ export type MockStreamBehavior =
 
 const BEHAVIORS: readonly MockStreamBehavior[] = ['stream', 'connecting', 'error']
 
+/** How the frame fills the surface; mirrors the real element's `fitMode`. */
+type MockFitMode = 'cover' | 'contain' | 'fill'
+
+const FIT_MODES: readonly MockFitMode[] = ['cover', 'contain', 'fill']
+
 /** Delay before breaking the image, so the card's watch is listening by then. */
 const BREAK_DELAY_MS = 50
 
@@ -45,6 +50,7 @@ interface MockStateObj {
 class MockHaCameraStream extends HTMLElement {
   #behavior: MockStreamBehavior = 'stream'
   #src = MOCK_CAMERA_FRAME
+  #fitMode: MockFitMode = 'cover'
   /** Last rendered inputs, so repeated property writes do not restart the frame. */
   #rendered: string | null = null
   /**
@@ -66,13 +72,25 @@ class MockHaCameraStream extends HTMLElement {
    */
   #configured = false
 
-  // The card assigns `stateObj` (plus `hass`, `muted`, `fitMode`, `controls`,
-  // which the mock ignores) as properties in a layout effect.
+  // The card assigns `stateObj` and `fitMode` — both honoured below — plus
+  // `hass`, `muted` and `controls`, which a still frame has no use for, in a
+  // layout effect.
   set stateObj(value: MockStateObj | undefined) {
     const { entity_picture: picture, mock_stream: behavior } = value?.attributes ?? {}
     this.#behavior = BEHAVIORS.find((known) => known === behavior) ?? 'stream'
     this.#src = picture ?? MOCK_CAMERA_FRAME
     this.#configured = true
+    this.#render()
+  }
+
+  // Assigned after `stateObj` in the same effect, so this is the write that
+  // gives a non-default fit its render — hence `fitMode` belongs in the
+  // `#rendered` key, or the second write would be memoised away and every
+  // story would letterbox nothing. Restarting the frame to restyle it is
+  // heavier than the real element, but harmless for a static image, and the
+  // superseded one is disarmed by `#isCurrent` like any other re-render.
+  set fitMode(value: MockFitMode | undefined) {
+    this.#fitMode = FIT_MODES.find((known) => known === value) ?? 'cover'
     this.#render()
   }
 
@@ -84,7 +102,7 @@ class MockHaCameraStream extends HTMLElement {
 
   #render() {
     if (!this.isConnected || !this.#configured) return
-    const inputs = `${this.#behavior}|${this.#src}`
+    const inputs = `${this.#behavior}|${this.#src}|${this.#fitMode}`
     if (inputs === this.#rendered) return
     this.#rendered = inputs
 
@@ -93,7 +111,7 @@ class MockHaCameraStream extends HTMLElement {
     if (this.#behavior === 'connecting') return
 
     const img = document.createElement('img')
-    img.style.cssText = 'width:100%;height:100%;object-fit:cover;display:block'
+    img.style.cssText = `width:100%;height:100%;object-fit:${this.#fitMode};display:block`
     img.alt = ''
     root.appendChild(img)
 

--- a/.storybook/mockCameraStream.ts
+++ b/.storybook/mockCameraStream.ts
@@ -1,0 +1,107 @@
+/**
+ * A network-free stand-in for Home Assistant's `<ha-camera-stream>`.
+ *
+ * `CameraCard` renders the real element and drives its status machine
+ * (`useCameraStreamStatus`) from what that element puts in its shadow root, so
+ * the workshop cannot reach any of the card's stream UI — connecting spinner,
+ * status pill, mute/fullscreen controls, stream error + Retry — without an
+ * element to observe. This mock provides one: it renders a still frame served
+ * by the workshop itself into an open shadow root, which is exactly the shape
+ * the card's MJPEG path watches (`shadowRoot > img`, decoded pixels ⇒
+ * streaming), and announces itself with the same bubbling, composed `load`
+ * event the real element dispatches.
+ *
+ * Behaviour is driven by the story's own fixture, via a story-only
+ * `mock_stream` attribute on the camera entity, so no story reaches into the
+ * mock directly.
+ */
+
+/** Frame served from `.storybook/public` — a real URL, so the fallback's
+ * cache-busting query parameter is harmless (a `data:` URL would be corrupted
+ * by it). */
+export const MOCK_CAMERA_FRAME = 'mock-camera-frame.svg'
+
+/** Deliberately absent, so the browser raises `error` on the <img>. */
+const BROKEN_FRAME = 'mock-camera-frame-missing.svg'
+
+/** How the mock element behaves; read from the entity's `mock_stream` attribute. */
+export type MockStreamBehavior =
+  /** Loads a frame: the card reaches its streaming state. */
+  | 'stream'
+  /** Never produces a frame: the card stays in its connecting state. */
+  | 'connecting'
+  /** Announces itself, then fails to load: the card surfaces a stream error. */
+  | 'error'
+
+const BEHAVIORS: readonly MockStreamBehavior[] = ['stream', 'connecting', 'error']
+
+/** Delay before breaking the image, so the card's watch is listening by then. */
+const BREAK_DELAY_MS = 50
+
+interface MockStateObj {
+  attributes?: { entity_picture?: string; mock_stream?: string }
+}
+
+class MockHaCameraStream extends HTMLElement {
+  #behavior: MockStreamBehavior = 'stream'
+  #src = MOCK_CAMERA_FRAME
+  /** Last rendered inputs, so repeated property writes do not restart the frame. */
+  #rendered: string | null = null
+
+  // The card assigns `stateObj` (plus `hass`, `muted`, `fitMode`, `controls`,
+  // which the mock ignores) as properties in a layout effect.
+  set stateObj(value: MockStateObj | undefined) {
+    const { entity_picture: picture, mock_stream: behavior } = value?.attributes ?? {}
+    this.#behavior = BEHAVIORS.find((known) => known === behavior) ?? 'stream'
+    this.#src = picture ?? MOCK_CAMERA_FRAME
+    this.#render()
+  }
+
+  connectedCallback() {
+    this.#render()
+  }
+
+  #render() {
+    if (!this.isConnected) return
+    const inputs = `${this.#behavior}|${this.#src}`
+    if (inputs === this.#rendered) return
+    this.#rendered = inputs
+
+    const root = this.shadowRoot ?? this.attachShadow({ mode: 'open' })
+    root.replaceChildren()
+    if (this.#behavior === 'connecting') return
+
+    const img = document.createElement('img')
+    img.style.cssText = 'width:100%;height:100%;object-fit:cover;display:block'
+    img.alt = ''
+    root.appendChild(img)
+
+    if (this.#behavior === 'error') {
+      // Announce the watch first and break the image a tick later: the card
+      // attaches its `error` listener in response to this event, and an
+      // <img> that already failed never re-fires it.
+      this.#announce()
+      setTimeout(() => {
+        img.src = BROKEN_FRAME
+      }, BREAK_DELAY_MS)
+      return
+    }
+
+    img.addEventListener('load', () => this.#announce())
+    img.src = this.#src
+  }
+
+  // `load` from an <img> does not bubble, so the host re-dispatches it the way
+  // the real element does — bubbling and composed, so the card's container
+  // listener sees it.
+  #announce() {
+    this.dispatchEvent(new Event('load', { bubbles: true, composed: true }))
+  }
+}
+
+/** Idempotent: the preview module may be evaluated more than once under HMR. */
+export function registerMockCameraStream() {
+  if (!customElements.get('ha-camera-stream')) {
+    customElements.define('ha-camera-stream', MockHaCameraStream)
+  }
+}

--- a/.storybook/mockCameraStreamReady.ts
+++ b/.storybook/mockCameraStreamReady.ts
@@ -1,0 +1,26 @@
+/**
+ * Workshop replacement for `CameraCard/useCameraStreamReady`.
+ *
+ * The real hook bootstraps `<ha-camera-stream>` through the Home Assistant
+ * frontend's card-helper ladder, which can only ever resolve inside HA — in
+ * the workshop it would report `unavailable` for every camera story, pinning
+ * the card to its still-image fallback and making the entire stream UI
+ * unreachable. The story's fixture decides instead, through a story-only
+ * `mock_readiness` attribute, so both branches are reachable: `unavailable`
+ * for the still-image fallback the standalone dev server also takes, and
+ * `ready` (the default) for the stream branch that `mockCameraStream` serves.
+ *
+ * `.storybook/vite.config.ts` substitutes this module for the real one in the
+ * workshop build only; the panel bundle and the unit suite are untouched.
+ */
+import { useEntity } from '~/hooks'
+
+export type CameraStreamReadiness = 'loading' | 'ready' | 'unavailable'
+
+const READINESS: readonly CameraStreamReadiness[] = ['loading', 'ready', 'unavailable']
+
+export function useCameraStreamReady(entityId: string): CameraStreamReadiness {
+  const { entity } = useEntity(entityId)
+  const requested = entity?.attributes.mock_readiness
+  return READINESS.find((known) => known === requested) ?? 'ready'
+}

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -41,6 +41,30 @@ const preview: Preview = {
       // workshop records the violations it finds as issues, and fixing them is
       // deliberately out of scope here (change 0009, PR 2).
       test: 'todo',
+      config: {
+        rules: [
+          {
+            // `region` reports a story-isolation artifact, not a card defect: a
+            // story renders a bare card with no surrounding landmark, while the
+            // real panel DOES provide one. Measured against the built workshop,
+            // a stock `axe.run(document.body)` flags it on 127 of 165 stories
+            // (301 nodes) — enough to bury the findings that ARE real defects,
+            // `button-name` (critical, 35 stories) and `aria-input-field-name`
+            // (serious, 6 stories), which stay reported and are tracked in
+            // issues #191 and #192.
+            //
+            // addon-a11y disables `region` in its own default rule set for this
+            // exact reason, so today this entry is a no-op for the addon's
+            // runner; it is pinned here so the suppression is explicit and
+            // survives a change to those addon defaults.
+            //
+            // Revisit if full-shell stories are ever added — a story that DOES
+            // render the panel's landmarks could fail this rule meaningfully.
+            id: 'region',
+            enabled: false,
+          },
+        ],
+      },
     },
   },
   globalTypes: {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,12 @@
 import type { Preview } from '@storybook/react-vite'
 import { DEFAULT_THEME_ID, listThemes } from '~/theme/themeRegistry'
 import { withProviders, withServiceCalls, withStoreSeed } from './decorators'
+import { registerMockCameraStream } from './mockCameraStream'
+
+// Custom elements are process-wide, so the stand-in for HA's
+// <ha-camera-stream> is registered once for the whole preview rather than per
+// story. Only camera stories that ask for the stream branch ever render it.
+registerMockCameraStream()
 
 // The same style set the panel injects (src/panel.ts) — imported here directly
 // because the panel entry also registers the custom element and starts the

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -30,6 +30,12 @@ const preview: Preview = {
         order: ['Shell', 'Cards'],
       },
     },
+    a11y: {
+      // Audit every story, but report rather than fail: the first pass of this
+      // workshop records the violations it finds as issues, and fixing them is
+      // deliberately out of scope here (change 0009, PR 2).
+      test: 'todo',
+    },
   },
   globalTypes: {
     theme: {

--- a/.storybook/public/mock-camera-frame.svg
+++ b/.storybook/public/mock-camera-frame.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 180" width="320" height="180">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2b3a4a" />
+      <stop offset="100%" stop-color="#0e1418" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="180" fill="url(#sky)" />
+  <circle cx="252" cy="46" r="20" fill="#f2d492" opacity="0.85" />
+  <path d="M0 132 L96 90 L176 132 Z" fill="#141c24" />
+  <rect x="0" y="132" width="320" height="48" fill="#1b2530" />
+  <rect x="118" y="140" width="84" height="30" rx="4" fill="#26333f" />
+  <text
+    x="160"
+    y="160"
+    font-family="monospace"
+    font-size="12"
+    fill="#8aa0b3"
+    text-anchor="middle"
+  >
+    DRIVEWAY
+  </text>
+</svg>

--- a/.storybook/vite.config.ts
+++ b/.storybook/vite.config.ts
@@ -13,6 +13,24 @@ import { resolve } from 'path'
  * owns is the project's `~/*` path alias.
  */
 export default defineConfig({
+  plugins: [
+    {
+      // `CameraCard` resolves its stream element through the Home Assistant
+      // frontend's card-helper ladder, which can only ever succeed inside HA.
+      // Swapping that one hook for a fixture-driven stub is what makes the
+      // card's stream states reachable in the workshop — see
+      // .storybook/mockCameraStreamReady.ts. Scoped to the importer so nothing
+      // else can pick the stub up, and it applies to the workshop build only.
+      name: 'liebe:mock-camera-stream-readiness',
+      enforce: 'pre',
+      resolveId(source: string, importer: string | undefined) {
+        if (source === './useCameraStreamReady' && importer?.includes('/CameraCard/')) {
+          return resolve(__dirname, 'mockCameraStreamReady.ts')
+        }
+        return null
+      },
+    },
+  ],
   resolve: {
     alias: {
       '~': resolve(__dirname, '../src'),

--- a/.storybook/vite.config.ts
+++ b/.storybook/vite.config.ts
@@ -24,7 +24,12 @@ export default defineConfig({
       name: 'liebe:mock-camera-stream-readiness',
       enforce: 'pre',
       resolveId(source: string, importer: string | undefined) {
-        if (source === './useCameraStreamReady' && importer?.includes('/CameraCard/')) {
+        // Importer ids arrive with the host's separators, so a Windows checkout
+        // yields `...\CameraCard\index.tsx`; normalise before matching so the
+        // scoping stays exactly as tight (only CameraCard importers) on every
+        // platform.
+        const importerPath = importer?.replace(/\\/g, '/')
+        if (source === './useCameraStreamReady' && importerPath?.includes('/CameraCard/')) {
           return resolve(__dirname, 'mockCameraStreamReady.ts')
         }
         return null

--- a/docs/changes/0009-storybook-setup.md
+++ b/docs/changes/0009-storybook-setup.md
@@ -51,9 +51,9 @@ The [storybook spec](../specs/storybook/index.md) owns the workshop's observable
   - [x] Store-seeding + service-call-interception decorators; appearance toolbar; grid-cell decorator
   - [x] Stories: `GridCard` shell (all states) + `LightCard`, `ClimateCard`, `SensorCard`, `BinarySensorCard` (state matrix per spec)
   - [x] Coverage exclusions for stories/fixtures/.storybook; lint/prettier config extended to new files
-- [ ] **PR 2 — Full card coverage**
-  - [ ] Stories for `CoverCard`, `FanCard`, `ButtonCard`, `WeatherCard` (all 4 variants), `CameraCard` (mock stream states), all 5 input helper cards, `TextCard`, `Separator`
-  - [ ] a11y addon enabled globally; audit and record violations as issues (fixes out of scope)
+- [x] **PR 2 — Full card coverage**
+  - [x] Stories for `CoverCard`, `FanCard`, `ButtonCard`, `WeatherCard` (all 4 variants), `CameraCard` (mock stream states), all 5 input helper cards, `TextCard`, `Separator`
+  - [x] a11y addon enabled globally; audit and record violations as issues (fixes out of scope)
 - [ ] **PR 3 — CI + publishing**
   - [ ] `storybook` CI job (build gate) on PRs
   - [ ] Deploy workflow publishes `/storybook/` to GitHub Pages alongside the panel; verify published URL

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,8 @@
       "devDependencies": {
         "@eslint/js": "^9.30.0",
         "@playwright/test": "^1.57.0",
-        "@storybook/react-vite": "10.5.4",
+        "@storybook/addon-a11y": "^10.5.4",
+        "@storybook/react-vite": "^10.5.4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
         "@testing-library/user-event": "^14.6.1",
@@ -51,12 +52,12 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.0.1",
-        "eslint-plugin-storybook": "10.5.4",
+        "eslint-plugin-storybook": "^10.5.4",
         "husky": "^9.1.7",
         "jsdom": "^27.3.0",
         "lint-staged": "^16.1.2",
         "prettier": "^3.6.2",
-        "storybook": "10.5.4",
+        "storybook": "^10.5.4",
         "typescript": "^5.9.3",
         "vite": "^7.2.7",
         "vite-tsconfig-paths": "^6.0.1",
@@ -4552,6 +4553,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@storybook/addon-a11y": {
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.5.4.tgz",
+      "integrity": "sha512-UWdZtB7Dh1GjqxTPOrisUNDhDGF5pKGzZdzW9DSSHMBcAOx2dsTmXGzLSFprAz4LTT0OHCtKhxNqKK0JZJ0Y8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "axe-core": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.5.4"
+      }
+    },
     "node_modules/@storybook/builder-vite": {
       "version": "10.5.4",
       "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.5.4.tgz",
@@ -6374,6 +6393,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/babel-dead-code-elimination": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@eslint/js": "^9.30.0",
     "@playwright/test": "^1.57.0",
+    "@storybook/addon-a11y": "^10.5.4",
     "@storybook/react-vite": "^10.5.4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",

--- a/src/components/ButtonCard.stories.tsx
+++ b/src/components/ButtonCard.stories.tsx
@@ -1,0 +1,106 @@
+import type { ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { ButtonCard } from './ButtonCard'
+import {
+  asUnavailable,
+  createInputBooleanEntity,
+  createLightEntity,
+  createSwitchEntity,
+} from '~/test/fixtures'
+import { gridCellArgTypes, withGridCell, type GridCellArgs } from '../../.storybook/decorators'
+
+const entityId = 'switch.coffee_machine'
+
+type ButtonCardStoryProps = ComponentProps<typeof ButtonCard> & GridCellArgs
+
+const meta: Meta<ButtonCardStoryProps> = {
+  title: 'Cards/ButtonCard',
+  component: ButtonCard,
+  decorators: [withGridCell],
+  argTypes: {
+    ...gridCellArgTypes,
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium', 'large'] },
+  },
+  args: {
+    entityId,
+    size: 'medium',
+    gridWidth: 2,
+    gridHeight: 2,
+  },
+  parameters: {
+    liebe: { entities: [createSwitchEntity()] },
+  },
+}
+
+export default meta
+type Story = StoryObj<ButtonCardStoryProps>
+
+/** Resting state. Clicking the card calls `homeassistant.toggle`. */
+export const Off: Story = {
+  parameters: { liebe: { entities: [createSwitchEntity({ state: 'off' })] } },
+}
+
+/** Active state — amber surface, amber title, and the state pill. */
+export const On: Story = {
+  parameters: { liebe: { entities: [createSwitchEntity({ state: 'on' })] } },
+}
+
+/**
+ * The card is the registry entry for `switch`, but it renders any on/off
+ * entity: the icon is picked from the entity id's domain.
+ */
+export const LightDomainIcon: Story = {
+  args: { entityId: 'light.living_room' },
+  parameters: { liebe: { entities: [createLightEntity({ state: 'on' })] } },
+}
+
+/** An `input_boolean` gets the check icon from the same domain switch. */
+export const InputBooleanDomainIcon: Story = {
+  args: { entityId: 'input_boolean.guest_mode' },
+  parameters: { liebe: { entities: [createInputBooleanEntity({ state: 'on' })] } },
+}
+
+/** Unavailable entities render the dimmed shell and ignore clicks. */
+export const Unavailable: Story = {
+  parameters: { liebe: { entities: [asUnavailable(createSwitchEntity())] } },
+}
+
+/** First load: the store is still filling, so the card shows its skeleton. */
+export const Loading: Story = {
+  parameters: { liebe: { entities: [], initialLoading: true } },
+}
+
+/**
+ * The card's reachable error state: every service call fails, so clicking the
+ * card surfaces `ERROR`. `HassService` retries three times with 1s/2s/4s
+ * backoff, so the error appears a few seconds after the click.
+ */
+export const ServiceCallFailure: Story = {
+  parameters: {
+    liebe: {
+      entities: [createSwitchEntity({ state: 'off' })],
+      serviceCall: 'error',
+      serviceCallError: 'homeassistant.toggle is not available',
+    },
+  },
+}
+
+/** Connection lost — the card falls back to the disconnected error display. */
+export const Disconnected: Story = {
+  parameters: { liebe: { entities: [createSwitchEntity()], connected: false } },
+}
+
+/**
+ * An entity id that is not in the store. `useEntity` cannot tell "not loaded
+ * yet" from "does not exist", so the card holds its skeleton indefinitely
+ * rather than reporting the entity as missing.
+ */
+export const UnknownEntity: Story = {
+  parameters: { liebe: { entities: [] } },
+}
+
+/** Edit mode exposes the delete affordance. */
+export const EditMode: Story = {
+  args: { onDelete: () => {} },
+  parameters: { liebe: { entities: [createSwitchEntity({ state: 'on' })], mode: 'edit' } },
+}

--- a/src/components/CameraCard/CameraCard.stories.tsx
+++ b/src/components/CameraCard/CameraCard.stories.tsx
@@ -1,0 +1,172 @@
+import type { ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { CameraCard } from './index'
+import { asUnavailable, createCameraEntity } from '~/test/fixtures'
+import type { GridItem } from '~/store/types'
+import { gridCellArgTypes, withGridCell, type GridCellArgs } from '../../../.storybook/decorators'
+
+const entityId = 'camera.driveway'
+
+/**
+ * A stand-in camera frame.
+ *
+ * The workshop is not an HA frontend, so `ensureHaElement` can never define
+ * `<ha-camera-stream>` — every camera story therefore renders the card's
+ * still-image fallback, which is exactly the path a standalone dev server
+ * takes. An inline data URI keeps that path network-free: the real
+ * `/api/camera_proxy/...` URL would 404 and collapse straight to the
+ * "no image" placeholder (see the `NoSnapshot` story for that state).
+ */
+const MOCK_FRAME =
+  'data:image/svg+xml;utf8,' +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 180">
+       <defs>
+         <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+           <stop offset="0%" stop-color="#2b3a4a"/>
+           <stop offset="100%" stop-color="#0e1418"/>
+         </linearGradient>
+       </defs>
+       <rect width="320" height="180" fill="url(#g)"/>
+       <rect x="0" y="128" width="320" height="52" fill="#1b2530"/>
+       <circle cx="248" cy="52" r="22" fill="#f2d492" opacity="0.85"/>
+       <path d="M0 128 L96 92 L168 128 Z" fill="#141c24"/>
+     </svg>`
+  )
+
+function withSnapshot(state: string) {
+  return createCameraEntity({ state, attributes: { entity_picture: MOCK_FRAME } })
+}
+
+/** A grid item so the card's configuration surface (fit, matting) is reachable. */
+function cameraItem(config: GridItem['config'] = {}): GridItem {
+  return {
+    id: 'story-camera',
+    entityId,
+    type: 'entity',
+    x: 0,
+    y: 0,
+    width: CameraCard.defaultDimensions.width,
+    height: CameraCard.defaultDimensions.height,
+    config,
+  }
+}
+
+type CameraCardStoryProps = ComponentProps<typeof CameraCard> & GridCellArgs
+
+const meta: Meta<CameraCardStoryProps> = {
+  title: 'Cards/CameraCard',
+  component: CameraCard,
+  decorators: [withGridCell],
+  argTypes: {
+    ...gridCellArgTypes,
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium', 'large'] },
+  },
+  args: {
+    entityId,
+    size: 'medium',
+    gridWidth: 4,
+    gridHeight: 3,
+  },
+  parameters: {
+    liebe: { entities: [withSnapshot('idle')] },
+  },
+}
+
+export default meta
+type Story = StoryObj<CameraCardStoryProps>
+
+/**
+ * Resting state: the camera is idle, so the pill reads `IDLE` over the latest
+ * snapshot. A camera has no on/off pair — idle and streaming are its
+ * equivalent representative states.
+ */
+export const Idle: Story = {
+  parameters: { liebe: { entities: [withSnapshot('idle')] } },
+}
+
+/** The active state: a streaming camera tints the shell blue. */
+export const Streaming: Story = {
+  parameters: { liebe: { entities: [withSnapshot('streaming')] } },
+}
+
+/** `recording` gets its own pill, ranked above streaming. */
+export const Recording: Story = {
+  parameters: { liebe: { entities: [withSnapshot('recording')] } },
+}
+
+/**
+ * No snapshot to fall back on: without `entity_picture` (or when the request
+ * fails) the fallback shows its labelled placeholder icon instead of a broken
+ * image.
+ */
+export const NoSnapshot: Story = {
+  parameters: {
+    liebe: {
+      entities: [createCameraEntity({ state: 'idle', attributes: { entity_picture: undefined } })],
+    },
+  },
+}
+
+/**
+ * A camera without `SUPPORT_STREAM` never renders a stream surface at all —
+ * the card falls back to its icon-and-pill layout.
+ */
+export const WithoutStreamSupport: Story = {
+  args: { gridHeight: 2 },
+  parameters: {
+    liebe: {
+      entities: [createCameraEntity({ state: 'idle', attributes: { supported_features: 0 } })],
+    },
+  },
+}
+
+/** `fit: 'contain'` letterboxes the frame instead of cropping it. */
+export const ContainFit: Story = {
+  args: { item: cameraItem({ fit: 'contain' }) },
+  parameters: { liebe: { entities: [withSnapshot('streaming')] } },
+}
+
+/** `matting: 'none'` drops the card padding so the frame is edge to edge. */
+export const NoMatting: Story = {
+  args: { item: cameraItem({ matting: 'none' }) },
+  parameters: { liebe: { entities: [withSnapshot('streaming')] } },
+}
+
+/** An unavailable camera keeps the last frame but reports `UNAVAILABLE`. */
+export const Unavailable: Story = {
+  parameters: { liebe: { entities: [asUnavailable(withSnapshot('idle'))] } },
+}
+
+export const Loading: Story = {
+  args: { gridHeight: 2 },
+  parameters: { liebe: { entities: [], initialLoading: true } },
+}
+
+/**
+ * The card reaches no service-call error (it calls no services), so its error
+ * story is the disconnected state it reaches through `useEntity`.
+ */
+export const Disconnected: Story = {
+  args: { gridHeight: 2 },
+  parameters: { liebe: { entities: [withSnapshot('idle')], connected: false } },
+}
+
+/**
+ * An entity id that is not in the store. `useEntity` cannot tell "not loaded
+ * yet" from "does not exist", so the card holds its skeleton indefinitely
+ * rather than reporting the entity as missing.
+ */
+export const UnknownEntity: Story = {
+  args: { gridHeight: 2 },
+  parameters: { liebe: { entities: [] } },
+}
+
+/**
+ * Edit mode makes the stream surface inert (no fullscreen toggle) and exposes
+ * the configure and delete affordances.
+ */
+export const EditMode: Story = {
+  args: { onDelete: () => {}, item: cameraItem() },
+  parameters: { liebe: { entities: [withSnapshot('idle')], mode: 'edit' } },
+}

--- a/src/components/CameraCard/CameraCard.stories.tsx
+++ b/src/components/CameraCard/CameraCard.stories.tsx
@@ -197,7 +197,7 @@ export const Disconnected: Story = {
  * yet" from "does not exist", so the card holds its skeleton indefinitely
  * rather than reporting the entity as missing.
  */
-export const MissingEntity: Story = {
+export const UnknownEntity: Story = {
   args: { gridHeight: 2 },
   parameters: { liebe: { entities: [] } },
 }

--- a/src/components/CameraCard/CameraCard.stories.tsx
+++ b/src/components/CameraCard/CameraCard.stories.tsx
@@ -197,7 +197,7 @@ export const Disconnected: Story = {
  * yet" from "does not exist", so the card holds its skeleton indefinitely
  * rather than reporting the entity as missing.
  */
-export const UnknownEntity: Story = {
+export const MissingEntity: Story = {
   args: { gridHeight: 2 },
   parameters: { liebe: { entities: [] } },
 }

--- a/src/components/CameraCard/CameraCard.stories.tsx
+++ b/src/components/CameraCard/CameraCard.stories.tsx
@@ -1,41 +1,40 @@
 import type { ComponentProps } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { CameraCard } from './index'
-import { asUnavailable, createCameraEntity } from '~/test/fixtures'
+import { asUnavailable, createCameraEntity, type EntityOverrides } from '~/test/fixtures'
 import type { GridItem } from '~/store/types'
 import { gridCellArgTypes, withGridCell, type GridCellArgs } from '../../../.storybook/decorators'
+import { MOCK_CAMERA_FRAME } from '../../../.storybook/mockCameraStream'
 
 const entityId = 'camera.driveway'
 
 /**
- * A stand-in camera frame.
+ * Camera fixture wired to the workshop's stream mocks.
  *
- * The workshop is not an HA frontend, so `ensureHaElement` can never define
- * `<ha-camera-stream>` — every camera story therefore renders the card's
- * still-image fallback, which is exactly the path a standalone dev server
- * takes. An inline data URI keeps that path network-free: the real
- * `/api/camera_proxy/...` URL would 404 and collapse straight to the
- * "no image" placeholder (see the `NoSnapshot` story for that state).
+ * Two story-only attributes drive them (see `.storybook/mockCameraStream.ts`
+ * and `.storybook/mockCameraStreamReady.ts`): `mock_readiness` decides whether
+ * the card renders the stream element or its still-image fallback, and
+ * `mock_stream` decides how that element behaves. Everything else — the status
+ * machine, the pill, the controls — is the card's real code.
  */
-const MOCK_FRAME =
-  'data:image/svg+xml;utf8,' +
-  encodeURIComponent(
-    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 180">
-       <defs>
-         <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
-           <stop offset="0%" stop-color="#2b3a4a"/>
-           <stop offset="100%" stop-color="#0e1418"/>
-         </linearGradient>
-       </defs>
-       <rect width="320" height="180" fill="url(#g)"/>
-       <rect x="0" y="128" width="320" height="52" fill="#1b2530"/>
-       <circle cx="248" cy="52" r="22" fill="#f2d492" opacity="0.85"/>
-       <path d="M0 128 L96 92 L168 128 Z" fill="#141c24"/>
-     </svg>`
-  )
-
-function withSnapshot(state: string) {
-  return createCameraEntity({ state, attributes: { entity_picture: MOCK_FRAME } })
+function camera(
+  state: string,
+  {
+    stream = 'stream',
+    readiness = 'ready',
+    ...overrides
+  }: EntityOverrides & { stream?: 'stream' | 'connecting' | 'error'; readiness?: string } = {}
+) {
+  return createCameraEntity({
+    state,
+    ...overrides,
+    attributes: {
+      entity_picture: MOCK_CAMERA_FRAME,
+      mock_stream: stream,
+      mock_readiness: readiness,
+      ...overrides.attributes,
+    },
+  })
 }
 
 /** A grid item so the card's configuration surface (fit, matting) is reachable. */
@@ -69,41 +68,81 @@ const meta: Meta<CameraCardStoryProps> = {
     gridHeight: 3,
   },
   parameters: {
-    liebe: { entities: [withSnapshot('idle')] },
+    liebe: { entities: [camera('idle')] },
   },
 }
 
 export default meta
 type Story = StoryObj<CameraCardStoryProps>
 
+/* ------------------------------------------------------------------ *
+ * Stream states
+ * ------------------------------------------------------------------ */
+
 /**
- * Resting state: the camera is idle, so the pill reads `IDLE` over the latest
- * snapshot. A camera has no on/off pair — idle and streaming are its
- * equivalent representative states.
+ * The active state: frames are flowing, so the pill reads `STREAMING` and the
+ * mute and fullscreen controls appear over the frame. A camera has no on/off
+ * pair — a live stream and a resting camera showing only its last snapshot
+ * (`StillImageFallback` below) are its representative states.
+ *
+ * Note that a live stream outranks the entity's own `idle` state in the pill:
+ * `deriveCameraStatus` reports what the surface is actually doing.
  */
-export const Idle: Story = {
-  parameters: { liebe: { entities: [withSnapshot('idle')] } },
-}
-
-/** The active state: a streaming camera tints the shell blue. */
 export const Streaming: Story = {
-  parameters: { liebe: { entities: [withSnapshot('streaming')] } },
-}
-
-/** `recording` gets its own pill, ranked above streaming. */
-export const Recording: Story = {
-  parameters: { liebe: { entities: [withSnapshot('recording')] } },
+  parameters: { liebe: { entities: [camera('idle')] } },
 }
 
 /**
- * No snapshot to fall back on: without `entity_picture` (or when the request
- * fails) the fallback shows its labelled placeholder icon instead of a broken
+ * `recording` gets its own pill, ranked above streaming — as does an entity
+ * reporting `streaming` while frames are flowing, which resolves to the same
+ * pill.
+ */
+export const Recording: Story = {
+  parameters: { liebe: { entities: [camera('recording')] } },
+}
+
+/**
+ * The stream element is mounted but has produced no frame yet: spinner over
+ * the surface and a `CONNECTING` pill. Left alone it eventually expires into
+ * the failure below — the card allows 20s of visible time before giving up.
+ */
+export const Connecting: Story = {
+  parameters: { liebe: { entities: [camera('streaming', { stream: 'connecting' })] } },
+}
+
+/**
+ * The stream fails to load, so the card replaces the surface with the error
+ * text and a Retry button (which remounts the element — and fails again here).
+ */
+export const StreamError: Story = {
+  parameters: { liebe: { entities: [camera('streaming', { stream: 'error' })] } },
+}
+
+/* ------------------------------------------------------------------ *
+ * Fallback and entity states
+ * ------------------------------------------------------------------ */
+
+/**
+ * The resting state: when `<ha-camera-stream>` cannot be bootstrapped — a
+ * standalone dev server, or an HA frontend that never defines the element —
+ * the card falls back to the periodically refreshed snapshot, and the pill
+ * reports the camera's own `IDLE` state.
+ */
+export const StillImageFallback: Story = {
+  parameters: { liebe: { entities: [camera('idle', { readiness: 'unavailable' })] } },
+}
+
+/**
+ * The same fallback without a snapshot to show: no `entity_picture` (or a
+ * failed request) renders the labelled placeholder icon rather than a broken
  * image.
  */
-export const NoSnapshot: Story = {
+export const StillImageWithoutSnapshot: Story = {
   parameters: {
     liebe: {
-      entities: [createCameraEntity({ state: 'idle', attributes: { entity_picture: undefined } })],
+      entities: [
+        camera('idle', { readiness: 'unavailable', attributes: { entity_picture: undefined } }),
+      ],
     },
   },
 }
@@ -115,27 +154,28 @@ export const NoSnapshot: Story = {
 export const WithoutStreamSupport: Story = {
   args: { gridHeight: 2 },
   parameters: {
-    liebe: {
-      entities: [createCameraEntity({ state: 'idle', attributes: { supported_features: 0 } })],
-    },
+    liebe: { entities: [camera('idle', { attributes: { supported_features: 0 } })] },
   },
 }
 
 /** `fit: 'contain'` letterboxes the frame instead of cropping it. */
 export const ContainFit: Story = {
   args: { item: cameraItem({ fit: 'contain' }) },
-  parameters: { liebe: { entities: [withSnapshot('streaming')] } },
+  parameters: { liebe: { entities: [camera('streaming')] } },
 }
 
 /** `matting: 'none'` drops the card padding so the frame is edge to edge. */
 export const NoMatting: Story = {
   args: { item: cameraItem({ matting: 'none' }) },
-  parameters: { liebe: { entities: [withSnapshot('streaming')] } },
+  parameters: { liebe: { entities: [camera('streaming')] } },
 }
 
-/** An unavailable camera keeps the last frame but reports `UNAVAILABLE`. */
+/**
+ * An unavailable entity reports `UNAVAILABLE` immediately rather than tearing
+ * the stream down — a short HA reconnect blip usually plays straight through.
+ */
 export const Unavailable: Story = {
-  parameters: { liebe: { entities: [asUnavailable(withSnapshot('idle'))] } },
+  parameters: { liebe: { entities: [asUnavailable(camera('idle'))] } },
 }
 
 export const Loading: Story = {
@@ -144,12 +184,12 @@ export const Loading: Story = {
 }
 
 /**
- * The card reaches no service-call error (it calls no services), so its error
- * story is the disconnected state it reaches through `useEntity`.
+ * The card calls no services, so its error story other than the stream failure
+ * above is the disconnected state it reaches through `useEntity`.
  */
 export const Disconnected: Story = {
   args: { gridHeight: 2 },
-  parameters: { liebe: { entities: [withSnapshot('idle')], connected: false } },
+  parameters: { liebe: { entities: [camera('idle')], connected: false } },
 }
 
 /**
@@ -168,5 +208,5 @@ export const UnknownEntity: Story = {
  */
 export const EditMode: Story = {
   args: { onDelete: () => {}, item: cameraItem() },
-  parameters: { liebe: { entities: [withSnapshot('idle')], mode: 'edit' } },
+  parameters: { liebe: { entities: [camera('idle')], mode: 'edit' } },
 }

--- a/src/components/CoverCard.stories.tsx
+++ b/src/components/CoverCard.stories.tsx
@@ -1,0 +1,142 @@
+import type { ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { CoverCard } from './CoverCard'
+import { asUnavailable, createCoverEntity } from '~/test/fixtures'
+import { gridCellArgTypes, withGridCell, type GridCellArgs } from '../../.storybook/decorators'
+
+const entityId = 'cover.living_room_blinds'
+
+type CoverCardStoryProps = ComponentProps<typeof CoverCard> & GridCellArgs
+
+const meta: Meta<CoverCardStoryProps> = {
+  title: 'Cards/CoverCard',
+  component: CoverCard,
+  decorators: [withGridCell],
+  argTypes: {
+    ...gridCellArgTypes,
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium', 'large'] },
+  },
+  args: {
+    entityId,
+    size: 'medium',
+    gridWidth: 3,
+    gridHeight: 4,
+  },
+  parameters: {
+    liebe: { entities: [createCoverEntity()] },
+  },
+}
+
+export default meta
+type Story = StoryObj<CoverCardStoryProps>
+
+/**
+ * Resting state: fully closed. A cover reports `open`/`closed` rather than
+ * `on`/`off`, so this is the domain's inactive equivalent — the open button is
+ * live and the close button is disabled.
+ */
+export const Closed: Story = {
+  parameters: {
+    liebe: {
+      entities: [
+        createCoverEntity({
+          state: 'closed',
+          attributes: { current_position: 0, current_tilt_position: 0 },
+        }),
+      ],
+    },
+  },
+}
+
+/** Fully open — the active state, with both position and tilt sliders live. */
+export const Open: Story = {
+  parameters: {
+    liebe: {
+      entities: [
+        createCoverEntity({
+          state: 'open',
+          attributes: { current_position: 100, current_tilt_position: 100 },
+        }),
+      ],
+    },
+  },
+}
+
+/** A partial position reports `70% OPEN` instead of the plain state. */
+export const PartiallyOpen: Story = {
+  parameters: { liebe: { entities: [createCoverEntity()] } },
+}
+
+/** While moving, the status pill tracks the transition and Stop becomes live. */
+export const Opening: Story = {
+  parameters: {
+    liebe: {
+      entities: [createCoverEntity({ state: 'opening', attributes: { current_position: 35 } })],
+    },
+  },
+}
+
+/**
+ * A cover that only supports open/close/stop (no `SET_POSITION`, no tilt) —
+ * the sliders and tilt block drop out, leaving just the three buttons.
+ */
+export const ButtonsOnly: Story = {
+  args: { gridHeight: 2 },
+  parameters: {
+    liebe: {
+      entities: [
+        createCoverEntity({
+          state: 'closed',
+          // OPEN | CLOSE | STOP
+          attributes: { supported_features: 11, current_position: 0 },
+        }),
+      ],
+    },
+  },
+}
+
+export const Unavailable: Story = {
+  args: { gridHeight: 2 },
+  parameters: { liebe: { entities: [asUnavailable(createCoverEntity())] } },
+}
+
+export const Loading: Story = {
+  args: { gridHeight: 3 },
+  parameters: { liebe: { entities: [], initialLoading: true } },
+}
+
+/**
+ * Every service call fails, so pressing open/close surfaces the card's `ERROR`
+ * status. `HassService` retries three times with 1s/2s/4s backoff before the
+ * error lands.
+ */
+export const ServiceCallFailure: Story = {
+  parameters: {
+    liebe: {
+      entities: [createCoverEntity({ state: 'closed', attributes: { current_position: 0 } })],
+      serviceCall: 'error',
+      serviceCallError: 'cover.open_cover is not available',
+    },
+  },
+}
+
+export const Disconnected: Story = {
+  args: { gridHeight: 2 },
+  parameters: { liebe: { entities: [createCoverEntity()], connected: false } },
+}
+
+/**
+ * An entity id that is not in the store. `useEntity` cannot tell "not loaded
+ * yet" from "does not exist", so the card holds its skeleton indefinitely
+ * rather than reporting the entity as missing.
+ */
+export const UnknownEntity: Story = {
+  args: { gridHeight: 3 },
+  parameters: { liebe: { entities: [] } },
+}
+
+/** Edit mode hides the buttons and sliders and exposes the delete affordance. */
+export const EditMode: Story = {
+  args: { onDelete: () => {}, gridHeight: 2 },
+  parameters: { liebe: { entities: [createCoverEntity()], mode: 'edit' } },
+}

--- a/src/components/FanCard.stories.tsx
+++ b/src/components/FanCard.stories.tsx
@@ -1,0 +1,127 @@
+import type { ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { FanCard } from './FanCard'
+import { asUnavailable, createFanEntity } from '~/test/fixtures'
+import { gridCellArgTypes, withGridCell, type GridCellArgs } from '../../.storybook/decorators'
+
+const entityId = 'fan.bedroom'
+
+type FanCardStoryProps = ComponentProps<typeof FanCard> & GridCellArgs
+
+const meta: Meta<FanCardStoryProps> = {
+  title: 'Cards/FanCard',
+  component: FanCard,
+  decorators: [withGridCell],
+  argTypes: {
+    ...gridCellArgTypes,
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium', 'large'] },
+  },
+  args: {
+    entityId,
+    size: 'medium',
+    gridWidth: 3,
+    gridHeight: 3,
+  },
+  parameters: {
+    liebe: { entities: [createFanEntity()] },
+  },
+}
+
+export default meta
+type Story = StoryObj<FanCardStoryProps>
+
+/** Resting state. Clicking the card turns the fan on at 50%. */
+export const Off: Story = {
+  parameters: {
+    liebe: { entities: [createFanEntity({ state: 'off', attributes: { percentage: 0 } })] },
+  },
+}
+
+/**
+ * Running at 66% — cyan surface, spinning icon, and the four speed buttons
+ * (the fixture supports `SET_SPEED` but not `PRESET_MODE`).
+ */
+export const On: Story = {
+  parameters: { liebe: { entities: [createFanEntity()] } },
+}
+
+/**
+ * A fan that also advertises `PRESET_MODE` swaps the speed buttons for the
+ * preset select — the card prefers presets whenever the fan publishes them.
+ */
+export const WithPresetModes: Story = {
+  parameters: {
+    liebe: {
+      entities: [
+        createFanEntity({
+          // SET_SPEED | PRESET_MODE
+          attributes: { supported_features: 9, preset_mode: 'sleep' },
+        }),
+      ],
+    },
+  },
+}
+
+/** A fan with no speed or preset support at all is a plain on/off tile. */
+export const OnOffOnly: Story = {
+  args: { gridHeight: 2 },
+  parameters: {
+    liebe: {
+      entities: [
+        createFanEntity({
+          attributes: {
+            supported_features: 0,
+            percentage: undefined,
+            preset_mode: undefined,
+            preset_modes: undefined,
+          },
+        }),
+      ],
+    },
+  },
+}
+
+export const Unavailable: Story = {
+  args: { gridHeight: 2 },
+  parameters: { liebe: { entities: [asUnavailable(createFanEntity())] } },
+}
+
+export const Loading: Story = {
+  args: { gridHeight: 2 },
+  parameters: { liebe: { entities: [], initialLoading: true } },
+}
+
+/**
+ * Every service call fails, so toggling the fan surfaces `ERROR`.
+ * `HassService` retries three times with 1s/2s/4s backoff before it lands.
+ */
+export const ServiceCallFailure: Story = {
+  parameters: {
+    liebe: {
+      entities: [createFanEntity({ state: 'off', attributes: { percentage: 0 } })],
+      serviceCall: 'error',
+      serviceCallError: 'fan.turn_on is not available',
+    },
+  },
+}
+
+export const Disconnected: Story = {
+  args: { gridHeight: 2 },
+  parameters: { liebe: { entities: [createFanEntity()], connected: false } },
+}
+
+/**
+ * An entity id that is not in the store. `useEntity` cannot tell "not loaded
+ * yet" from "does not exist", so the card holds its skeleton indefinitely
+ * rather than reporting the entity as missing.
+ */
+export const UnknownEntity: Story = {
+  args: { gridHeight: 2 },
+  parameters: { liebe: { entities: [] } },
+}
+
+/** Edit mode hides the speed controls and exposes the delete affordance. */
+export const EditMode: Story = {
+  args: { onDelete: () => {}, gridHeight: 2 },
+  parameters: { liebe: { entities: [createFanEntity()], mode: 'edit' } },
+}

--- a/src/components/InputBooleanCard.stories.tsx
+++ b/src/components/InputBooleanCard.stories.tsx
@@ -1,0 +1,83 @@
+import type { ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { InputBooleanCard } from './InputBooleanCard'
+import { asUnavailable, createInputBooleanEntity } from '~/test/fixtures'
+import { gridCellArgTypes, withGridCell, type GridCellArgs } from '../../.storybook/decorators'
+
+const entityId = 'input_boolean.guest_mode'
+
+type InputBooleanCardStoryProps = ComponentProps<typeof InputBooleanCard> & GridCellArgs
+
+const meta: Meta<InputBooleanCardStoryProps> = {
+  title: 'Cards/Inputs/InputBooleanCard',
+  component: InputBooleanCard,
+  decorators: [withGridCell],
+  argTypes: {
+    ...gridCellArgTypes,
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium', 'large'] },
+  },
+  args: {
+    entityId,
+    size: 'medium',
+    gridWidth: 2,
+    gridHeight: 2,
+  },
+  parameters: {
+    liebe: { entities: [createInputBooleanEntity()] },
+  },
+}
+
+export default meta
+type Story = StoryObj<InputBooleanCardStoryProps>
+
+/** Resting state. Both the card and the switch call `homeassistant.toggle`. */
+export const Off: Story = {
+  parameters: { liebe: { entities: [createInputBooleanEntity({ state: 'off' })] } },
+}
+
+/** Active state — amber toggle icon and a checked switch. */
+export const On: Story = {
+  parameters: { liebe: { entities: [createInputBooleanEntity({ state: 'on' })] } },
+}
+
+export const Unavailable: Story = {
+  parameters: { liebe: { entities: [asUnavailable(createInputBooleanEntity())] } },
+}
+
+export const Loading: Story = {
+  parameters: { liebe: { entities: [], initialLoading: true } },
+}
+
+/**
+ * Every service call fails, so flipping the switch surfaces the card's error
+ * border. `HassService` retries three times with 1s/2s/4s backoff before the
+ * error lands.
+ */
+export const ServiceCallFailure: Story = {
+  parameters: {
+    liebe: {
+      entities: [createInputBooleanEntity({ state: 'off' })],
+      serviceCall: 'error',
+      serviceCallError: 'homeassistant.toggle is not available',
+    },
+  },
+}
+
+export const Disconnected: Story = {
+  parameters: { liebe: { entities: [createInputBooleanEntity()], connected: false } },
+}
+
+/**
+ * An entity id that is not in the store. `useEntity` cannot tell "not loaded
+ * yet" from "does not exist", so the card holds its skeleton indefinitely
+ * rather than reporting the entity as missing.
+ */
+export const UnknownEntity: Story = {
+  parameters: { liebe: { entities: [] } },
+}
+
+/** Edit mode swaps the switch for a plain ON/OFF status line. */
+export const EditMode: Story = {
+  args: { onDelete: () => {} },
+  parameters: { liebe: { entities: [createInputBooleanEntity({ state: 'on' })], mode: 'edit' } },
+}

--- a/src/components/InputDateTimeCard.stories.tsx
+++ b/src/components/InputDateTimeCard.stories.tsx
@@ -39,7 +39,15 @@ export const DateAndTime: Story = {
   parameters: { liebe: { entities: [createInputDateTimeEntity()] } },
 }
 
-/** `has_time: false` narrows the field to a date picker. */
+/**
+ * `has_time: false` narrows the field to a date picker.
+ *
+ * Known defect this story exposes: HA publishes a date-only state as
+ * `YYYY-MM-DD`, which `new Date(...)` parses as UTC midnight, so the rendered
+ * date is a day early for viewers west of UTC. Fixing it is out of scope for
+ * this change (workshop setup) — the story is here so the fix has somewhere to
+ * be demonstrated.
+ */
 export const DateOnly: Story = {
   parameters: {
     liebe: {

--- a/src/components/InputDateTimeCard.stories.tsx
+++ b/src/components/InputDateTimeCard.stories.tsx
@@ -1,0 +1,119 @@
+import type { ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { InputDateTimeCard } from './InputDateTimeCard'
+import { asUnavailable, createInputDateTimeEntity } from '~/test/fixtures'
+import { gridCellArgTypes, withGridCell, type GridCellArgs } from '../../.storybook/decorators'
+
+const entityId = 'input_datetime.wake_up'
+
+type InputDateTimeCardStoryProps = ComponentProps<typeof InputDateTimeCard> & GridCellArgs
+
+const meta: Meta<InputDateTimeCardStoryProps> = {
+  title: 'Cards/Inputs/InputDateTimeCard',
+  component: InputDateTimeCard,
+  decorators: [withGridCell],
+  argTypes: {
+    ...gridCellArgTypes,
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium', 'large'] },
+  },
+  args: {
+    entityId,
+    size: 'medium',
+    gridWidth: 4,
+    gridHeight: 2,
+  },
+  parameters: {
+    liebe: { entities: [createInputDateTimeEntity()] },
+  },
+}
+
+export default meta
+type Story = StoryObj<InputDateTimeCardStoryProps>
+
+/**
+ * Date and time together — the calendar icon, a localized timestamp, and the
+ * "Date & Time" status. A datetime helper has no on/off pair, so its two
+ * representative states are a set value and an unset one.
+ */
+export const DateAndTime: Story = {
+  parameters: { liebe: { entities: [createInputDateTimeEntity()] } },
+}
+
+/** `has_time: false` narrows the field to a date picker. */
+export const DateOnly: Story = {
+  parameters: {
+    liebe: {
+      entities: [
+        createInputDateTimeEntity({
+          state: '2026-12-24',
+          attributes: { friendly_name: 'Holiday Start', has_time: false },
+        }),
+      ],
+    },
+  },
+}
+
+/**
+ * `has_date: false` swaps the icon for a clock and the field for a time
+ * picker. HA publishes a bare `HH:MM:SS` state here, which is not a parseable
+ * `Date`, so the card falls back to showing it verbatim.
+ */
+export const TimeOnly: Story = {
+  parameters: {
+    liebe: {
+      entities: [
+        createInputDateTimeEntity({
+          state: '06:30:00',
+          attributes: { friendly_name: 'Alarm', has_date: false },
+        }),
+      ],
+    },
+  },
+}
+
+/** An unset helper reports `(not set)` rather than a raw `unknown`. */
+export const NotSet: Story = {
+  parameters: { liebe: { entities: [createInputDateTimeEntity({ state: 'unknown' })] } },
+}
+
+export const Unavailable: Story = {
+  parameters: { liebe: { entities: [asUnavailable(createInputDateTimeEntity())] } },
+}
+
+export const Loading: Story = {
+  parameters: { liebe: { entities: [], initialLoading: true } },
+}
+
+/**
+ * Every service call fails, so committing a new value surfaces the card's
+ * error border. `HassService` retries three times with 1s/2s/4s backoff before
+ * the error lands.
+ */
+export const ServiceCallFailure: Story = {
+  parameters: {
+    liebe: {
+      entities: [createInputDateTimeEntity()],
+      serviceCall: 'error',
+      serviceCallError: 'input_datetime.set_datetime is not available',
+    },
+  },
+}
+
+export const Disconnected: Story = {
+  parameters: { liebe: { entities: [createInputDateTimeEntity()], connected: false } },
+}
+
+/**
+ * An entity id that is not in the store. `useEntity` cannot tell "not loaded
+ * yet" from "does not exist", so the card holds its skeleton indefinitely
+ * rather than reporting the entity as missing.
+ */
+export const UnknownEntity: Story = {
+  parameters: { liebe: { entities: [] } },
+}
+
+/** Edit mode exposes the delete affordance; the value field stays visible. */
+export const EditMode: Story = {
+  args: { onDelete: () => {} },
+  parameters: { liebe: { entities: [createInputDateTimeEntity()], mode: 'edit' } },
+}

--- a/src/components/InputNumberCard.stories.tsx
+++ b/src/components/InputNumberCard.stories.tsx
@@ -1,0 +1,111 @@
+import type { ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { InputNumberCard } from './InputNumberCard'
+import { asUnavailable, createInputNumberEntity } from '~/test/fixtures'
+import { gridCellArgTypes, withGridCell, type GridCellArgs } from '../../.storybook/decorators'
+
+const entityId = 'input_number.target_humidity'
+
+type InputNumberCardStoryProps = ComponentProps<typeof InputNumberCard> & GridCellArgs
+
+const meta: Meta<InputNumberCardStoryProps> = {
+  title: 'Cards/Inputs/InputNumberCard',
+  component: InputNumberCard,
+  decorators: [withGridCell],
+  argTypes: {
+    ...gridCellArgTypes,
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium', 'large'] },
+  },
+  args: {
+    entityId,
+    size: 'medium',
+    gridWidth: 3,
+    gridHeight: 2,
+  },
+  parameters: {
+    liebe: { entities: [createInputNumberEntity()] },
+  },
+}
+
+export default meta
+type Story = StoryObj<InputNumberCardStoryProps>
+
+/**
+ * A typical value mid-range. A number helper has no on/off pair, so its two
+ * representative states are a typical value and one pinned at a bound.
+ */
+export const TypicalValue: Story = {
+  parameters: { liebe: { entities: [createInputNumberEntity()] } },
+}
+
+/** At the maximum, the increment button disables itself. */
+export const AtMaximum: Story = {
+  parameters: { liebe: { entities: [createInputNumberEntity({ state: '100' })] } },
+}
+
+/** At the minimum, the decrement button disables itself. */
+export const AtMinimum: Story = {
+  parameters: { liebe: { entities: [createInputNumberEntity({ state: '0' })] } },
+}
+
+/** A sub-1 step switches the display to one decimal place. */
+export const FractionalStep: Story = {
+  parameters: {
+    liebe: {
+      entities: [
+        createInputNumberEntity({
+          state: '2.5',
+          attributes: {
+            friendly_name: 'Sleep Timer',
+            min: 0,
+            max: 12,
+            step: 0.5,
+            unit_of_measurement: 'h',
+          },
+        }),
+      ],
+    },
+  },
+}
+
+export const Unavailable: Story = {
+  parameters: { liebe: { entities: [asUnavailable(createInputNumberEntity())] } },
+}
+
+export const Loading: Story = {
+  parameters: { liebe: { entities: [], initialLoading: true } },
+}
+
+/**
+ * Every service call fails, so incrementing the value surfaces the card's
+ * error border. `HassService` retries three times with 1s/2s/4s backoff before
+ * the error lands.
+ */
+export const ServiceCallFailure: Story = {
+  parameters: {
+    liebe: {
+      entities: [createInputNumberEntity()],
+      serviceCall: 'error',
+      serviceCallError: 'input_number.set_value is not available',
+    },
+  },
+}
+
+export const Disconnected: Story = {
+  parameters: { liebe: { entities: [createInputNumberEntity()], connected: false } },
+}
+
+/**
+ * An entity id that is not in the store. `useEntity` cannot tell "not loaded
+ * yet" from "does not exist", so the card holds its skeleton indefinitely
+ * rather than reporting the entity as missing.
+ */
+export const UnknownEntity: Story = {
+  parameters: { liebe: { entities: [] } },
+}
+
+/** Edit mode exposes the delete affordance; the stepper stays visible. */
+export const EditMode: Story = {
+  args: { onDelete: () => {} },
+  parameters: { liebe: { entities: [createInputNumberEntity()], mode: 'edit' } },
+}

--- a/src/components/InputSelectCard.stories.tsx
+++ b/src/components/InputSelectCard.stories.tsx
@@ -1,0 +1,95 @@
+import type { ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { InputSelectCard } from './InputSelectCard'
+import { asUnavailable, createInputSelectEntity } from '~/test/fixtures'
+import { gridCellArgTypes, withGridCell, type GridCellArgs } from '../../.storybook/decorators'
+
+const entityId = 'input_select.house_mode'
+
+type InputSelectCardStoryProps = ComponentProps<typeof InputSelectCard> & GridCellArgs
+
+const meta: Meta<InputSelectCardStoryProps> = {
+  title: 'Cards/Inputs/InputSelectCard',
+  component: InputSelectCard,
+  decorators: [withGridCell],
+  argTypes: {
+    ...gridCellArgTypes,
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium', 'large'] },
+  },
+  args: {
+    entityId,
+    size: 'medium',
+    gridWidth: 3,
+    gridHeight: 2,
+  },
+  parameters: {
+    liebe: { entities: [createInputSelectEntity()] },
+  },
+}
+
+export default meta
+type Story = StoryObj<InputSelectCardStoryProps>
+
+/**
+ * The default option. A select helper has no on/off pair, so its two
+ * representative states are two different options.
+ */
+export const HomeSelected: Story = {
+  parameters: { liebe: { entities: [createInputSelectEntity({ state: 'Home' })] } },
+}
+
+/** A different option selected — the trigger reflects the entity state. */
+export const VacationSelected: Story = {
+  parameters: { liebe: { entities: [createInputSelectEntity({ state: 'Vacation' })] } },
+}
+
+/** With no options published, the select is disabled and the count is hidden. */
+export const WithoutOptions: Story = {
+  parameters: {
+    liebe: {
+      entities: [createInputSelectEntity({ state: 'Home', attributes: { options: [] } })],
+    },
+  },
+}
+
+export const Unavailable: Story = {
+  parameters: { liebe: { entities: [asUnavailable(createInputSelectEntity())] } },
+}
+
+export const Loading: Story = {
+  parameters: { liebe: { entities: [], initialLoading: true } },
+}
+
+/**
+ * Every service call fails, so picking an option surfaces the card's error
+ * border. `HassService` retries three times with 1s/2s/4s backoff before the
+ * error lands.
+ */
+export const ServiceCallFailure: Story = {
+  parameters: {
+    liebe: {
+      entities: [createInputSelectEntity()],
+      serviceCall: 'error',
+      serviceCallError: 'input_select.select_option is not available',
+    },
+  },
+}
+
+export const Disconnected: Story = {
+  parameters: { liebe: { entities: [createInputSelectEntity()], connected: false } },
+}
+
+/**
+ * An entity id that is not in the store. `useEntity` cannot tell "not loaded
+ * yet" from "does not exist", so the card holds its skeleton indefinitely
+ * rather than reporting the entity as missing.
+ */
+export const UnknownEntity: Story = {
+  parameters: { liebe: { entities: [] } },
+}
+
+/** Edit mode exposes the delete affordance; the select stays visible. */
+export const EditMode: Story = {
+  args: { onDelete: () => {} },
+  parameters: { liebe: { entities: [createInputSelectEntity()], mode: 'edit' } },
+}

--- a/src/components/InputTextCard.stories.tsx
+++ b/src/components/InputTextCard.stories.tsx
@@ -1,0 +1,100 @@
+import type { ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { InputTextCard } from './InputTextCard'
+import { asUnavailable, createInputTextEntity } from '~/test/fixtures'
+import { gridCellArgTypes, withGridCell, type GridCellArgs } from '../../.storybook/decorators'
+
+const entityId = 'input_text.doorbell_message'
+
+type InputTextCardStoryProps = ComponentProps<typeof InputTextCard> & GridCellArgs
+
+const meta: Meta<InputTextCardStoryProps> = {
+  title: 'Cards/Inputs/InputTextCard',
+  component: InputTextCard,
+  decorators: [withGridCell],
+  argTypes: {
+    ...gridCellArgTypes,
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium', 'large'] },
+  },
+  args: {
+    entityId,
+    size: 'medium',
+    gridWidth: 4,
+    gridHeight: 2,
+  },
+  parameters: {
+    liebe: { entities: [createInputTextEntity()] },
+  },
+}
+
+export default meta
+type Story = StoryObj<InputTextCardStoryProps>
+
+/**
+ * A value set. A text helper has no on/off pair, so its two representative
+ * states are a populated value and an empty one.
+ */
+export const WithValue: Story = {
+  parameters: { liebe: { entities: [createInputTextEntity()] } },
+}
+
+/** An empty value renders the `(empty)` placeholder rather than a blank box. */
+export const Empty: Story = {
+  parameters: { liebe: { entities: [createInputTextEntity({ state: '' })] } },
+}
+
+/** `mode: 'password'` masks the stored value until the field is opened. */
+export const PasswordMode: Story = {
+  parameters: {
+    liebe: {
+      entities: [
+        createInputTextEntity({
+          state: 'hunter2',
+          attributes: { friendly_name: 'Alarm Code', mode: 'password' },
+        }),
+      ],
+    },
+  },
+}
+
+export const Unavailable: Story = {
+  parameters: { liebe: { entities: [asUnavailable(createInputTextEntity())] } },
+}
+
+export const Loading: Story = {
+  parameters: { liebe: { entities: [], initialLoading: true } },
+}
+
+/**
+ * Every service call fails, so submitting an edit surfaces the card's error
+ * border. `HassService` retries three times with 1s/2s/4s backoff before the
+ * error lands.
+ */
+export const ServiceCallFailure: Story = {
+  parameters: {
+    liebe: {
+      entities: [createInputTextEntity()],
+      serviceCall: 'error',
+      serviceCallError: 'input_text.set_value is not available',
+    },
+  },
+}
+
+export const Disconnected: Story = {
+  parameters: { liebe: { entities: [createInputTextEntity()], connected: false } },
+}
+
+/**
+ * An entity id that is not in the store. `useEntity` cannot tell "not loaded
+ * yet" from "does not exist", so the card holds its skeleton indefinitely
+ * rather than reporting the entity as missing.
+ */
+export const UnknownEntity: Story = {
+  parameters: { liebe: { entities: [] } },
+}
+
+/** Edit mode exposes the delete affordance; the value field stays visible. */
+export const EditMode: Story = {
+  args: { onDelete: () => {} },
+  parameters: { liebe: { entities: [createInputTextEntity()], mode: 'edit' } },
+}

--- a/src/components/Separator.stories.tsx
+++ b/src/components/Separator.stories.tsx
@@ -1,0 +1,82 @@
+import type { ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Separator } from './Separator'
+import { gridCellArgTypes, withGridCell, type GridCellArgs } from '../../.storybook/decorators'
+
+type SeparatorStoryProps = ComponentProps<typeof Separator> & GridCellArgs
+
+/**
+ * A non-entity layout part: a titled rule used to group a screen. It has no
+ * entity states, so its matrix is the two orientations, the title/untitled
+ * pair, the colour option, and edit mode (where it becomes selectable).
+ */
+const meta: Meta<SeparatorStoryProps> = {
+  title: 'Cards/Separator',
+  component: Separator,
+  decorators: [withGridCell],
+  argTypes: {
+    ...gridCellArgTypes,
+    orientation: { control: { type: 'inline-radio' }, options: ['horizontal', 'vertical'] },
+    textColor: {
+      control: { type: 'select' },
+      options: ['gray', 'blue', 'green', 'red', 'orange', 'purple'],
+    },
+  },
+  args: {
+    title: 'Downstairs',
+    gridWidth: 4,
+    gridHeight: 1,
+  },
+}
+
+export default meta
+type Story = StoryObj<SeparatorStoryProps>
+
+/** The default: a horizontal rule with the title centered in it. */
+export const Horizontal: Story = {}
+
+/** Without a title the rule is continuous. */
+export const HorizontalWithoutTitle: Story = {
+  args: { title: undefined },
+}
+
+/** Vertical orientation rotates both the rule and its label. */
+export const Vertical: Story = {
+  args: { orientation: 'vertical', gridWidth: 1, gridHeight: 3 },
+}
+
+export const VerticalWithoutTitle: Story = {
+  args: { orientation: 'vertical', title: undefined, gridWidth: 1, gridHeight: 3 },
+}
+
+/** The label colour is an option; the rule itself always uses the gray token. */
+export const ColouredTitle: Story = {
+  args: { textColor: 'blue' },
+}
+
+/**
+ * The separator-specific props win over the generic ones — that is how a
+ * persisted grid item drives it.
+ */
+export const SeparatorPropsWin: Story = {
+  args: {
+    orientation: 'horizontal',
+    textColor: 'gray',
+    separatorOrientation: 'vertical',
+    separatorTextColor: 'orange',
+    gridWidth: 1,
+    gridHeight: 3,
+  },
+}
+
+/** Edit mode makes the whole area clickable so it can be selected. */
+export const EditMode: Story = {
+  args: { onDelete: () => {} },
+  parameters: { liebe: { mode: 'edit' } },
+}
+
+/** Selected in edit mode — the blue selection surface. */
+export const SelectedInEditMode: Story = {
+  args: { isSelected: true, onSelect: () => {} },
+  parameters: { liebe: { mode: 'edit' } },
+}

--- a/src/components/TextCard.stories.tsx
+++ b/src/components/TextCard.stories.tsx
@@ -1,0 +1,109 @@
+import type { ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { TextCard } from './TextCard'
+import { gridCellArgTypes, withGridCell, type GridCellArgs } from '../../.storybook/decorators'
+
+const SAMPLE_MARKDOWN = `# Good morning
+
+The **kitchen** window is still open — close it before you leave.
+
+- Bins go out tonight
+- Guest arriving at *18:00*
+
+\`\`\`
+sensor.front_door
+\`\`\`
+`
+
+type TextCardStoryProps = ComponentProps<typeof TextCard> & GridCellArgs
+
+/**
+ * A non-entity card: it renders markdown from its own config, so it has no
+ * entity states to matrix. Its meaningful states are the display options
+ * (alignment, text size, colour), the empty/placeholder content, and edit mode
+ * — where the card becomes a textarea.
+ */
+const meta: Meta<TextCardStoryProps> = {
+  title: 'Cards/TextCard',
+  component: TextCard,
+  decorators: [withGridCell],
+  argTypes: {
+    ...gridCellArgTypes,
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium', 'large'] },
+    alignment: { control: { type: 'inline-radio' }, options: ['left', 'center', 'right'] },
+    textSize: { control: { type: 'inline-radio' }, options: ['small', 'medium', 'large'] },
+    textColor: {
+      control: { type: 'select' },
+      options: ['default', 'gray', 'blue', 'green', 'red', 'orange', 'purple', 'cyan', 'pink'],
+    },
+  },
+  args: {
+    size: 'medium',
+    gridWidth: 4,
+    gridHeight: 3,
+    content: SAMPLE_MARKDOWN,
+  },
+}
+
+export default meta
+type Story = StoryObj<TextCardStoryProps>
+
+/** Markdown content, left aligned at the default size. */
+export const Default: Story = {}
+
+/** Centered, larger text — the two display options a screen most often uses. */
+export const CenteredLarge: Story = {
+  args: { alignment: 'center', textSize: 'large' },
+}
+
+/** A coloured heading, driven purely by the `textColor` option. */
+export const Coloured: Story = {
+  args: { alignment: 'right', textColor: 'cyan' },
+}
+
+/**
+ * `config` wins over the equivalent props, which is how a persisted dashboard
+ * drives the card.
+ */
+export const FromConfig: Story = {
+  args: {
+    content: 'ignored — config wins',
+    config: {
+      content: '## Utility room\n\nWashing machine finishes in **12 minutes**.',
+      alignment: 'center',
+      textSize: 'large',
+      textColor: 'blue',
+    },
+  },
+}
+
+/**
+ * An unsupported option value (from hand-edited or older YAML) falls back to
+ * the default rather than being applied verbatim.
+ */
+export const InvalidOptionsFallBack: Story = {
+  args: {
+    config: {
+      content: 'Unknown alignment, size, and colour all fall back to the defaults.',
+      alignment: 'justify',
+      textSize: 'enormous',
+      textColor: 'chartreuse',
+    },
+  },
+}
+
+/** No content at all: the card shows its "double-click to edit" placeholder. */
+export const Placeholder: Story = {
+  args: { content: undefined, gridHeight: 2 },
+}
+
+/** An intentionally empty string renders empty — it is not a missing value. */
+export const EmptyContent: Story = {
+  args: { config: { content: '' }, gridHeight: 2 },
+}
+
+/** Edit mode replaces the rendered markdown with a focused textarea. */
+export const EditMode: Story = {
+  args: { onDelete: () => {} },
+  parameters: { liebe: { mode: 'edit' } },
+}

--- a/src/components/TextCard.stories.tsx
+++ b/src/components/TextCard.stories.tsx
@@ -81,7 +81,7 @@ export const FromConfig: Story = {
  * An unsupported option value (from hand-edited or older YAML) falls back to
  * the default rather than being applied verbatim.
  */
-export const InvalidOptionsFallBack: Story = {
+export const InvalidOptionsFallback: Story = {
   args: {
     config: {
       content: 'Unknown alignment, size, and colour all fall back to the defaults.',

--- a/src/components/WeatherCard/WeatherCard.stories.tsx
+++ b/src/components/WeatherCard/WeatherCard.stories.tsx
@@ -1,0 +1,130 @@
+import type { ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { WeatherCard } from './index'
+import { asUnavailable, createWeatherEntity } from '~/test/fixtures'
+import { gridCellArgTypes, withGridCell, type GridCellArgs } from '../../../.storybook/decorators'
+
+const entityId = 'weather.home'
+
+type WeatherCardStoryProps = ComponentProps<typeof WeatherCard> & GridCellArgs
+
+/**
+ * The weather card renders one of four registered presentation variants, chosen
+ * by `config.variant` (`preset` is still read for older exports). The variants
+ * are declared as a static `variants` map on the component, so `getCardVariant`
+ * resolves them without the card ever importing the registry.
+ */
+const meta: Meta<WeatherCardStoryProps> = {
+  title: 'Cards/WeatherCard',
+  component: WeatherCard,
+  decorators: [withGridCell],
+  argTypes: {
+    ...gridCellArgTypes,
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium', 'large'] },
+  },
+  args: {
+    entityId,
+    size: 'medium',
+    gridWidth: 4,
+    gridHeight: 3,
+  },
+  parameters: {
+    liebe: { entities: [createWeatherEntity()] },
+  },
+}
+
+export default meta
+type Story = StoryObj<WeatherCardStoryProps>
+
+/* ------------------------------------------------------------------ *
+ * Variants
+ * ------------------------------------------------------------------ */
+
+/**
+ * The default variant: condition background image, temperature, and humidity.
+ * Weather never reports `on`/`off`, so the two representative states are two
+ * distinct conditions — this one and `Rainy` below.
+ */
+export const Default: Story = {}
+
+/** The `minimal` variant — a transparent tile with just name, temp, condition. */
+export const Minimal: Story = {
+  args: { config: { variant: 'minimal' }, gridWidth: 2, gridHeight: 2 },
+}
+
+/** The `modern` variant — gradient surface with a lucide condition icon. */
+export const Modern: Story = {
+  args: { config: { variant: 'modern' }, gridWidth: 3, gridHeight: 3 },
+}
+
+/** The `detailed` variant — adds pressure, wind, visibility, and the forecast. */
+export const Detailed: Story = {
+  args: { config: { variant: 'detailed' }, gridWidth: 4, gridHeight: 4 },
+}
+
+/**
+ * Older dashboards persisted the variant as `preset`; the card still honours it
+ * so existing exports keep rendering the variant they were saved with.
+ */
+export const LegacyPresetConfig: Story = {
+  args: { config: { preset: 'modern' }, gridWidth: 3, gridHeight: 3 },
+}
+
+/* ------------------------------------------------------------------ *
+ * States
+ * ------------------------------------------------------------------ */
+
+/** A second condition: rain swaps both the icon and the background image. */
+export const Rainy: Story = {
+  parameters: {
+    liebe: {
+      entities: [createWeatherEntity({ state: 'rainy', attributes: { temperature: 12.8 } })],
+    },
+  },
+}
+
+/** `temperatureUnit` converts the entity's Celsius reading for display. */
+export const Fahrenheit: Story = {
+  args: { config: { variant: 'minimal', temperatureUnit: 'fahrenheit' }, gridWidth: 2 },
+}
+
+export const Unavailable: Story = {
+  args: { gridHeight: 2 },
+  parameters: { liebe: { entities: [asUnavailable(createWeatherEntity())] } },
+}
+
+/** `unknown` is treated exactly like `unavailable` by every weather variant. */
+export const UnknownState: Story = {
+  args: { gridHeight: 2 },
+  parameters: { liebe: { entities: [createWeatherEntity({ state: 'unknown' })] } },
+}
+
+export const Loading: Story = {
+  args: { gridHeight: 2 },
+  parameters: { liebe: { entities: [], initialLoading: true } },
+}
+
+/**
+ * Weather is read-only — it has no service-call path — so its error story is
+ * the disconnected state it reaches through `useEntity`.
+ */
+export const Disconnected: Story = {
+  args: { gridHeight: 2 },
+  parameters: { liebe: { entities: [createWeatherEntity()], connected: false } },
+}
+
+/**
+ * An entity id that is not in the store. `useEntity` cannot tell "not loaded
+ * yet" from "does not exist", so the card holds its skeleton indefinitely
+ * rather than reporting the entity as missing.
+ */
+export const UnknownEntity: Story = {
+  args: { gridHeight: 2 },
+  parameters: { liebe: { entities: [] } },
+}
+
+/** Edit mode exposes the delete affordance. */
+export const EditMode: Story = {
+  args: { onDelete: () => {} },
+  parameters: { liebe: { entities: [createWeatherEntity()], mode: 'edit' } },
+}

--- a/src/components/WeatherCard/WeatherCard.stories.tsx
+++ b/src/components/WeatherCard/WeatherCard.stories.tsx
@@ -9,10 +9,19 @@ const entityId = 'weather.home'
 type WeatherCardStoryProps = ComponentProps<typeof WeatherCard> & GridCellArgs
 
 /**
- * The weather card renders one of four registered presentation variants, chosen
- * by `config.variant` (`preset` is still read for older exports). The variants
- * are declared as a static `variants` map on the component, so `getCardVariant`
- * resolves them without the card ever importing the registry.
+ * The weather card has four presentations, and two separate things select one.
+ *
+ * These stories render `WeatherCard` itself, which does its own selection: it
+ * reads `config.variant || config.preset || 'default'` and switches to the
+ * matching variant component (`src/components/WeatherCard/index.tsx`). That is
+ * the path a legacy `preset`-only config takes, and the path every story below
+ * exercises.
+ *
+ * The static `variants` map attached to the component is for the registry:
+ * `GridView` resolves `config.variant` through `getCardVariant(domain, variant)`
+ * and renders the variant component directly, skipping `WeatherCard`. The map
+ * is declared on the component rather than pushed into `cardRegistry` so the
+ * card never imports the registry (that import cycle crashes the bundle).
  */
 const meta: Meta<WeatherCardStoryProps> = {
   title: 'Cards/WeatherCard',


### PR DESCRIPTION
## Summary

Completes story coverage for every card that exists today and turns on the accessibility addon, the second task of `docs/changes/0009-storybook-setup.md`.

## Stories

`CoverCard`, `FanCard`, `ButtonCard`, `WeatherCard` (all four variants), `CameraCard`, all five input-helper cards, `TextCard`, and `Separator` — 165 stories total across 17 files, following the state matrices in the storybook spec.

## Reaching the camera card's real stream states

`CameraCard` resolves its stream element through Home Assistant's card-helper ladder, which can only succeed inside HA — so without intervention the entire stream UI was unreachable in the workshop and the stories would only ever have shown the fallback. Two mocks fix that:

- `.storybook/mockCameraStream.ts` registers a stand-in `<ha-camera-stream>` custom element once for the preview.
- `.storybook/mockCameraStreamReady.ts` replaces the card's readiness hook, substituted by a Vite plugin declared in `.storybook/vite.config.ts`.

The substitution is confined to the workshop by three independent mechanisms: `.storybook/vite.config.ts` is loaded only via `main.ts`'s `viteConfigPath` (the panel builds use `vite.config.ts` / `vite.config.ha.ts`, the test runner uses `vitest.config.ts`, and none reference it); the plugin's `resolveId` rewrites only the exact specifier `./useCameraStreamReady` and only for importers under `/CameraCard/`; and the mock modules are imported solely by the preview and the camera stories. Verified rather than assumed — `npm run build:ha` succeeds and the resulting `dist/panel.js` contains zero references to any mock. The real `useCameraStreamReady` and its unit tests are untouched.

The mock frame is a static SVG served via `staticDirs`, not a `data:` URI, because `StillImageFallback` appends a `?_ts=N` cache-buster that a data URL swallows into its payload — which silently broke the first attempt.

## Accessibility

The addon is enabled globally, in reporting mode (`test: 'todo'`). Fixing violations is explicitly out of scope for this change, so the audit results are recorded as issues instead:

- **#191** — `button-name` (critical): 66 nodes across 7 cards, all icon-only controls with no accessible name.
- **#192** — `aria-input-field-name` (serious): 11 nodes; `aria-label` sits on Radix's `Slider.Root` while `role="slider"` is on the thumb.

The audit was run for real: `storybook-static` served locally, every story's `iframe.html` driven in headless Chromium with `axe-core` injected, across both dark and light appearance — 330 runs.

The axe `region` rule is explicitly disabled in `preview.tsx`. It fires on 127 of 165 stories purely because a story renders a bare card while the real panel supplies the landmark, so it reports a story-isolation artifact rather than a card defect, and it would bury the two findings above. `addon-a11y` already disables it in its own defaults, so the entry is a no-op for the addon's runner today — it is pinned so the decision is explicit and survives a change to those defaults.

## Product bug found, not fixed

`InputDateTimeCard` renders date-only values one day early for viewers west of UTC: HA publishes `YYYY-MM-DD`, which `new Date(...)` parses as UTC midnight. Out of scope here, documented in the `DateOnly` story so a fix has somewhere to be demonstrated, and tracked in **#193**.

## Testing

- `npm test` — 64 files, 815 passed, 2 skipped
- `npm run lint`, `npm run typecheck` — clean
- `npm run build-storybook` — succeeds
- `npm run build:ha` — succeeds, no mock references in the panel bundle

## Scope

The CI build gate and Pages publishing are the remaining task in this change document, which stays `draft` until that final PR lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Storybook coverage across many cards and UI states (normal, loading, unavailable, disconnected, error/service-failure, unknown-entity, and edit mode).
  * Added network-free camera stream simulations for key stream lifecycles, including connecting/error handling and still-image fallbacks.
  * Enabled accessibility auditing in Storybook for easier issue detection.
* **Documentation**
  * Updated the coverage checklist to reflect the newly added Storybook scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->