### PR TITLE
feat(theming): inject the theme layer and resolve appearance

### DIFF
--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -131,9 +131,11 @@ export const withServiceCalls: Decorator = (Story, context) => (
  * ------------------------------------------------------------------ */
 
 /**
- * Wraps every story in the panel's provider shell and stamps the theming
- * engine's contract attributes (`data-liebe-theme`, `data-appearance`) so
- * scoped theme rules have the same hooks they get in the panel.
+ * Wraps every story in the panel's provider shell, driven by the toolbar the
+ * way the panel is driven by its configuration: the provider stamps the
+ * contract attributes (`data-liebe-theme`, `data-appearance`) on the theme root
+ * and injects the selected theme's layer, so scoped theme rules have exactly
+ * the hooks and the cascade they get in the panel.
  *
  * Single-appearance themes force their appearance, and the forced value is
  * written back into the toolbar global so the control shows what is actually
@@ -163,10 +165,8 @@ export const withProviders: Decorator = (Story) => {
   }, [appearance, requested, updateGlobals])
 
   return (
-    <LiebeThemeProvider appearance={appearance}>
+    <LiebeThemeProvider themeId={themeId} appearance={appearance}>
       <div
-        data-liebe-theme={themeId}
-        data-appearance={appearance}
         style={{
           background: 'var(--color-background)',
           color: 'var(--gray-12)',

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -19,16 +19,16 @@ window.__LIEBE_ASSET_BASE_URL__ = new URL('./', document.baseURI).href
 
 // The same style set the panel injects (src/panel.ts) — imported here directly
 // because the panel entry also registers the custom element and starts the
-// Home Assistant connection, neither of which may run in the preview.
-// The token layers are part of that set and are imported in the same order the
-// panel injects them (base → theme → user, per the theming spec); the
+// Home Assistant connection, neither of which may run in the preview. These are
+// the `liebe-base` layer; the theme layer is injected by LiebeThemeProvider
+// from the registry, here as in the panel, which is what makes the toolbar's
+// theme control the real engine rather than a workshop-only path. The
 // stylesheets carry the `@layer` statement that makes the order binding.
 import '@radix-ui/themes/styles.css'
 import 'react-grid-layout/css/styles.css'
 import 'react-resizable/css/styles.css'
 import '~/styles/app.css'
 import '~/styles/tokens.css'
-import '~/theme/themes/default.css'
 
 const preview: Preview = {
   // Outermost first: providers wrap the mock connection, which wraps the

--- a/.storybook/vite.config.ts
+++ b/.storybook/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
 import { resolve } from 'path'
+import { baselineCssPlugin } from '../vite/baselineCssPlugin'
 
 /**
  * Storybook's own Vite config.
@@ -14,6 +15,7 @@ import { resolve } from 'path'
  */
 export default defineConfig({
   plugins: [
+    baselineCssPlugin(),
     {
       // `CameraCard` resolves its stream element through the Home Assistant
       // frontend's card-helper ladder, which can only ever succeed inside HA.

--- a/docs/changes/0012-theming-engine.md
+++ b/docs/changes/0012-theming-engine.md
@@ -43,7 +43,7 @@ Skipping or weakening any rule to land the PR is a bug in the PR.
 
 ## Tasks
 
-- [ ] **PR 1 — Injection + registry + appearance**: style layers; adopt and extend the minimal theme-registry module from 0009 as the runtime registry (the storybook toolbar already enumerates it); appearance resolution + Radix wiring; root stamping; unit tests
+- [x] **PR 1 — Injection + registry + appearance**: style layers; adopt and extend the minimal theme-registry module from 0009 as the runtime registry (the storybook toolbar already enumerates it); appearance resolution + Radix wiring; root stamping; unit tests
 - [ ] **PR 2 — Config + UI**: schema fields + validation + export/import + dirty-tracking; legacy scalar-`theme` migration with unit tests; **dashboard-config spec synchronized in this same PR** (store shape, `setTheme`, initialization, export/import, migration — the schema change and its owning spec must never merge apart); picker, appearance control, custom-CSS editor; **the injection-time sanitizer ships in this same PR** (imports, off-origin references incl. escaped/protocol-relative/custom-property and inherited-variable indirection, with editor notices and the full bypass-test suite — imported YAML applies immediately, so warnings without the sanitizer would violate the offline/security boundary); component tests; user-override story
 - [ ] **PR 3 — E2E + theming spec sync**: live-switch and round-trip e2e; update theming spec changelog and document the chosen user-CSS root selector (the dashboard-config spec was already synchronized in PR 2, atomically with the schema change)
 

--- a/src/components/AppTaskbar.css
+++ b/src/components/AppTaskbar.css
@@ -1,24 +1,35 @@
-/* App Taskbar - Windows taskbar-like styling */
+/*
+ * Layered into `liebe-base` like every other Liebe sheet: an unlayered author
+ * rule outranks every cascade layer regardless of specificity, so anything left
+ * outside a layer here would be the one part of this component a theme or user
+ * CSS could not restyle (docs/specs/theming — "Application mechanism").
+ */
 
-.app-taskbar {
-  background-color: var(--color-panel-solid);
-  border-right: 1px solid var(--gray-a5);
-  padding: var(--space-3);
-  height: 100%;
-  transition: width 150ms ease-out;
-}
+@layer liebe-base, liebe-theme, liebe-user;
 
-/* Collapsed state - just icons */
-.app-taskbar.collapsed {
-  width: auto;
-}
+@layer liebe-base {
+  /* App Taskbar - Windows taskbar-like styling */
 
-/* Expanded state - icons + text */
-.app-taskbar.expanded {
-  width: 200px;
-}
+  .app-taskbar {
+    background-color: var(--color-panel-solid);
+    border-right: 1px solid var(--gray-a5);
+    padding: var(--space-3);
+    height: 100%;
+    transition: width 150ms ease-out;
+  }
 
-/* Ensure separators span full width */
-.app-taskbar .rt-Separator {
-  width: 100%;
+  /* Collapsed state - just icons */
+  .app-taskbar.collapsed {
+    width: auto;
+  }
+
+  /* Expanded state - icons + text */
+  .app-taskbar.expanded {
+    width: 200px;
+  }
+
+  /* Ensure separators span full width */
+  .app-taskbar .rt-Separator {
+    width: 100%;
+  }
 }

--- a/src/components/CameraCard/CameraCard.css
+++ b/src/components/CameraCard/CameraCard.css
@@ -1,96 +1,107 @@
-@keyframes recording-pulse {
-  0% {
-    opacity: 1;
-    transform: scale(1);
-  }
-  50% {
-    opacity: 0.6;
-    transform: scale(1.1);
-  }
-  100% {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
+/*
+ * Layered into `liebe-base` like every other Liebe sheet: an unlayered author
+ * rule outranks every cascade layer regardless of specificity, so anything left
+ * outside a layer here would be the one part of this component a theme or user
+ * CSS could not restyle (docs/specs/theming — "Application mechanism").
+ */
 
-.recording-dot {
-  width: 0.625em;
-  height: 0.625em;
-  /* Radix theme token, not a fixed hex, so the dot follows the palette. */
-  background-color: var(--red-9);
-  border-radius: 50%;
-  display: inline-block;
-  animation: recording-pulse 1.5s ease-in-out infinite;
-}
+@layer liebe-base, liebe-theme, liebe-user;
 
-@media (prefers-reduced-motion: reduce) {
+@layer liebe-base {
+  @keyframes recording-pulse {
+    0% {
+      opacity: 1;
+      transform: scale(1);
+    }
+    50% {
+      opacity: 0.6;
+      transform: scale(1.1);
+    }
+    100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
   .recording-dot {
-    animation: none;
+    width: 0.625em;
+    height: 0.625em;
+    /* Radix theme token, not a fixed hex, so the dot follows the palette. */
+    background-color: var(--red-9);
+    border-radius: 50%;
+    display: inline-block;
+    animation: recording-pulse 1.5s ease-in-out infinite;
   }
-}
 
-/* The stream surface is a role=button (tap toggles the in-place zoom), so a
-   pointer tap focuses it too. Chrome then paints its UA ring — `outline: auto`,
-   which reads as a white border over the dark stream — and its :focus-visible
-   heuristic makes that ring STICKY: once any keyboard interaction has happened
-   (pressing ESC to leave the zoom is the usual one), every later tap keeps the
-   ring until the card unmounts. Hence "sometimes, and it goes away on a
-   re-render". Replace the UA ring with the Radix focus token, and drop it for
-   pointer-only focus.
-   Ordered so the ring is the FALLBACK, not the enhancement: a browser without
-   :focus-visible support drops the `:not(:focus-visible)` rule as invalid and
-   keeps the plain `:focus` ring, rather than being left with no keyboard focus
-   indicator at all. */
-.camera-stream-surface:focus {
-  outline: 2px solid var(--focus-8);
-  /* Inset so the ring is not clipped by the card's overflow: hidden. */
-  outline-offset: -2px;
-}
+  @media (prefers-reduced-motion: reduce) {
+    .recording-dot {
+      animation: none;
+    }
+  }
 
-.camera-stream-surface:focus:not(:focus-visible) {
-  outline: none;
-}
+  /* The stream surface is a role=button (tap toggles the in-place zoom), so a
+     pointer tap focuses it too. Chrome then paints its UA ring — `outline: auto`,
+     which reads as a white border over the dark stream — and its :focus-visible
+     heuristic makes that ring STICKY: once any keyboard interaction has happened
+     (pressing ESC to leave the zoom is the usual one), every later tap keeps the
+     ring until the card unmounts. Hence "sometimes, and it goes away on a
+     re-render". Replace the UA ring with the Radix focus token, and drop it for
+     pointer-only focus.
+     Ordered so the ring is the FALLBACK, not the enhancement: a browser without
+     :focus-visible support drops the `:not(:focus-visible)` rule as invalid and
+     keeps the plain `:focus` ring, rather than being left with no keyboard focus
+     indicator at all. */
+  .camera-stream-surface:focus {
+    outline: 2px solid var(--focus-8);
+    /* Inset so the ring is not clipped by the card's overflow: hidden. */
+    outline-offset: -2px;
+  }
 
-/* In zoom the surface IS the viewport, so a ring hugging the screen edges is
-   pure noise — the always-visible "Click or press ESC to exit" hint is the
-   affordance there. Both selectors, so the ring stays suppressed where
-   :focus-visible is unsupported too. */
-.camera-stream-surface-fullscreen:focus,
-.camera-stream-surface-fullscreen:focus-visible {
-  outline: none;
-}
+  .camera-stream-surface:focus:not(:focus-visible) {
+    outline: none;
+  }
 
-.camera-control-button {
-  position: relative;
-  width: 2.5em;
-  height: 2.5em;
-  border-radius: 0.5em;
-  border: none;
-  background-color: rgba(255, 255, 255, 0.1);
-  color: white;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-  padding: 0;
-  font-size: inherit;
-}
+  /* In zoom the surface IS the viewport, so a ring hugging the screen edges is
+     pure noise — the always-visible "Click or press ESC to exit" hint is the
+     affordance there. Both selectors, so the ring stays suppressed where
+     :focus-visible is unsupported too. */
+  .camera-stream-surface-fullscreen:focus,
+  .camera-stream-surface-fullscreen:focus-visible {
+    outline: none;
+  }
 
-.camera-control-button:hover {
-  background-color: rgba(255, 255, 255, 0.2);
-}
+  .camera-control-button {
+    position: relative;
+    width: 2.5em;
+    height: 2.5em;
+    border-radius: 0.5em;
+    border: none;
+    background-color: rgba(255, 255, 255, 0.1);
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+    padding: 0;
+    font-size: inherit;
+  }
 
-/* Touch-target expansion: the visual button scales with card size (2.5em of
-   an 8-11.2px base) and can render well below the 44px minimum touch target.
-   A centered pseudo-element extends the HIT AREA to at least 44px in each
-   dimension without changing the visual size or the overlay layout. */
-.camera-control-button::after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: max(100%, 44px);
-  height: max(100%, 44px);
-  transform: translate(-50%, -50%);
+  .camera-control-button:hover {
+    background-color: rgba(255, 255, 255, 0.2);
+  }
+
+  /* Touch-target expansion: the visual button scales with card size (2.5em of
+     an 8-11.2px base) and can render well below the 44px minimum touch target.
+     A centered pseudo-element extends the HIT AREA to at least 44px in each
+     dimension without changing the visual size or the overlay layout. */
+  .camera-control-button::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: max(100%, 44px);
+    height: max(100%, 44px);
+    transform: translate(-50%, -50%);
+  }
 }

--- a/src/components/ConnectionStatus.css
+++ b/src/components/ConnectionStatus.css
@@ -1,40 +1,51 @@
-@keyframes spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
+/*
+ * Layered into `liebe-base` like every other Liebe sheet: an unlayered author
+ * rule outranks every cascade layer regardless of specificity, so anything left
+ * outside a layer here would be the one part of this component a theme or user
+ * CSS could not restyle (docs/specs/theming — "Application mechanism").
+ */
 
-.spin {
-  animation: spin 1s linear infinite;
-}
+@layer liebe-base, liebe-theme, liebe-user;
 
-@keyframes pulse-ring {
-  0% {
-    transform: scale(0.8);
-    opacity: 0.75;
+@layer liebe-base {
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
   }
-  100% {
-    transform: scale(2);
-    opacity: 0;
+
+  .spin {
+    animation: spin 1s linear infinite;
   }
-}
 
-.pulse-container {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
+  @keyframes pulse-ring {
+    0% {
+      transform: scale(0.8);
+      opacity: 0.75;
+    }
+    100% {
+      transform: scale(2);
+      opacity: 0;
+    }
+  }
 
-.pulse-ring {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  border-radius: 50%;
-  background-color: currentColor;
-  animation: pulse-ring 1s cubic-bezier(0.215, 0.61, 0.355, 1);
-  pointer-events: none;
+  .pulse-container {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .pulse-ring {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background-color: currentColor;
+    animation: pulse-ring 1s cubic-bezier(0.215, 0.61, 0.355, 1);
+    pointer-events: none;
+  }
 }

--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -1,3 +1,14 @@
-/* Dashboard-specific styles */
+/*
+ * Layered into `liebe-base` like every other Liebe sheet: an unlayered author
+ * rule outranks every cascade layer regardless of specificity, so anything left
+ * outside a layer here would be the one part of this component a theme or user
+ * CSS could not restyle (docs/specs/theming — "Application mechanism").
+ */
 
-/* Currently no dashboard-specific styles needed */
+@layer liebe-base, liebe-theme, liebe-user;
+
+@layer liebe-base {
+  /* Dashboard-specific styles */
+
+  /* Currently no dashboard-specific styles needed */
+}

--- a/src/components/GridLayoutSection.css
+++ b/src/components/GridLayoutSection.css
@@ -1,258 +1,269 @@
-/* Grid Layout Section Styles */
+/*
+ * Layered into `liebe-base` like every other Liebe sheet: an unlayered author
+ * rule outranks every cascade layer regardless of specificity, so anything left
+ * outside a layer here would be the one part of this component a theme or user
+ * CSS could not restyle (docs/specs/theming — "Application mechanism").
+ */
 
-/* Override react-grid-layout styles for better Radix UI integration */
-.react-grid-layout {
-  position: relative;
-}
+@layer liebe-base, liebe-theme, liebe-user;
 
-.react-grid-item {
-  transition: none;
-}
+@layer liebe-base {
+  /* Grid Layout Section Styles */
 
-.react-grid-item.resizing {
-  z-index: 1;
-  will-change: width, height;
-}
-
-.react-grid-item.react-draggable-dragging {
-  transition: none;
-  z-index: 3;
-  will-change: transform;
-  cursor: move;
-}
-
-.react-grid-item.dropping {
-  visibility: hidden;
-}
-
-.react-grid-item.react-grid-placeholder {
-  background: var(--accent-3);
-  opacity: 0.5;
-  transition: none;
-  z-index: 2;
-  border-radius: var(--radius-3);
-  border: 2px dashed var(--accent-7);
-}
-
-/* Grid item container */
-.grid-item {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-}
-
-/* Resize handles */
-.react-resizable-handle {
-  position: absolute;
-  width: 20px;
-  height: 20px;
-  background-color: transparent;
-  z-index: 1;
-}
-
-.react-resizable-handle::after {
-  content: '';
-  position: absolute;
-  border: 2px solid var(--accent-9);
-  background: var(--color-background);
-  opacity: 0;
-  transition: none;
-}
-
-.react-grid-item:hover .react-resizable-handle::after {
-  opacity: 1;
-}
-
-/* Corner handles */
-.react-resizable-handle-se,
-.react-resizable-handle-sw,
-.react-resizable-handle-ne,
-.react-resizable-handle-nw {
-  width: 20px;
-  height: 20px;
-}
-
-.react-resizable-handle-se::after,
-.react-resizable-handle-sw::after,
-.react-resizable-handle-ne::after,
-.react-resizable-handle-nw::after {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-}
-
-.react-resizable-handle-se {
-  bottom: 0;
-  right: 0;
-  cursor: se-resize;
-}
-
-.react-resizable-handle-se::after {
-  bottom: 4px;
-  right: 4px;
-}
-
-.react-resizable-handle-sw {
-  bottom: 0;
-  left: 0;
-  cursor: sw-resize;
-}
-
-.react-resizable-handle-sw::after {
-  bottom: 4px;
-  left: 4px;
-}
-
-.react-resizable-handle-ne {
-  top: 0;
-  right: 0;
-  cursor: ne-resize;
-}
-
-.react-resizable-handle-ne::after {
-  top: 4px;
-  right: 4px;
-}
-
-.react-resizable-handle-nw {
-  top: 0;
-  left: 0;
-  cursor: nw-resize;
-}
-
-.react-resizable-handle-nw::after {
-  top: 4px;
-  left: 4px;
-}
-
-/* Edge handles */
-.react-resizable-handle-e,
-.react-resizable-handle-w {
-  top: 50%;
-  transform: translateY(-50%);
-  width: 20px;
-  height: 40px;
-}
-
-.react-resizable-handle-e::after,
-.react-resizable-handle-w::after {
-  width: 4px;
-  height: 24px;
-  border-radius: 2px;
-  top: 50%;
-  transform: translateY(-50%);
-}
-
-.react-resizable-handle-e {
-  right: 0;
-  cursor: e-resize;
-}
-
-.react-resizable-handle-e::after {
-  right: 6px;
-}
-
-.react-resizable-handle-w {
-  left: 0;
-  cursor: w-resize;
-}
-
-.react-resizable-handle-w::after {
-  left: 6px;
-}
-
-.react-resizable-handle-n,
-.react-resizable-handle-s {
-  left: 50%;
-  transform: translateX(-50%);
-  width: 40px;
-  height: 20px;
-}
-
-.react-resizable-handle-n::after,
-.react-resizable-handle-s::after {
-  width: 24px;
-  height: 4px;
-  border-radius: 2px;
-  left: 50%;
-  transform: translateX(-50%);
-}
-
-.react-resizable-handle-n {
-  top: 0;
-  cursor: n-resize;
-}
-
-.react-resizable-handle-n::after {
-  top: 6px;
-}
-
-.react-resizable-handle-s {
-  bottom: 0;
-  cursor: s-resize;
-}
-
-.react-resizable-handle-s::after {
-  bottom: 6px;
-}
-
-/* Ensure ButtonCard fills the grid item */
-.grid-item > * {
-  width: 100%;
-  height: 100%;
-}
-
-/* Responsive adjustments */
-@media (max-width: 767px) {
-  /* Smaller resize handles for mobile */
-  .react-resizable-handle {
-    width: 24px;
-    height: 24px;
+  /* Override react-grid-layout styles for better Radix UI integration */
+  .react-grid-layout {
+    position: relative;
   }
 
+  .react-grid-item {
+    transition: none;
+  }
+
+  .react-grid-item.resizing {
+    z-index: 1;
+    will-change: width, height;
+  }
+
+  .react-grid-item.react-draggable-dragging {
+    transition: none;
+    z-index: 3;
+    will-change: transform;
+    cursor: move;
+  }
+
+  .react-grid-item.dropping {
+    visibility: hidden;
+  }
+
+  .react-grid-item.react-grid-placeholder {
+    background: var(--accent-3);
+    opacity: 0.5;
+    transition: none;
+    z-index: 2;
+    border-radius: var(--radius-3);
+    border: 2px dashed var(--accent-7);
+  }
+
+  /* Grid item container */
+  .grid-item {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* Resize handles */
+  .react-resizable-handle {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    background-color: transparent;
+    z-index: 1;
+  }
+
+  .react-resizable-handle::after {
+    content: '';
+    position: absolute;
+    border: 2px solid var(--accent-9);
+    background: var(--color-background);
+    opacity: 0;
+    transition: none;
+  }
+
+  .react-grid-item:hover .react-resizable-handle::after {
+    opacity: 1;
+  }
+
+  /* Corner handles */
   .react-resizable-handle-se,
   .react-resizable-handle-sw,
   .react-resizable-handle-ne,
   .react-resizable-handle-nw {
-    width: 24px;
-    height: 24px;
+    width: 20px;
+    height: 20px;
   }
 
-  /* Disable hover effects on touch devices */
-  @media (pointer: coarse) {
-    .react-grid-item:hover .react-resizable-handle::after {
-      opacity: 0;
-    }
-
-    /* Show resize handles when in edit mode */
-    .react-grid-item.react-draggable .react-resizable-handle::after {
-      opacity: 1;
-    }
-  }
-}
-
-@media (min-width: 768px) and (max-width: 1023px) {
-  /* Tablet adjustments */
-}
-
-/* Touch-friendly adjustments */
-@media (pointer: coarse) {
-  /* Larger touch targets for resize handles */
-  .react-resizable-handle {
-    width: 32px;
-    height: 32px;
+  .react-resizable-handle-se::after,
+  .react-resizable-handle-sw::after,
+  .react-resizable-handle-ne::after,
+  .react-resizable-handle-nw::after {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
   }
 
+  .react-resizable-handle-se {
+    bottom: 0;
+    right: 0;
+    cursor: se-resize;
+  }
+
+  .react-resizable-handle-se::after {
+    bottom: 4px;
+    right: 4px;
+  }
+
+  .react-resizable-handle-sw {
+    bottom: 0;
+    left: 0;
+    cursor: sw-resize;
+  }
+
+  .react-resizable-handle-sw::after {
+    bottom: 4px;
+    left: 4px;
+  }
+
+  .react-resizable-handle-ne {
+    top: 0;
+    right: 0;
+    cursor: ne-resize;
+  }
+
+  .react-resizable-handle-ne::after {
+    top: 4px;
+    right: 4px;
+  }
+
+  .react-resizable-handle-nw {
+    top: 0;
+    left: 0;
+    cursor: nw-resize;
+  }
+
+  .react-resizable-handle-nw::after {
+    top: 4px;
+    left: 4px;
+  }
+
+  /* Edge handles */
   .react-resizable-handle-e,
   .react-resizable-handle-w {
-    width: 32px;
-    height: 60px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 20px;
+    height: 40px;
+  }
+
+  .react-resizable-handle-e::after,
+  .react-resizable-handle-w::after {
+    width: 4px;
+    height: 24px;
+    border-radius: 2px;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  .react-resizable-handle-e {
+    right: 0;
+    cursor: e-resize;
+  }
+
+  .react-resizable-handle-e::after {
+    right: 6px;
+  }
+
+  .react-resizable-handle-w {
+    left: 0;
+    cursor: w-resize;
+  }
+
+  .react-resizable-handle-w::after {
+    left: 6px;
   }
 
   .react-resizable-handle-n,
   .react-resizable-handle-s {
-    width: 60px;
-    height: 32px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 40px;
+    height: 20px;
+  }
+
+  .react-resizable-handle-n::after,
+  .react-resizable-handle-s::after {
+    width: 24px;
+    height: 4px;
+    border-radius: 2px;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  .react-resizable-handle-n {
+    top: 0;
+    cursor: n-resize;
+  }
+
+  .react-resizable-handle-n::after {
+    top: 6px;
+  }
+
+  .react-resizable-handle-s {
+    bottom: 0;
+    cursor: s-resize;
+  }
+
+  .react-resizable-handle-s::after {
+    bottom: 6px;
+  }
+
+  /* Ensure ButtonCard fills the grid item */
+  .grid-item > * {
+    width: 100%;
+    height: 100%;
+  }
+
+  /* Responsive adjustments */
+  @media (max-width: 767px) {
+    /* Smaller resize handles for mobile */
+    .react-resizable-handle {
+      width: 24px;
+      height: 24px;
+    }
+
+    .react-resizable-handle-se,
+    .react-resizable-handle-sw,
+    .react-resizable-handle-ne,
+    .react-resizable-handle-nw {
+      width: 24px;
+      height: 24px;
+    }
+
+    /* Disable hover effects on touch devices */
+    @media (pointer: coarse) {
+      .react-grid-item:hover .react-resizable-handle::after {
+        opacity: 0;
+      }
+
+      /* Show resize handles when in edit mode */
+      .react-grid-item.react-draggable .react-resizable-handle::after {
+        opacity: 1;
+      }
+    }
+  }
+
+  @media (min-width: 768px) and (max-width: 1023px) {
+    /* Tablet adjustments */
+  }
+
+  /* Touch-friendly adjustments */
+  @media (pointer: coarse) {
+    /* Larger touch targets for resize handles */
+    .react-resizable-handle {
+      width: 32px;
+      height: 32px;
+    }
+
+    .react-resizable-handle-e,
+    .react-resizable-handle-w {
+      width: 32px;
+      height: 60px;
+    }
+
+    .react-resizable-handle-n,
+    .react-resizable-handle-s {
+      width: 60px;
+      height: 32px;
+    }
   }
 }

--- a/src/components/LiebeThemeProvider.tsx
+++ b/src/components/LiebeThemeProvider.tsx
@@ -61,7 +61,11 @@ export function LiebeThemeProvider({
   const cameraFullscreenActive = useCameraFullscreenActive()
 
   const themeRoot = useRef<HTMLDivElement>(null)
-  const themeCss = getThemeOrDefault(themeId).css
+  // Stamped from the theme that is actually rendered, not from what was asked
+  // for: an unregistered id falls back to Default, and a stamp naming the
+  // missing theme would leave that theme's scoped rules addressing a palette
+  // nothing here renders.
+  const { id: activeThemeId, css: themeCss } = getThemeOrDefault(themeId)
 
   // A layout effect, so the theme layer is in the root before the browser
   // paints the tree it styles. The `<style>` is keyed to the root rather than
@@ -76,7 +80,7 @@ export function LiebeThemeProvider({
     <Theme
       ref={themeRoot}
       className="liebe-root"
-      data-liebe-theme={themeId}
+      data-liebe-theme={activeThemeId}
       data-appearance={appearance}
       appearance={appearance}
       style={

--- a/src/components/LiebeThemeProvider.tsx
+++ b/src/components/LiebeThemeProvider.tsx
@@ -1,15 +1,25 @@
 import { Theme } from '@radix-ui/themes'
-import type { ReactNode } from 'react'
+import { useLayoutEffect, useRef, type ReactNode } from 'react'
 import { useCameraFullscreenActive, CAMERA_FULLSCREEN_Z_INDEX } from '~/store/cameraFullscreenStore'
+import { applyThemeCssToRootOf } from '~/theme/styleInjection'
+import { DEFAULT_THEME_ID, getThemeOrDefault, type ThemeAppearance } from '~/theme/themeRegistry'
 
 export interface LiebeThemeProviderProps {
   children: ReactNode
   /**
-   * Resolved appearance for the Radix `Theme`. The panel leaves this undefined
-   * (Radix then inherits from the surrounding document); the Storybook preview
-   * passes the appearance chosen in the toolbar.
+   * Resolved appearance for the Radix `Theme`. The panel passes what
+   * `useThemeSelection` resolved; the Storybook preview passes the appearance
+   * chosen in the toolbar. Left undefined, Radix inherits from the surrounding
+   * document and nothing is stamped — the appearance is then not this tree's to
+   * claim.
    */
-  appearance?: 'dark' | 'light'
+  appearance?: ThemeAppearance
+  /**
+   * Id of the theme to apply. Unregistered ids fall back to Default
+   * (`getThemeOrDefault`), so an imported configuration naming a theme this
+   * build does not have still renders.
+   */
+  themeId?: string
 }
 
 /**
@@ -20,8 +30,28 @@ export interface LiebeThemeProviderProps {
  * not the panel — today the Storybook preview — can render components inside
  * exactly the same provider stack the panel uses. See
  * docs/specs/storybook/index.md ("Global decorators & toolbar").
+ *
+ * It owns two halves of the theming contract (docs/specs/theming —
+ * "Application mechanism"):
+ *
+ *  - **Root stamping.** `data-liebe-theme`, `data-appearance` and the
+ *    `liebe-root` class go on the Radix theme root, and not on a wrapper,
+ *    because that is the element the token sheets declare `--liebe-*` on. A
+ *    `var()` in a custom property substitutes at the element that declares it,
+ *    and a derived companion (`--liebe-c-light-tint`) only re-derives where its
+ *    base is overridden on the *same* element — so a theme or user rule keyed
+ *    off a stamp on any other element would leave the companions behind on the
+ *    old hue. `liebe-root` is the selector user CSS is documented to target;
+ *    `.radix-themes` is a vendor name and not ours to promise.
+ *  - **Theme layer injection.** The active theme's CSS is injected into the
+ *    root this tree is mounted in — the shadow root in Home Assistant, the
+ *    document in the workshop — so switching themes applies live.
  */
-export function LiebeThemeProvider({ children, appearance }: LiebeThemeProviderProps) {
+export function LiebeThemeProvider({
+  children,
+  appearance,
+  themeId = DEFAULT_THEME_ID,
+}: LiebeThemeProviderProps) {
   // This is the ROOT Theme (data-is-root-theme="true"), so it establishes a
   // stacking context (`position: relative; z-index: 0`) that would otherwise
   // cap the camera card's in-place fullscreen overlay below Home Assistant's
@@ -30,8 +60,24 @@ export function LiebeThemeProvider({ children, appearance }: LiebeThemeProviderP
   // node. See docs/changes/0008-camera-fullscreen-no-dom-move.md.
   const cameraFullscreenActive = useCameraFullscreenActive()
 
+  const themeRoot = useRef<HTMLDivElement>(null)
+  const themeCss = getThemeOrDefault(themeId).css
+
+  // A layout effect, so the theme layer is in the root before the browser
+  // paints the tree it styles. The `<style>` is keyed to the root rather than
+  // to this component and is deliberately left in place on unmount: it belongs
+  // to the panel's root, and removing it would strip the theme from a tree that
+  // is only remounting.
+  useLayoutEffect(() => {
+    applyThemeCssToRootOf(themeRoot.current, themeCss)
+  }, [themeCss])
+
   return (
     <Theme
+      ref={themeRoot}
+      className="liebe-root"
+      data-liebe-theme={themeId}
+      data-appearance={appearance}
       appearance={appearance}
       style={
         cameraFullscreenActive

--- a/src/components/PanelApp.tsx
+++ b/src/components/PanelApp.tsx
@@ -3,8 +3,14 @@ import { useEffect } from 'react'
 import { RouterProvider } from '@tanstack/react-router'
 import { router } from '~/router'
 import { LiebeThemeProvider } from './LiebeThemeProvider'
+import { useThemeSelection } from '~/theme/useThemeSelection'
 
 export function PanelApp() {
+  // Resolved here rather than inside the provider: the provider is the shell
+  // the workshop shares, and the workshop's toolbar — not the dashboard
+  // configuration — decides what it renders.
+  const { themeId, appearance } = useThemeSelection()
+
   useEffect(() => {
     // Initialize the dashboard store
     // For panel mode, we start with no screens and let the user create them
@@ -15,7 +21,7 @@ export function PanelApp() {
   }, [])
 
   return (
-    <LiebeThemeProvider>
+    <LiebeThemeProvider themeId={themeId} appearance={appearance}>
       <RouterProvider router={router} />
     </LiebeThemeProvider>
   )

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -1,24 +1,35 @@
-/* Sidebar - Simple content area */
+/*
+ * Layered into `liebe-base` like every other Liebe sheet: an unlayered author
+ * rule outranks every cascade layer regardless of specificity, so anything left
+ * outside a layer here would be the one part of this component a theme or user
+ * CSS could not restyle (docs/specs/theming — "Application mechanism").
+ */
 
-.sidebar {
-  width: var(--sidebar-width);
-  background-color: var(--color-panel-solid);
-  border-right: 1px solid var(--gray-a5);
-  height: 100%;
-  transition:
-    width 120ms ease-out,
-    opacity 100ms ease-out;
-  -webkit-overflow-scrolling: touch;
-}
+@layer liebe-base, liebe-theme, liebe-user;
 
-/* Mobile responsive */
-@media (max-width: 768px) {
+@layer liebe-base {
+  /* Sidebar - Simple content area */
+
   .sidebar {
-    position: fixed;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    width: 100%;
-    z-index: var(--z-modal);
+    width: var(--sidebar-width);
+    background-color: var(--color-panel-solid);
+    border-right: 1px solid var(--gray-a5);
+    height: 100%;
+    transition:
+      width 120ms ease-out,
+      opacity 100ms ease-out;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* Mobile responsive */
+  @media (max-width: 768px) {
+    .sidebar {
+      position: fixed;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      width: 100%;
+      z-index: var(--z-modal);
+    }
   }
 }

--- a/src/components/TextCard.css
+++ b/src/components/TextCard.css
@@ -1,53 +1,64 @@
-/* TextCard specific styles */
-.text-card-content {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  word-wrap: break-word;
-}
+/*
+ * Layered into `liebe-base` like every other Liebe sheet: an unlayered author
+ * rule outranks every cascade layer regardless of specificity, so anything left
+ * outside a layer here would be the one part of this component a theme or user
+ * CSS could not restyle (docs/specs/theming — "Application mechanism").
+ */
 
-.text-card-content p:last-child {
-  margin-bottom: 0;
-}
+@layer liebe-base, liebe-theme, liebe-user;
 
-.text-card-content h1:last-child,
-.text-card-content h2:last-child,
-.text-card-content h3:last-child {
-  margin-bottom: 0;
-}
-
-/* Responsive text sizing */
-@media (max-width: 640px) {
+@layer liebe-base {
+  /* TextCard specific styles */
   .text-card-content {
-    font-size: 0.9em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-wrap: break-word;
   }
-}
 
-/* Animation for edit mode */
-.text-card-edit-indicator {
-  position: absolute;
-  top: 8px;
-  left: 8px;
-  width: 6px;
-  height: 6px;
-  background-color: var(--blue-9);
-  border-radius: 50%;
-  opacity: 0;
-  transition: opacity 0.2s ease;
-}
-
-.text-card-edit-mode .text-card-edit-indicator {
-  opacity: 1;
-  animation: pulse 2s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%,
-  100% {
-    transform: scale(1);
-    opacity: 0.8;
+  .text-card-content p:last-child {
+    margin-bottom: 0;
   }
-  50% {
-    transform: scale(1.2);
+
+  .text-card-content h1:last-child,
+  .text-card-content h2:last-child,
+  .text-card-content h3:last-child {
+    margin-bottom: 0;
+  }
+
+  /* Responsive text sizing */
+  @media (max-width: 640px) {
+    .text-card-content {
+      font-size: 0.9em;
+    }
+  }
+
+  /* Animation for edit mode */
+  .text-card-edit-indicator {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    width: 6px;
+    height: 6px;
+    background-color: var(--blue-9);
+    border-radius: 50%;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+  }
+
+  .text-card-edit-mode .text-card-edit-indicator {
     opacity: 1;
+    animation: pulse 2s ease-in-out infinite;
+  }
+
+  @keyframes pulse {
+    0%,
+    100% {
+      transform: scale(1);
+      opacity: 0.8;
+    }
+    50% {
+      transform: scale(1.2);
+      opacity: 1;
+    }
   }
 }

--- a/src/components/__tests__/LiebeThemeProvider.test.tsx
+++ b/src/components/__tests__/LiebeThemeProvider.test.tsx
@@ -61,7 +61,7 @@ describe('LiebeThemeProvider', () => {
 
   it('stamps the theming contract on the element the tokens are declared on', () => {
     const { container } = render(
-      <LiebeThemeProvider appearance="dark" themeId="lcars">
+      <LiebeThemeProvider appearance="dark" themeId={DEFAULT_THEME_ID}>
         <span />
       </LiebeThemeProvider>
     )
@@ -73,7 +73,7 @@ describe('LiebeThemeProvider', () => {
     const theme = getRootTheme(container)
     expect(theme.classList.contains('radix-themes')).toBe(true)
     expect(theme.classList.contains('liebe-root')).toBe(true)
-    expect(theme.getAttribute('data-liebe-theme')).toBe('lcars')
+    expect(theme.getAttribute('data-liebe-theme')).toBe(DEFAULT_THEME_ID)
     expect(theme.getAttribute('data-appearance')).toBe('dark')
   })
 
@@ -100,10 +100,11 @@ describe('LiebeThemeProvider', () => {
     expect(style?.textContent).toBe(getTheme(DEFAULT_THEME_ID)!.css)
   })
 
-  it('renders an unregistered theme id with the default theme’s CSS', () => {
+  it('renders an unregistered theme id as the default theme', () => {
     // An imported configuration naming a theme this build does not have must
-    // still be styled, not fall back to bare base tokens.
-    render(
+    // still be styled, not fall back to bare base tokens — and must not stamp
+    // a theme nothing is rendering.
+    const { container } = render(
       <LiebeThemeProvider themeId="from-a-newer-liebe">
         <span />
       </LiebeThemeProvider>
@@ -111,6 +112,7 @@ describe('LiebeThemeProvider', () => {
 
     const style = document.head.querySelector(THEME_STYLE_SELECTOR)
     expect(style?.textContent).toBe(getTheme(DEFAULT_THEME_ID)!.css)
+    expect(getRootTheme(container).getAttribute('data-liebe-theme')).toBe(DEFAULT_THEME_ID)
   })
 
   it('lifts the root Theme stacking while a camera overlay is open', () => {

--- a/src/components/__tests__/LiebeThemeProvider.test.tsx
+++ b/src/components/__tests__/LiebeThemeProvider.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render, act } from '@testing-library/react'
 import { LiebeThemeProvider } from '../LiebeThemeProvider'
 import {
@@ -6,6 +6,10 @@ import {
   enterCameraFullscreen,
   exitCameraFullscreen,
 } from '~/store/cameraFullscreenStore'
+import { THEME_STYLE_SLOT } from '~/theme/styleInjection'
+import { DEFAULT_THEME_ID, getTheme } from '~/theme/themeRegistry'
+
+const THEME_STYLE_SELECTOR = `style[data-liebe="${THEME_STYLE_SLOT}"]`
 
 function getRootTheme(container: HTMLElement): HTMLElement {
   return container.querySelector('[data-is-root-theme="true"]') as HTMLElement
@@ -14,6 +18,10 @@ function getRootTheme(container: HTMLElement): HTMLElement {
 describe('LiebeThemeProvider', () => {
   beforeEach(() => {
     cameraFullscreenStore.setState(() => 0)
+  })
+
+  afterEach(() => {
+    document.head.querySelectorAll(THEME_STYLE_SELECTOR).forEach((style) => style.remove())
   })
 
   it('renders children inside the root Radix Theme', () => {
@@ -49,6 +57,60 @@ describe('LiebeThemeProvider', () => {
     )
 
     expect(getRootTheme(container).classList.contains('light')).toBe(true)
+  })
+
+  it('stamps the theming contract on the element the tokens are declared on', () => {
+    const { container } = render(
+      <LiebeThemeProvider appearance="dark" themeId="lcars">
+        <span />
+      </LiebeThemeProvider>
+    )
+
+    // The stamps and the `--liebe-*` declarations have to meet on one element:
+    // a derived companion only re-derives where its base is overridden on the
+    // same element, so a theme rule keyed off a stamp anywhere else would leave
+    // tint and text behind on the old hue.
+    const theme = getRootTheme(container)
+    expect(theme.classList.contains('radix-themes')).toBe(true)
+    expect(theme.classList.contains('liebe-root')).toBe(true)
+    expect(theme.getAttribute('data-liebe-theme')).toBe('lcars')
+    expect(theme.getAttribute('data-appearance')).toBe('dark')
+  })
+
+  it('claims no appearance when none is given', () => {
+    const { container } = render(
+      <LiebeThemeProvider>
+        <span />
+      </LiebeThemeProvider>
+    )
+
+    const theme = getRootTheme(container)
+    expect(theme.hasAttribute('data-appearance')).toBe(false)
+    expect(theme.getAttribute('data-liebe-theme')).toBe(DEFAULT_THEME_ID)
+  })
+
+  it('injects the active theme as the theme layer of its root', () => {
+    render(
+      <LiebeThemeProvider>
+        <span />
+      </LiebeThemeProvider>
+    )
+
+    const style = document.head.querySelector(THEME_STYLE_SELECTOR)
+    expect(style?.textContent).toBe(getTheme(DEFAULT_THEME_ID)!.css)
+  })
+
+  it('renders an unregistered theme id with the default theme’s CSS', () => {
+    // An imported configuration naming a theme this build does not have must
+    // still be styled, not fall back to bare base tokens.
+    render(
+      <LiebeThemeProvider themeId="from-a-newer-liebe">
+        <span />
+      </LiebeThemeProvider>
+    )
+
+    const style = document.head.querySelector(THEME_STYLE_SELECTOR)
+    expect(style?.textContent).toBe(getTheme(DEFAULT_THEME_ID)!.css)
   })
 
   it('lifts the root Theme stacking while a camera overlay is open', () => {

--- a/src/components/__tests__/PanelApp.test.tsx
+++ b/src/components/__tests__/PanelApp.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
 import { render, act } from '@testing-library/react'
 import { PanelApp } from '../PanelApp'
 import {
@@ -6,6 +6,8 @@ import {
   enterCameraFullscreen,
   exitCameraFullscreen,
 } from '~/store/cameraFullscreenStore'
+import { dashboardStore } from '~/store/dashboardStore'
+import { DEFAULT_THEME_ID } from '~/theme/themeRegistry'
 
 // Render the router as an inert marker: this test only exercises PanelApp's
 // root-Theme stacking lift, not the routed app.
@@ -17,6 +19,25 @@ vi.mock('@tanstack/react-router', () => ({
 function getRootTheme(container: HTMLElement): HTMLElement {
   return container.querySelector('[data-is-root-theme="true"]') as HTMLElement
 }
+
+describe('PanelApp theming', () => {
+  afterEach(() => {
+    dashboardStore.setState((state) => ({ ...state, theme: 'auto' }))
+  })
+
+  it('renders the configured theme and the appearance it resolves to', () => {
+    dashboardStore.setState((state) => ({ ...state, theme: 'dark' }))
+
+    const { container } = render(<PanelApp />)
+
+    const theme = getRootTheme(container)
+    expect(theme.getAttribute('data-liebe-theme')).toBe(DEFAULT_THEME_ID)
+    // Resolved, not inherited: the panel drives Radix's appearance so the
+    // Radix-aliased tokens flip with the Liebe ones.
+    expect(theme.getAttribute('data-appearance')).toBe('dark')
+    expect(theme.classList.contains('dark')).toBe(true)
+  })
+})
 
 describe('PanelApp root-Theme stacking lift', () => {
   beforeEach(() => {

--- a/src/components/__tests__/PanelApp.test.tsx
+++ b/src/components/__tests__/PanelApp.test.tsx
@@ -7,6 +7,7 @@ import {
   exitCameraFullscreen,
 } from '~/store/cameraFullscreenStore'
 import { dashboardStore } from '~/store/dashboardStore'
+import { THEME_STYLE_SLOT } from '~/theme/styleInjection'
 import { DEFAULT_THEME_ID } from '~/theme/themeRegistry'
 
 // Render the router as an inert marker: this test only exercises PanelApp's
@@ -23,6 +24,11 @@ function getRootTheme(container: HTMLElement): HTMLElement {
 describe('PanelApp theming', () => {
   afterEach(() => {
     dashboardStore.setState((state) => ({ ...state, theme: 'auto' }))
+    // The theme layer belongs to the root, not to the React tree, so unmounting
+    // deliberately leaves it behind — this suite has to clear it itself.
+    document.head
+      .querySelectorAll(`style[data-liebe="${THEME_STYLE_SLOT}"]`)
+      .forEach((style) => style.remove())
   })
 
   it('renders the configured theme and the appearance it resolves to', () => {

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -21,17 +21,21 @@ declare global {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const Provider = HomeAssistantProvider as any
 
-// Import styles. Bundled into `liebe.css`, which connectedCallback links into
-// the shadow root — that is how the token contract reaches the panel. The
-// Storybook preview imports the same set at the preview-document level, so the
-// workshop and the panel render against identical styles; a test asserts the
-// two lists stay in sync (src/theme/__tests__/tokens.test.ts).
+// Import the baseline styles — the `liebe-base` layer. Bundled into
+// `liebe.css`, which connectedCallback links into the shadow root; the vendored
+// sheets among them are wrapped into the layer at build time
+// (vite/baselineCssPlugin.ts). That is how the token contract reaches the
+// panel. The Storybook preview imports the same set at the preview-document
+// level, so the workshop and the panel render against identical styles; a test
+// asserts the two lists stay in sync (src/theme/__tests__/tokens.test.ts).
+//
+// The theme layer is deliberately NOT among them: the active theme is injected
+// by LiebeThemeProvider from the registry, so it can be swapped live.
 import '@radix-ui/themes/styles.css'
 import 'react-grid-layout/css/styles.css'
 import 'react-resizable/css/styles.css'
 import '~/styles/app.css'
 import '~/styles/tokens.css'
-import '~/theme/themes/default.css'
 
 class LiebePanel extends HTMLElement {
   _hass: HomeAssistant | null = null

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,15 +1,15 @@
 /// <reference types="vite/client" />
 import { createRootRoute, Outlet, Scripts } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
-import { Theme } from '@radix-ui/themes'
 import '@radix-ui/themes/styles.css'
 import 'react-grid-layout/css/styles.css'
 import 'react-resizable/css/styles.css'
-import * as React from 'react'
 import { DefaultCatchBoundary } from '~/components/DefaultCatchBoundary'
+import { LiebeThemeProvider } from '~/components/LiebeThemeProvider'
 import { NotFound } from '~/components/NotFound'
 import { useHomeAssistantRouting, useIsHomeAssistant } from '~/hooks'
-import { useDashboardPersistence, useDashboardStore } from '~/store'
+import { useDashboardPersistence } from '~/store'
+import { useThemeSelection } from '~/theme/useThemeSelection'
 import '~/styles/app.css'
 
 export const Route = createRootRoute({
@@ -18,7 +18,21 @@ export const Route = createRootRoute({
   component: RootComponent,
 })
 
-function RootComponent() {
+/**
+ * The routed tree's own theme root.
+ *
+ * Standalone (the dev SPA) this is the only one; inside the panel it nests
+ * under `PanelApp`'s. Either way it is a `LiebeThemeProvider` reading the same
+ * `useThemeSelection`, which is what keeps the two in step: a plain Radix
+ * `Theme` here would re-declare every `--liebe-*` token on an element carrying
+ * none of the theming stamps, and a token override the user wrote against
+ * `.liebe-root` would then lose to the base sheet on this element (a
+ * declaration beats an inherited value, whatever the layer). It used to resolve
+ * the appearance a second time as well, from its own media-query state, which
+ * rendered light for one frame on a dark OS and ignored a theme's forced
+ * appearance.
+ */
+export function RootComponent() {
   // Enable persistence globally
   useDashboardPersistence()
 
@@ -28,44 +42,14 @@ function RootComponent() {
   // Check if we're running in Home Assistant
   const isInHomeAssistant = useIsHomeAssistant()
 
-  // Get theme from dashboard store
-  const theme = useDashboardStore((state) => state.theme)
-  const [systemPrefersDark, setSystemPrefersDark] = React.useState(false)
-
-  // Listen for system theme changes
-  React.useEffect(() => {
-    if (theme !== 'auto' || typeof window === 'undefined') return
-
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-    setSystemPrefersDark(mediaQuery.matches)
-
-    const handler = (e: MediaQueryListEvent) => {
-      setSystemPrefersDark(e.matches)
-    }
-
-    mediaQuery.addEventListener('change', handler)
-    return () => mediaQuery.removeEventListener('change', handler)
-  }, [theme])
-
-  // Determine the appearance based on theme setting
-  const getAppearance = () => {
-    if (theme === 'light' || theme === 'dark') {
-      return theme
-    }
-    // For 'auto', use system preference
-    if (theme === 'auto') {
-      return systemPrefersDark ? 'dark' : 'light'
-    }
-    // Default to light
-    return 'light'
-  }
+  const { themeId, appearance } = useThemeSelection()
 
   return (
     <>
-      <Theme appearance={getAppearance()}>
+      <LiebeThemeProvider themeId={themeId} appearance={appearance}>
         <Outlet />
         {!isInHomeAssistant && <TanStackRouterDevtools position="bottom-right" />}
-      </Theme>
+      </LiebeThemeProvider>
       <Scripts />
     </>
   )

--- a/src/routes/__tests__/__root.test.tsx
+++ b/src/routes/__tests__/__root.test.tsx
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { dashboardStore } from '~/store/dashboardStore'
+import { DEFAULT_THEME_ID } from '~/theme/themeRegistry'
+
+// The route module is a router shell: `createRootRoute` and `Scripts` need a
+// router, and the devtools pull a dev-only bundle. Stubbing them leaves the
+// component itself — the theme root — as the thing under test.
+vi.mock('@tanstack/react-router', () => ({
+  createRootRoute: (options: unknown) => ({ options }),
+  Outlet: () => <div data-testid="outlet" />,
+  Scripts: () => null,
+}))
+vi.mock('@tanstack/react-router-devtools', () => ({
+  TanStackRouterDevtools: () => <div data-testid="devtools" />,
+}))
+vi.mock('~/hooks', () => ({
+  useHomeAssistantRouting: vi.fn(),
+  useIsHomeAssistant: () => true,
+}))
+vi.mock('~/store', () => ({ useDashboardPersistence: vi.fn() }))
+
+const { RootComponent } = await import('../__root')
+
+describe('RootComponent', () => {
+  afterEach(() => {
+    dashboardStore.setState((state) => ({ ...state, theme: 'auto' }))
+  })
+
+  it('renders the routed tree inside a stamped Liebe theme root', () => {
+    dashboardStore.setState((state) => ({ ...state, theme: 'dark' }))
+
+    const { container, getByTestId } = render(<RootComponent />)
+
+    // Nested under the panel's provider, standalone in the dev SPA — either
+    // way it has to be a Liebe theme root, or a user token override written
+    // against `.liebe-root` loses to the base sheet on this element.
+    const theme = container.querySelector('.radix-themes') as HTMLElement
+    expect(theme.classList.contains('liebe-root')).toBe(true)
+    expect(theme.getAttribute('data-liebe-theme')).toBe(DEFAULT_THEME_ID)
+    expect(theme.getAttribute('data-appearance')).toBe('dark')
+    expect(theme.contains(getByTestId('outlet'))).toBe(true)
+  })
+})

--- a/src/routes/__tests__/__root.test.tsx
+++ b/src/routes/__tests__/__root.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@testing-library/react'
 import { dashboardStore } from '~/store/dashboardStore'
+import { THEME_STYLE_SLOT } from '~/theme/styleInjection'
 import { DEFAULT_THEME_ID } from '~/theme/themeRegistry'
 
 // The route module is a router shell: `createRootRoute` and `Scripts` need a
@@ -25,6 +26,11 @@ const { RootComponent } = await import('../__root')
 describe('RootComponent', () => {
   afterEach(() => {
     dashboardStore.setState((state) => ({ ...state, theme: 'auto' }))
+    // The theme layer outlives the tree that injected it (it belongs to the
+    // root), so it is this suite's to clear.
+    document.head
+      .querySelectorAll(`style[data-liebe="${THEME_STYLE_SLOT}"]`)
+      .forEach((style) => style.remove())
   })
 
   it('renders the routed tree inside a stamped Liebe theme root', () => {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -37,16 +37,47 @@
       'Helvetica Neue',
       Arial,
       sans-serif;
-    background-color: #fafafa;
-    color: #333;
   }
 
-  @media (prefers-color-scheme: dark) {
-    html,
-    body {
-      background-color: #0a0a0a;
-      color: #e5e5e5;
-    }
+  /*
+   * The dashboard ground.
+   *
+   * Painted here, on the Liebe theme root, and deliberately NOT on `html` /
+   * `body`. `--liebe-bg` and `--liebe-fg` are declared on `.radix-themes`
+   * (src/styles/tokens.css) because every surface token aliases a Radix token
+   * that exists only there, and a `var()` inside a custom property substitutes
+   * at the element that declares it. `html` and `body` are ANCESTORS of that
+   * element, so no `var()` on them can reach the tokens — custom properties
+   * inherit down, never up.
+   *
+   * The colour literals that used to sit on `html`/`body` were the cost of
+   * that: a second source of truth for the ground, outside the token contract
+   * and so unreachable by both themes and user CSS, and gated on
+   * `prefers-color-scheme` rather than on the appearance the panel actually
+   * resolves. Any disagreement between the two — an explicit `dark` setting on
+   * a light OS, a `dark-only` theme, a future Home Assistant darkness signal —
+   * put a near-white page behind a dark dashboard.
+   *
+   * Whatever the root does not cover (overscroll, and the moment before React
+   * mounts) is the UA canvas, which follows `color-scheme`. That stays correct
+   * without a literal: Radix propagates the root theme's appearance up to
+   * `:root`'s `color-scheme` with its own `:has()` rule, so the canvas follows
+   * the resolved appearance too.
+   *
+   * `background`, not `background-color`: a theme MAY set `--liebe-bg` to
+   * wallpaper rather than a flat colour (docs/specs/theming — Liquid Glass is a
+   * layered radial-gradient mesh), which `background-color` could not accept.
+   *
+   * Both classes are named to clear Radix's own `.radix-themes:where([data-
+   * has-background='true'])`, which is what painted the ground before and would
+   * otherwise put `--color-background` — plain white in light, where the card
+   * token is also white — over the ground the contract defines. The nested
+   * theme root the router mounts carries `liebe-root` too, so it grounds
+   * itself in the same token instead of covering its parent.
+   */
+  .radix-themes.liebe-root {
+    background: var(--liebe-bg);
+    color: var(--liebe-fg);
   }
 
   /* Responsive CSS Variables */

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,17 +1,17 @@
 /*
  * Basic CSS reset and defaults.
  *
- * The reset is layered; the rest of this sheet is not (yet — wrapping all
- * baseline CSS into `liebe-base` is change 0012, per docs/specs/theming
- * "Application mechanism"). Layered is what the reset has to be for any other
- * layered stylesheet to set padding or margin at all: an unlayered author rule
- * outranks every cascade layer regardless of selector specificity, so an
- * unlayered `* { padding: 0 }` silently zeroed the padding of every layered
- * rule — the card anatomy's chips and pills among them.
+ * The whole sheet is layered into `liebe-base`. An unlayered author rule
+ * outranks every cascade layer regardless of selector specificity, so anything
+ * left outside a layer here would be baseline styling no theme and no user CSS
+ * could reach (docs/specs/theming — "Application mechanism"). The reset and the
+ * touch-target floor were layered first, by change 0010, because an unlayered
+ * `* { padding: 0 }` silently zeroed the padding of every layered rule — the
+ * card anatomy's chips and pills among them; change 0012 finished the sheet.
  *
- * Moving it into the layer costs nothing else: at zero specificity this rule
- * already lost to every other author rule in the panel, and it still outranks
- * the user-agent defaults it exists to normalise, since origin beats layering.
+ * Layering costs the reset nothing else: at zero specificity it already lost to
+ * every other author rule in the panel, and it still outranks the user-agent
+ * defaults it exists to normalise, since origin beats layering.
  */
 @layer liebe-base, liebe-theme, liebe-user;
 
@@ -21,167 +21,161 @@
     margin: 0;
     padding: 0;
   }
-}
 
-html {
-  color-scheme: light dark;
-}
+  html {
+    color-scheme: light dark;
+  }
 
-html,
-body {
-  font-family:
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    Roboto,
-    'Helvetica Neue',
-    Arial,
-    sans-serif;
-  background-color: #fafafa;
-  color: #333;
-}
-
-@media (prefers-color-scheme: dark) {
   html,
   body {
-    background-color: #0a0a0a;
-    color: #e5e5e5;
+    font-family:
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      'Segoe UI',
+      Roboto,
+      'Helvetica Neue',
+      Arial,
+      sans-serif;
+    background-color: #fafafa;
+    color: #333;
   }
-}
 
-.using-mouse * {
-  outline: none !important;
-}
-
-/* Responsive CSS Variables */
-:root {
-  /* Spacing Scale */
-  --spacing-xs: 4px;
-  --spacing-sm: 8px;
-  --spacing-md: 12px;
-  --spacing-lg: 16px;
-  --spacing-xl: 20px;
-  --spacing-2xl: 24px;
-  --spacing-3xl: 32px;
-  --spacing-4xl: 48px;
-
-  /* Touch Target Sizes */
-  --touch-target-min: 44px;
-
-  /* Container Padding */
-  --container-padding: var(--spacing-lg);
-
-  /* Grid Margins */
-  --grid-margin: var(--spacing-lg);
-
-  /* Header Height */
-  --header-height: 64px;
-
-  /* Sidebar Width */
-  --sidebar-width: 320px;
-
-  /* Z-index Scale */
-  --z-header: 10;
-  --z-sticky: 15;
-  --z-sidebar: 20;
-  --z-modal-backdrop: 50;
-  --z-modal: 60;
-  --z-tooltip: 100;
-}
-
-/* Mobile-specific variables */
-@media (max-width: 767px) {
-  :root {
-    --container-padding: var(--spacing-sm);
-    --grid-margin: var(--spacing-sm);
-    --header-height: 56px;
-    --sidebar-width: 100vw;
+  @media (prefers-color-scheme: dark) {
+    html,
+    body {
+      background-color: #0a0a0a;
+      color: #e5e5e5;
+    }
   }
-}
 
-/* Tablet-specific variables */
-@media (min-width: 768px) and (max-width: 1023px) {
+  /* Responsive CSS Variables */
   :root {
-    --container-padding: var(--spacing-md);
-    --grid-margin: var(--spacing-md);
-    --sidebar-width: 280px;
-  }
-}
+    /* Spacing Scale */
+    --spacing-xs: 4px;
+    --spacing-sm: 8px;
+    --spacing-md: 12px;
+    --spacing-lg: 16px;
+    --spacing-xl: 20px;
+    --spacing-2xl: 24px;
+    --spacing-3xl: 32px;
+    --spacing-4xl: 48px;
 
-/* Desktop and up */
-@media (min-width: 1024px) {
-  :root {
-    --sidebar-width: 320px;
-  }
-}
+    /* Touch Target Sizes */
+    --touch-target-min: 44px;
 
-/* Wide screens */
-@media (min-width: 1440px) {
-  :root {
-    --container-padding: var(--spacing-xl);
+    /* Container Padding */
+    --container-padding: var(--spacing-lg);
+
+    /* Grid Margins */
     --grid-margin: var(--spacing-lg);
-    --sidebar-width: 360px;
+
+    /* Header Height */
+    --header-height: 64px;
+
+    /* Sidebar Width */
+    --sidebar-width: 320px;
+
+    /* Z-index Scale */
+    --z-header: 10;
+    --z-sticky: 15;
+    --z-sidebar: 20;
+    --z-modal-backdrop: 50;
+    --z-modal: 60;
+    --z-tooltip: 100;
   }
-}
 
-/* Utility Classes */
-.mobile-only {
-  display: none;
-}
+  /* Mobile-specific variables */
+  @media (max-width: 767px) {
+    :root {
+      --container-padding: var(--spacing-sm);
+      --grid-margin: var(--spacing-sm);
+      --header-height: 56px;
+      --sidebar-width: 100vw;
+    }
+  }
 
-.tablet-up {
-  display: initial;
-}
+  /* Tablet-specific variables */
+  @media (min-width: 768px) and (max-width: 1023px) {
+    :root {
+      --container-padding: var(--spacing-md);
+      --grid-margin: var(--spacing-md);
+      --sidebar-width: 280px;
+    }
+  }
 
-.desktop-up {
-  display: initial;
-}
+  /* Desktop and up */
+  @media (min-width: 1024px) {
+    :root {
+      --sidebar-width: 320px;
+    }
+  }
 
-@media (max-width: 767px) {
+  /* Wide screens */
+  @media (min-width: 1440px) {
+    :root {
+      --container-padding: var(--spacing-xl);
+      --grid-margin: var(--spacing-lg);
+      --sidebar-width: 360px;
+    }
+  }
+
+  /* Utility Classes */
   .mobile-only {
-    display: initial;
+    display: none;
   }
 
   .tablet-up {
-    display: none;
+    display: initial;
   }
 
   .desktop-up {
-    display: none;
-  }
-}
-
-@media (min-width: 768px) and (max-width: 1023px) {
-  .mobile-only {
-    display: none;
+    display: initial;
   }
 
-  .desktop-up {
-    display: none;
+  @media (max-width: 767px) {
+    .mobile-only {
+      display: initial;
+    }
+
+    .tablet-up {
+      display: none;
+    }
+
+    .desktop-up {
+      display: none;
+    }
   }
-}
 
-/* Responsive Typography */
-.responsive-text {
-  font-size: clamp(0.875rem, 2vw, 1rem);
-}
+  @media (min-width: 768px) and (max-width: 1023px) {
+    .mobile-only {
+      display: none;
+    }
 
-.responsive-heading {
-  font-size: clamp(1.25rem, 3vw, 1.5rem);
-}
+    .desktop-up {
+      display: none;
+    }
+  }
 
-/*
- * Touch-friendly tap targets.
- *
- * Layered for the same reason as the reset above: unlayered, this floor
- * outranks every layered rule and so restyles rather than merely enlarges a
- * component that states its own size from a token — it would stretch the
- * anatomy's 34px chip past `--liebe-chip-height`, i.e. beat a token. Layered,
- * it still applies everywhere nothing more specific declares a minimum, which
- * is every control it was written for.
- */
-@layer liebe-base {
+  /* Responsive Typography */
+  .responsive-text {
+    font-size: clamp(0.875rem, 2vw, 1rem);
+  }
+
+  .responsive-heading {
+    font-size: clamp(1.25rem, 3vw, 1.5rem);
+  }
+
+  /*
+   * Touch-friendly tap targets.
+   *
+   * Layered for the same reason as the reset above: unlayered, this floor
+   * outranks every layered rule and so restyles rather than merely enlarges a
+   * component that states its own size from a token — it would stretch the
+   * anatomy's 34px chip past `--liebe-chip-height`, i.e. beat a token. Layered,
+   * it still applies everywhere nothing more specific declares a minimum, which
+   * is every control it was written for.
+   */
   @media (pointer: coarse) {
     button,
     [role='button'],
@@ -193,70 +187,70 @@ body {
       min-width: var(--touch-target-min);
     }
   }
-}
 
-/* Radix UI Slider Styles */
-.SliderRoot {
-  position: relative;
-  display: flex;
-  align-items: center;
-  user-select: none;
-  touch-action: none;
-  width: 100%;
-  height: 20px;
-}
-
-.SliderTrack {
-  background-color: var(--gray-6);
-  position: relative;
-  flex-grow: 1;
-  border-radius: 9999px;
-  height: 3px;
-}
-
-.SliderRange {
-  position: absolute;
-  background-color: var(--amber-9);
-  border-radius: 9999px;
-  height: 100%;
-}
-
-.SliderThumb {
-  display: block;
-  width: 20px;
-  height: 20px;
-  background-color: white;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.14);
-  border-radius: 10px;
-  outline: none;
-}
-
-.SliderThumb:hover {
-  background-color: var(--gray-1);
-}
-
-.SliderThumb:focus {
-  box-shadow: 0 0 0 5px rgba(0, 0, 0, 0.08);
-}
-
-/* Fan spinning animations */
-@keyframes fan-spin {
-  from {
-    transform: rotate(0deg);
+  /* Radix UI Slider Styles */
+  .SliderRoot {
+    position: relative;
+    display: flex;
+    align-items: center;
+    user-select: none;
+    touch-action: none;
+    width: 100%;
+    height: 20px;
   }
-  to {
-    transform: rotate(360deg);
+
+  .SliderTrack {
+    background-color: var(--gray-6);
+    position: relative;
+    flex-grow: 1;
+    border-radius: 9999px;
+    height: 3px;
   }
-}
 
-.fan-spin-slow {
-  animation: fan-spin 3s linear infinite;
-}
+  .SliderRange {
+    position: absolute;
+    background-color: var(--amber-9);
+    border-radius: 9999px;
+    height: 100%;
+  }
 
-.fan-spin-medium {
-  animation: fan-spin 1.5s linear infinite;
-}
+  .SliderThumb {
+    display: block;
+    width: 20px;
+    height: 20px;
+    background-color: white;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.14);
+    border-radius: 10px;
+    outline: none;
+  }
 
-.fan-spin-fast {
-  animation: fan-spin 0.75s linear infinite;
+  .SliderThumb:hover {
+    background-color: var(--gray-1);
+  }
+
+  .SliderThumb:focus {
+    box-shadow: 0 0 0 5px rgba(0, 0, 0, 0.08);
+  }
+
+  /* Fan spinning animations */
+  @keyframes fan-spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  .fan-spin-slow {
+    animation: fan-spin 3s linear infinite;
+  }
+
+  .fan-spin-medium {
+    animation: fan-spin 1.5s linear infinite;
+  }
+
+  .fan-spin-fast {
+    animation: fan-spin 0.75s linear infinite;
+  }
 }

--- a/src/theme/__tests__/appearance.test.ts
+++ b/src/theme/__tests__/appearance.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { resolveAppearancePreference, resolveThemeAppearance } from '../appearance'
+import type { ThemeDefinition } from '../themeRegistry'
+
+const theme = (appearances: ThemeDefinition['appearances']): ThemeDefinition => ({
+  id: 'test',
+  label: 'Test',
+  appearances,
+  css: '',
+})
+
+describe('resolveAppearancePreference', () => {
+  it.each(['dark', 'light'] as const)('honours an explicit %s', (preference) => {
+    expect(resolveAppearancePreference(preference, { prefersDark: preference === 'light' })).toBe(
+      preference
+    )
+  })
+
+  it.each([
+    [true, 'dark'],
+    [false, 'light'],
+  ] as const)('follows prefers-color-scheme (dark: %s) on auto', (prefersDark, expected) => {
+    expect(resolveAppearancePreference('auto', { prefersDark })).toBe(expected)
+  })
+
+  it.each([
+    [true, 'dark'],
+    [false, 'light'],
+  ] as const)('prefers the host’s darkness (%s) when it is known', (hostDark, expected) => {
+    // The hook for HA theme darkness: the panel should look dark when the
+    // frontend around it is dark, whatever the OS says.
+    expect(resolveAppearancePreference('auto', { prefersDark: !hostDark, hostDark })).toBe(expected)
+  })
+})
+
+describe('resolveThemeAppearance', () => {
+  it('lets a both-appearance theme render what was asked for', () => {
+    expect(resolveThemeAppearance(theme('both'), 'auto', { prefersDark: true })).toBe('dark')
+  })
+
+  it.each([
+    ['dark-only', 'light', 'dark'],
+    ['light-only', 'dark', 'light'],
+  ] as const)('forces the appearance a %s theme provides', (appearances, preference, expected) => {
+    expect(resolveThemeAppearance(theme(appearances), preference, { prefersDark: false })).toBe(
+      expected
+    )
+  })
+
+  it('resolves against the environment when no theme is registered', () => {
+    expect(resolveThemeAppearance(undefined, 'auto', { prefersDark: true })).toBe('dark')
+  })
+})

--- a/src/theme/__tests__/cssLayers.test.ts
+++ b/src/theme/__tests__/cssLayers.test.ts
@@ -152,6 +152,16 @@ describe('wrapInLayer', () => {
     expect(wrapped).toContain(`@layer ${BASE_LAYER} {`)
   })
 
+  it('gives a layered sheet the order statement it is missing', () => {
+    // Layered but silent about the order: injected into a root where nothing
+    // else declares it, the layer would sort by first use instead.
+    const wrapped = wrapInLayer('@layer liebe-theme { .a { color: red } }', BASE_LAYER)
+
+    expect(wrapped.startsWith(LAYER_ORDER_STATEMENT)).toBe(true)
+    expect(wrapped).toContain('@layer liebe-theme { .a { color: red } }')
+    expect(wrapped).not.toContain(`@layer ${BASE_LAYER} {`)
+  })
+
   it('leaves a sheet that declares its own layers untouched', () => {
     // Liebe's own sheets are authored inside their layer; re-wrapping would
     // nest them (`liebe-base.liebe-theme`) and break the order.

--- a/src/theme/__tests__/cssLayers.test.ts
+++ b/src/theme/__tests__/cssLayers.test.ts
@@ -108,6 +108,35 @@ describe('stripThemableImportance', () => {
 
     expect(stripThemableImportance(css)).toBe(css)
   })
+
+  /*
+   * `!important` is a priority only at the end of its own declaration.
+   * Anywhere else — inside a quoted string, inside a `url()` — it is ordinary
+   * text, and rewriting it corrupts CSS that never asked for importance. Each
+   * of these is on a THEMABLE property, so the stripper does reach the
+   * declaration and the assertion is about what it does once there. It stops
+   * being hypothetical the moment the custom-CSS editor feeds user input
+   * through here.
+   */
+  it.each([
+    ['a double-quoted custom-property value', '.a { --label: "not !important"; }'],
+    ['a single-quoted custom-property value', ".a { --label: 'not !important'; }"],
+    ['a quoted url()', '.a { background-image: url("not-!important.png"); }'],
+    ['an unquoted url()', '.a { background: url(not-!important.png) no-repeat; }'],
+    ['a quoted font family', '.a { font-family: "Not !important", sans-serif; }'],
+  ])('leaves !important inside %s alone', (_case, css) => {
+    expect(stripThemableImportance(css)).toBe(css)
+  })
+
+  it('still strips a real priority from a value that quotes the word first', () => {
+    const css = '.a { background-image: url("not-!important.png") !important; }'
+
+    expect(stripThemableImportance(css)).toBe('.a { background-image: url("not-!important.png"); }')
+  })
+
+  it('strips a priority the sheet ends on, with no terminator after it', () => {
+    expect(stripThemableImportance('.a { color: red !important')).toBe('.a { color: red')
+  })
 })
 
 describe('isFullyLayered', () => {

--- a/src/theme/__tests__/cssLayers.test.ts
+++ b/src/theme/__tests__/cssLayers.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import {
   BASE_LAYER,
   LAYER_ORDER_STATEMENT,
+  isFullyLayered,
   isThemableProperty,
   prepareBaselineCss,
   stripThemableImportance,
@@ -109,12 +110,46 @@ describe('stripThemableImportance', () => {
   })
 })
 
+describe('isFullyLayered', () => {
+  it('accepts a sheet whose every rule is inside a layer', () => {
+    expect(
+      isFullyLayered(`${LAYER_ORDER_STATEMENT}\n@layer liebe-base {\n.a { color: red }\n}\n`)
+    ).toBe(true)
+  })
+
+  it('accepts a leading @charset ahead of the layer', () => {
+    expect(isFullyLayered('@charset "utf-8";@layer liebe-base { .a { color: red } }')).toBe(true)
+  })
+
+  it.each([
+    // The order statement alone declares an order and layers nothing.
+    ['an order statement with unlayered rules', `${LAYER_ORDER_STATEMENT}\n.a { color: red }`],
+    ['a partially layered sheet', '@layer liebe-base { .a { color: red } }\n.b { color: blue }'],
+    ['a comment that merely mentions @layer', '/* @layer liebe-base */\n.a { color: red }'],
+    ['a top-level at-rule that is not a layer', '@media print { .a { color: red } }'],
+    ['a statement that is neither @layer nor @charset', "@import url('x.css');"],
+    ['an unbalanced closing brace', '@layer liebe-base { .a { color: red } } }'],
+    ['an unclosed rule', '@layer liebe-base { .a { color: red }'],
+    ['a declaration floating at the top level', 'color: red'],
+  ])('rejects %s', (_case, css) => {
+    expect(isFullyLayered(css)).toBe(false)
+  })
+})
+
 describe('wrapInLayer', () => {
   it('wraps an unlayered sheet and declares the layer order', () => {
     const wrapped = wrapInLayer('.a { color: red }', BASE_LAYER)
 
     expect(wrapped).toContain(LAYER_ORDER_STATEMENT)
     expect(wrapped).toContain(`@layer ${BASE_LAYER} {\n.a { color: red }\n}`)
+  })
+
+  it('wraps a sheet that declares the layer order but layers nothing', () => {
+    // Mentioning `@layer` is not being layered: these rules would still
+    // outrank every layer.
+    const wrapped = wrapInLayer(`${LAYER_ORDER_STATEMENT}\n.a { color: red }`, BASE_LAYER)
+
+    expect(wrapped).toContain(`@layer ${BASE_LAYER} {`)
   })
 
   it('leaves a sheet that declares its own layers untouched', () => {

--- a/src/theme/__tests__/cssLayers.test.ts
+++ b/src/theme/__tests__/cssLayers.test.ts
@@ -1,0 +1,180 @@
+import { createRequire } from 'node:module'
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import {
+  BASE_LAYER,
+  LAYER_ORDER_STATEMENT,
+  isThemableProperty,
+  prepareBaselineCss,
+  stripThemableImportance,
+  wrapInLayer,
+} from '../cssLayers'
+
+/**
+ * The layer contract, asserted on the text the panel actually ships: the
+ * transforms are what stand between an unlayered vendored stylesheet and a
+ * theme that cannot override it (docs/specs/theming — "Application mechanism").
+ */
+
+const require = createRequire(import.meta.url)
+
+/** A vendored stylesheet exactly as the panel imports it. */
+function readVendored(specifier: string): string {
+  return readFileSync(require.resolve(specifier), 'utf8')
+}
+
+const vendoredSheets = {
+  '@radix-ui/themes/styles.css': readVendored('@radix-ui/themes/styles.css'),
+  'react-grid-layout/css/styles.css': readVendored('react-grid-layout/css/styles.css'),
+  'react-resizable/css/styles.css': readVendored('react-resizable/css/styles.css'),
+}
+
+/** Every `property: value !important` declaration left in a sheet. */
+function importantProperties(css: string): string[] {
+  return [...css.matchAll(/([;{]\s*|^\s*)(--[\w-]+|[-\w]+)\s*:[^;{}]*?!\s*important/gi)].map(
+    ([, , property]) => property.toLowerCase()
+  )
+}
+
+describe('themable properties', () => {
+  it.each([
+    'color',
+    'background',
+    'background-image',
+    'border',
+    'border-top-color',
+    'border-radius',
+    'box-shadow',
+    'font',
+    'font-family',
+    'letter-spacing',
+    'text-transform',
+    'outline',
+    'all',
+    // The token channel itself: an important token in the baseline would pin a
+    // value beyond the reach of both later layers.
+    '--liebe-card-bg',
+  ])('counts %s as governed by the token contract', (property) => {
+    expect(isThemableProperty(property)).toBe(true)
+  })
+
+  it.each([
+    'display',
+    'visibility',
+    'pointer-events',
+    'user-select',
+    '-webkit-user-select',
+    'cursor',
+    'animation',
+    'box-decoration-break',
+    'width',
+    'position',
+    // Prefix families must not match a merely similar name.
+    'bordering',
+    'fontastic',
+  ])('leaves %s to the component', (property) => {
+    expect(isThemableProperty(property)).toBe(false)
+  })
+
+  it('ignores case and surrounding whitespace', () => {
+    expect(isThemableProperty(' Color ')).toBe(true)
+  })
+})
+
+describe('stripThemableImportance', () => {
+  it('drops importance from themable declarations', () => {
+    const css = '.a { color: red !important; background: blue !important; }'
+
+    expect(stripThemableImportance(css)).toBe('.a { color: red; background: blue; }')
+  })
+
+  it('keeps importance on behavioural declarations', () => {
+    // Radix's ScrollArea and Skeleton rules: nothing a theme overrides, and
+    // stripping them breaks scroll layout and loading states.
+    const css = '.rt-ScrollAreaViewport > * { display: block !important; }'
+
+    expect(stripThemableImportance(css)).toBe(css)
+  })
+
+  it('handles a themable declaration first in its rule and odd spellings', () => {
+    const css = '.a{COLOR: red ! IMPORTANT;display:block !important}'
+
+    expect(stripThemableImportance(css)).toBe('.a{COLOR: red;display:block !important}')
+  })
+
+  it('leaves a declaration in a following rule alone', () => {
+    const css = '.a { width: 1px } .b { display: flex !important }'
+
+    expect(stripThemableImportance(css)).toBe(css)
+  })
+})
+
+describe('wrapInLayer', () => {
+  it('wraps an unlayered sheet and declares the layer order', () => {
+    const wrapped = wrapInLayer('.a { color: red }', BASE_LAYER)
+
+    expect(wrapped).toContain(LAYER_ORDER_STATEMENT)
+    expect(wrapped).toContain(`@layer ${BASE_LAYER} {\n.a { color: red }\n}`)
+  })
+
+  it('leaves a sheet that declares its own layers untouched', () => {
+    // Liebe's own sheets are authored inside their layer; re-wrapping would
+    // nest them (`liebe-base.liebe-theme`) and break the order.
+    const authored = `${LAYER_ORDER_STATEMENT}\n@layer liebe-theme {\n.a { color: red }\n}\n`
+
+    expect(wrapInLayer(authored, BASE_LAYER)).toBe(authored)
+  })
+
+  it('keeps a leading @charset ahead of the wrapper', () => {
+    // `@charset` is only honoured as the very first thing in a sheet.
+    const wrapped = wrapInLayer('@charset "utf-8";\n.a { color: red }', BASE_LAYER)
+
+    expect(wrapped.startsWith('@charset "utf-8";')).toBe(true)
+    expect(wrapped).toContain(`@layer ${BASE_LAYER} {`)
+    expect(wrapped).not.toContain('@charset "utf-8";\n.a')
+  })
+})
+
+describe('prepareBaselineCss', () => {
+  it('layers and de-emphasises in one pass', () => {
+    const prepared = prepareBaselineCss('.a { color: red !important; display: block !important }')
+
+    expect(prepared).toContain(`@layer ${BASE_LAYER} {`)
+    expect(prepared).toContain('color: red;')
+    expect(prepared).toContain('display: block !important')
+  })
+})
+
+describe('the vendored stylesheets as they ship', () => {
+  it.each(Object.entries(vendoredSheets))(
+    '%s lands in the base layer with no themable importance',
+    (_specifier, css) => {
+      const prepared = prepareBaselineCss(css)
+
+      expect(prepared).toContain(LAYER_ORDER_STATEMENT)
+      expect(prepared).toContain(`@layer ${BASE_LAYER} {`)
+      expect(importantProperties(prepared).filter(isThemableProperty)).toEqual([])
+    }
+  )
+
+  it('preserves the behavioural importance Radix depends on', () => {
+    const prepared = prepareBaselineCss(vendoredSheets['@radix-ui/themes/styles.css'])
+
+    // The ScrollArea viewport and the Skeleton mask: overriding these is not
+    // theming, it is breaking the component.
+    expect(prepared).toContain('display: block !important')
+    expect(prepared).toContain('visibility: hidden !important')
+    expect(prepared).toContain('pointer-events: none !important')
+  })
+
+  it.each(Object.entries(vendoredSheets))(
+    '%s contains no @import, which a layer wrapper would invalidate',
+    (_specifier, css) => {
+      // `@import` is only valid at the top of a sheet, so a dependency that
+      // starts using one would break silently inside the wrapper. Fail here
+      // instead, where the fix (hoisting it as `@import … layer(liebe-base)`)
+      // is obvious.
+      expect(css).not.toMatch(/@import\b/)
+    }
+  )
+})

--- a/src/theme/__tests__/styleInjection.test.ts
+++ b/src/theme/__tests__/styleInjection.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { LAYER_ORDER_STATEMENT, THEME_LAYER } from '../cssLayers'
+import {
+  applyThemeCss,
+  applyThemeCssToRootOf,
+  isStyleRoot,
+  THEME_STYLE_SLOT,
+} from '../styleInjection'
+
+const SLOT_SELECTOR = `style[data-liebe="${THEME_STYLE_SLOT}"]`
+
+function shadowRoot(): ShadowRoot {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  return host.attachShadow({ mode: 'open' })
+}
+
+afterEach(() => {
+  document.head.querySelectorAll(SLOT_SELECTOR).forEach((style) => style.remove())
+  document.body.replaceChildren()
+})
+
+describe('isStyleRoot', () => {
+  it('accepts the roots a Liebe tree can be mounted in', () => {
+    expect(isStyleRoot(document)).toBe(true)
+    expect(isStyleRoot(shadowRoot())).toBe(true)
+  })
+
+  it('rejects anything else', () => {
+    // What `getRootNode()` returns for a detached tree — there is nowhere to
+    // inject a theme, and the panel must not throw over it.
+    expect(isStyleRoot(document.createElement('div'))).toBe(false)
+    expect(isStyleRoot(null)).toBe(false)
+  })
+})
+
+describe('applyThemeCss', () => {
+  it('injects the theme layer into a shadow root', () => {
+    const root = shadowRoot()
+
+    applyThemeCss(root, '@layer liebe-theme { .a { color: red } }')
+
+    const style = root.querySelector(SLOT_SELECTOR)
+    expect(style?.parentNode).toBe(root)
+    expect(style?.textContent).toContain('@layer liebe-theme { .a { color: red } }')
+  })
+
+  it('injects into the head of a document root', () => {
+    applyThemeCss(document, '@layer liebe-theme { .a { color: red } }')
+
+    expect(document.head.querySelector(SLOT_SELECTOR)).not.toBeNull()
+  })
+
+  it('rewrites the same element on a theme switch', () => {
+    const root = shadowRoot()
+
+    const first = applyThemeCss(root, '@layer liebe-theme { .a { color: red } }')
+    const second = applyThemeCss(root, '@layer liebe-theme { .a { color: blue } }')
+
+    // Stacking sheets would make precedence depend on insertion order, and
+    // would leave the outgoing theme's rules in the root.
+    expect(second).toBe(first)
+    expect(root.querySelectorAll(SLOT_SELECTOR)).toHaveLength(1)
+    expect(first.textContent).toContain('color: blue')
+    expect(first.textContent).not.toContain('color: red')
+  })
+
+  it('leaves the element alone when the CSS has not changed', () => {
+    const root = shadowRoot()
+    const css = '@layer liebe-theme { .a { color: red } }'
+
+    const style = applyThemeCss(root, css)
+    const before = style.textContent
+    applyThemeCss(root, css)
+
+    expect(style.textContent).toBe(before)
+  })
+
+  it('finds the root of a node inside a shadow tree, and mirrors it for portals', () => {
+    const root = shadowRoot()
+    const child = document.createElement('div')
+    root.appendChild(child)
+
+    const style = applyThemeCssToRootOf(child, '@layer liebe-theme { .a { color: red } }')
+
+    expect(style?.parentNode).toBe(root)
+    // Radix dialogs portal to `document.body`, outside the shadow root and its
+    // layers; without the mirror they would render off the active palette.
+    expect(document.head.querySelector(SLOT_SELECTOR)?.textContent).toBe(style?.textContent)
+  })
+
+  it('does not mirror when the tree already lives in the document', () => {
+    const child = document.createElement('div')
+    document.body.appendChild(child)
+
+    applyThemeCssToRootOf(child, '@layer liebe-theme { .a { color: red } }')
+
+    expect(document.head.querySelectorAll(SLOT_SELECTOR)).toHaveLength(1)
+  })
+
+  it('does nothing for a node that is in no root yet', () => {
+    // A tree rendered into a detached container, or one mid-mount: there is
+    // nowhere to hold a stylesheet, and that must not throw.
+    expect(applyThemeCssToRootOf(document.createElement('div'), '.a {}')).toBeNull()
+    expect(applyThemeCssToRootOf(null, '.a {}')).toBeNull()
+    expect(document.head.querySelector(SLOT_SELECTOR)).toBeNull()
+  })
+
+  it('layers a theme payload that forgot its own layer', () => {
+    const root = shadowRoot()
+
+    applyThemeCss(root, '.a { color: red }')
+
+    const css = root.querySelector(SLOT_SELECTOR)?.textContent ?? ''
+    expect(css).toContain(LAYER_ORDER_STATEMENT)
+    expect(css).toContain(`@layer ${THEME_LAYER} {`)
+  })
+})

--- a/src/theme/__tests__/themeRegistry.test.ts
+++ b/src/theme/__tests__/themeRegistry.test.ts
@@ -2,18 +2,31 @@ import { describe, it, expect } from 'vitest'
 import {
   DEFAULT_THEME_ID,
   getTheme,
+  getThemeOrDefault,
   listThemes,
   resolveAppearance,
   supportsAppearanceChoice,
   type ThemeDefinition,
 } from '../themeRegistry'
 
-const darkOnly: ThemeDefinition = { id: 'lcars', label: 'LCARS', appearances: 'dark-only' }
-const lightOnly: ThemeDefinition = { id: 'paper', label: 'Paper', appearances: 'light-only' }
+const darkOnly: ThemeDefinition = {
+  id: 'lcars',
+  label: 'LCARS',
+  appearances: 'dark-only',
+  css: '',
+}
+const lightOnly: ThemeDefinition = {
+  id: 'paper',
+  label: 'Paper',
+  appearances: 'light-only',
+  css: '',
+}
 
 describe('themeRegistry', () => {
   it('registers exactly the built-in themes that exist today', () => {
-    expect(listThemes()).toEqual([{ id: 'default', label: 'Default', appearances: 'both' }])
+    expect(listThemes()).toEqual([
+      { id: 'default', label: 'Default', appearances: 'both', css: expect.any(String) },
+    ])
   })
 
   it('hands out a copy of the list so callers cannot add to the registry', () => {
@@ -36,6 +49,29 @@ describe('themeRegistry', () => {
       id: 'default',
       label: 'Default',
       appearances: 'both',
+      css: expect.any(String),
+    })
+  })
+
+  it('carries each theme’s stylesheet, authored inside the theme layer', () => {
+    // The payload IS the theme (docs/specs/theming — "Theme model"): the engine
+    // injects this text, so a theme that shipped no CSS, or CSS outside its
+    // layer, would either do nothing or outrank the user layer.
+    const { css } = getTheme(DEFAULT_THEME_ID)!
+
+    expect(css).toContain('@layer liebe-base, liebe-theme, liebe-user;')
+    expect(css).toContain('@layer liebe-theme {')
+    expect(css).toContain('--liebe-c-light: var(--amber-9);')
+  })
+
+  describe('getThemeOrDefault', () => {
+    it('returns the registered theme', () => {
+      expect(getThemeOrDefault(DEFAULT_THEME_ID)).toBe(getTheme(DEFAULT_THEME_ID))
+    })
+
+    it('falls back to Default for an id this build does not have', () => {
+      // A configuration imported from a newer Liebe still has to render.
+      expect(getThemeOrDefault('lcars')).toBe(getTheme(DEFAULT_THEME_ID))
     })
   })
 

--- a/src/theme/__tests__/tokens.test.ts
+++ b/src/theme/__tests__/tokens.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs'
+import { globSync, readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import {
@@ -147,10 +147,46 @@ describe('style set', () => {
     expect(cssImports(previewSource)).toEqual(cssImports(panelSource))
   })
 
-  it('injects both token layers', () => {
-    expect(cssImports(panelSource)).toEqual(
-      expect.arrayContaining(['~/styles/tokens.css', '~/theme/themes/default.css'])
-    )
+  it('imports the base token layer', () => {
+    expect(cssImports(panelSource)).toEqual(expect.arrayContaining(['~/styles/tokens.css']))
+  })
+
+  it('imports no theme sheet, because the theme layer is injected', () => {
+    // A statically imported theme would apply whichever themes are registered,
+    // all at once and permanently. The active theme comes from the registry
+    // and is injected into the root instead (src/theme/styleInjection.ts), so
+    // it can be swapped live.
+    for (const source of [panelSource, previewSource]) {
+      expect(cssImports(source).filter((specifier) => specifier.startsWith('~/theme/'))).toEqual([])
+    }
+  })
+})
+
+describe('baseline stylesheets', () => {
+  // Every sheet the panel injects, not just the token sheets: an unlayered
+  // author rule outranks every cascade layer, so one sheet left outside
+  // `liebe-base` is one component a theme and user CSS cannot restyle
+  // (docs/specs/theming — "Application mechanism"). The vendored sheets cannot
+  // be authored, and are wrapped at build time by vite/baselineCssPlugin.ts.
+  const sheets = globSync('src/**/*.css', { cwd: process.cwd() }).sort()
+
+  it('finds the sheets to check', () => {
+    // Guards the assertion below against a glob that silently matches nothing.
+    expect(sheets.length).toBeGreaterThan(5)
+  })
+
+  it.each(sheets)('%s puts all of its CSS inside a cascade layer', (sheet) => {
+    const rules = stripComments(read(`../../../${sheet}`)).trim()
+    const statement = '@layer liebe-base, liebe-theme, liebe-user;'
+
+    expect(rules).toContain(statement)
+
+    const body = rules.replace(statement, '').trim()
+    expect(body.startsWith('@layer ')).toBe(true)
+    expect(body.endsWith('}')).toBe(true)
+    // One block: a second top-level `@layer` would be a chance for CSS to sit
+    // between them, outside every layer.
+    expect(body.indexOf('@layer')).toBe(body.lastIndexOf('@layer'))
   })
 })
 

--- a/src/theme/__tests__/useThemeSelection.test.tsx
+++ b/src/theme/__tests__/useThemeSelection.test.tsx
@@ -1,0 +1,116 @@
+import { act, render, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { dashboardStore } from '~/store/dashboardStore'
+import { usePrefersDark, useThemeSelection } from '../useThemeSelection'
+import { DEFAULT_THEME_ID } from '../themeRegistry'
+
+/**
+ * A `matchMedia` stub that can flip, so the appearance can be watched
+ * following the OS rather than merely reading it once.
+ */
+function stubMatchMedia(initialMatches: boolean) {
+  const listeners = new Set<() => void>()
+  const query = {
+    matches: initialMatches,
+    media: '(prefers-color-scheme: dark)',
+    addEventListener: (_event: string, listener: () => void) => listeners.add(listener),
+    removeEventListener: (_event: string, listener: () => void) => listeners.delete(listener),
+  }
+  const matchMedia = vi.fn(() => query as unknown as MediaQueryList)
+  window.matchMedia = matchMedia as unknown as typeof window.matchMedia
+
+  return {
+    matchMedia,
+    listeners,
+    set(matches: boolean) {
+      query.matches = matches
+      act(() => listeners.forEach((listener) => listener()))
+    },
+  }
+}
+
+const originalMatchMedia = window.matchMedia
+const originalTheme = dashboardStore.state.theme
+
+afterEach(() => {
+  window.matchMedia = originalMatchMedia
+  dashboardStore.setState((state) => ({ ...state, theme: originalTheme }))
+})
+
+describe('usePrefersDark', () => {
+  it('reads the media query on first render', () => {
+    stubMatchMedia(true)
+
+    expect(renderHook(() => usePrefersDark()).result.current).toBe(true)
+  })
+
+  it('follows the media query while mounted, and unsubscribes on unmount', () => {
+    const media = stubMatchMedia(false)
+    const { result, unmount } = renderHook(() => usePrefersDark())
+
+    expect(result.current).toBe(false)
+    media.set(true)
+    expect(result.current).toBe(true)
+
+    unmount()
+    expect(media.listeners.size).toBe(0)
+  })
+
+  it('renders light where matchMedia does not exist', () => {
+    // Some embedding environments have no media-query API at all; the panel
+    // renders rather than failing over it.
+    Reflect.deleteProperty(window, 'matchMedia')
+    const { result, unmount } = renderHook(() => usePrefersDark())
+
+    expect(result.current).toBe(false)
+    expect(() => unmount()).not.toThrow()
+  })
+})
+
+describe('useThemeSelection', () => {
+  function selection() {
+    return renderHook(() => useThemeSelection()).result.current
+  }
+
+  it('renders the default theme', () => {
+    stubMatchMedia(false)
+
+    expect(selection().themeId).toBe(DEFAULT_THEME_ID)
+  })
+
+  it.each([
+    [true, 'dark'],
+    [false, 'light'],
+  ] as const)('follows the OS (dark: %s) while the preference is auto', (prefersDark, expected) => {
+    stubMatchMedia(prefersDark)
+    dashboardStore.setState((state) => ({ ...state, theme: 'auto' }))
+
+    expect(selection().appearance).toBe(expected)
+  })
+
+  it.each(['dark', 'light'] as const)('honours an explicit %s preference', (preference) => {
+    stubMatchMedia(preference === 'light')
+    dashboardStore.setState((state) => ({ ...state, theme: preference }))
+
+    expect(selection().appearance).toBe(preference)
+  })
+
+  it('re-resolves when the preference changes, without a reload', () => {
+    stubMatchMedia(true)
+    dashboardStore.setState((state) => ({ ...state, theme: 'auto' }))
+
+    const seen: string[] = []
+    function Probe() {
+      seen.push(useThemeSelection().appearance)
+      return null
+    }
+    render(<Probe />)
+
+    act(() => {
+      dashboardStore.setState((state) => ({ ...state, theme: 'light' }))
+    })
+
+    expect(seen[0]).toBe('dark')
+    expect(seen.at(-1)).toBe('light')
+  })
+})

--- a/src/theme/appearance.ts
+++ b/src/theme/appearance.ts
@@ -1,0 +1,52 @@
+/**
+ * Appearance resolution.
+ *
+ * Two independent things decide what the panel renders in: what the user asked
+ * for (`auto | dark | light`, persisted in the dashboard configuration) and
+ * what the active theme is able to render (a `dark-only` theme forces its own).
+ * `auto` follows the environment. See docs/specs/theming/index.md —
+ * "Application mechanism".
+ */
+
+import { resolveAppearance, type ThemeAppearance, type ThemeDefinition } from './themeRegistry'
+
+/** What the configuration stores: an explicit appearance, or "follow the environment". */
+export type AppearancePreference = 'auto' | ThemeAppearance
+
+/** Environment signals `auto` resolves against. */
+export interface AppearanceSignals {
+  /** `prefers-color-scheme: dark` — the baseline signal, always available. */
+  prefersDark: boolean
+  /**
+   * Home Assistant's own theme darkness, when the panel can detect it.
+   *
+   * The hook for the spec's open question ("HA theme darkness detection"):
+   * whether that is readable reliably across HA versions is unsettled, so
+   * nothing supplies it yet and `auto` falls back to `prefers-color-scheme`.
+   * When a detector lands it passes a boolean here and takes precedence — the
+   * panel should look dark when the frontend around it is dark, whatever the OS
+   * says.
+   */
+  hostDark?: boolean
+}
+
+/** Resolves the stored preference against the environment, ignoring the theme. */
+export function resolveAppearancePreference(
+  preference: AppearancePreference,
+  { prefersDark, hostDark }: AppearanceSignals
+): ThemeAppearance {
+  if (preference !== 'auto') return preference
+  return (hostDark ?? prefersDark) ? 'dark' : 'light'
+}
+
+/**
+ * The appearance actually rendered: the resolved preference, unless the theme
+ * only provides one appearance and forces it.
+ */
+export function resolveThemeAppearance(
+  theme: ThemeDefinition | undefined,
+  preference: AppearancePreference,
+  signals: AppearanceSignals
+): ThemeAppearance {
+  return resolveAppearance(theme, resolveAppearancePreference(preference, signals))
+}

--- a/src/theme/cssLayers.ts
+++ b/src/theme/cssLayers.ts
@@ -123,8 +123,56 @@ export function stripThemableImportance(css: string): string {
 // including ahead of the layer wrapper.
 const LEADING_CHARSET = /^\s*@charset\s+[^;]+;/i
 
+const COMMENT = /\/\*[\s\S]*?\*\//g
+
+/** Top-level statements that are allowed to sit outside a layer block. */
+function isAllowedStatement(text: string): boolean {
+  const statement = text.trim().toLowerCase()
+  return statement === '' || statement.startsWith('@layer') || statement.startsWith('@charset')
+}
+
 /**
- * Wraps a sheet in `layer`, unless it already declares layers of its own.
+ * Whether every rule in a sheet is already inside a cascade layer.
+ *
+ * Deliberately structural rather than "does the text contain `@layer`": a sheet
+ * that carries only the order statement, or one layered block followed by
+ * ordinary rules, mentions `@layer` and is still mostly unlayered — and
+ * unlayered author rules outrank every layer, which is the failure this whole
+ * module exists to prevent. Being wrong in the safe direction costs only a
+ * redundant wrapper (a nested layer still sorts inside its parent), so anything
+ * this cannot read as fully enclosed is treated as not enclosed.
+ */
+export function isFullyLayered(css: string): boolean {
+  let depth = 0
+  let pending = ''
+
+  for (const character of css.replace(COMMENT, '')) {
+    if (character === '{') {
+      if (depth === 0 && !pending.trim().toLowerCase().startsWith('@layer')) return false
+      depth += 1
+      pending = ''
+    } else if (character === '}') {
+      depth -= 1
+      if (depth < 0) return false
+      pending = ''
+    } else if (depth === 0) {
+      if (character !== ';') {
+        pending += character
+      } else if (isAllowedStatement(pending)) {
+        pending = ''
+      } else {
+        return false
+      }
+    }
+  }
+
+  // Anything left over is a rule the sheet never closed, or a declaration
+  // floating at the top level.
+  return depth === 0 && isAllowedStatement(pending)
+}
+
+/**
+ * Wraps a sheet in `layer`, unless every rule in it is already layered.
  *
  * Liebe's own sheets are authored inside their layer and are returned
  * unchanged; vendored sheets and any future unlayered CSS get wrapped. The
@@ -132,7 +180,7 @@ const LEADING_CHARSET = /^\s*@charset\s+[^;]+;/i
  * one sheet still gets the order right.
  */
 export function wrapInLayer(css: string, layer: string): string {
-  if (/@layer\b/i.test(css)) return css
+  if (isFullyLayered(css)) return css
 
   const [charset] = css.match(LEADING_CHARSET) ?? []
   const body = charset ? css.slice(charset.length) : css

--- a/src/theme/cssLayers.ts
+++ b/src/theme/cssLayers.ts
@@ -1,0 +1,149 @@
+/**
+ * The cascade-layer machinery of the theming engine.
+ *
+ * Everything the panel styles itself with lands in one of three layers —
+ * `liebe-base` (tokens, component sheets, the vendored Radix stylesheet),
+ * `liebe-theme` (the active theme) and `liebe-user` (custom CSS) — and a later
+ * layer wins regardless of selector specificity. Source order alone could not
+ * deliver that: a theme rule scoped to an appearance would outrank a less
+ * specific user override. See docs/specs/theming/index.md, "Application
+ * mechanism".
+ *
+ * These are pure text transforms with no DOM dependency, because they run in
+ * two places: the build (the Vite plugin in `vite/baselineCssPlugin.ts` wraps
+ * the sheets the panel ships, including the ones from `node_modules` that
+ * cannot be authored inside a layer) and the browser (`styleInjection.ts` wraps
+ * the theme payload it injects into the shadow root).
+ */
+
+/** Baseline: tokens, component sheets, vendored stylesheets. */
+export const BASE_LAYER = 'liebe-base'
+/** The active theme's token overrides and scoped rules. */
+export const THEME_LAYER = 'liebe-theme'
+/** User-authored custom CSS — the last word on every token. */
+export const USER_LAYER = 'liebe-user'
+
+/**
+ * Establishes the layer order. Repeated in every sheet and every injected
+ * `<style>`: the first declaration a root sees fixes the order, and which sheet
+ * that is depends on bundling and load order, so each one has to carry it.
+ */
+export const LAYER_ORDER_STATEMENT = `@layer ${BASE_LAYER}, ${THEME_LAYER}, ${USER_LAYER};`
+
+/**
+ * Properties the token contract governs — colours, backgrounds, borders,
+ * shadows, radii and typography (docs/specs/design-system/index.md).
+ *
+ * Prefix families rather than a flat list, because a shorthand and its
+ * longhands are the same declaration wearing different names: leaving
+ * `border-top-color` out while listing `border` would let importance survive on
+ * half of a themed border.
+ *
+ * Deliberately NOT the same set as `GridCard`'s inline-style fence. That fence
+ * answers "what may a caller set inline?", and so lets a card carry its data
+ * through `background-image` (weather artwork) while fencing `padding` and
+ * `outline` (the state rings). This set answers "what may a baseline
+ * stylesheet declare as `!important`?", where every paint layer counts and
+ * geometry the contract does not own does not.
+ */
+const THEMABLE_PROPERTY_PREFIXES = [
+  'background',
+  'border',
+  'column-rule',
+  'font',
+  'outline',
+  'text-decoration',
+  'text-emphasis',
+] as const
+
+const THEMABLE_PROPERTIES: ReadonlySet<string> = new Set([
+  // Resets every property there is, importance included.
+  'all',
+  'accent-color',
+  'backdrop-filter',
+  '-webkit-backdrop-filter',
+  'box-shadow',
+  'caret-color',
+  'color',
+  'fill',
+  'filter',
+  'letter-spacing',
+  'line-height',
+  'stroke',
+  'text-shadow',
+  'text-transform',
+])
+
+/**
+ * Whether the token contract governs this property.
+ *
+ * Custom properties are themable by definition: they are the token channel
+ * itself, so a `!important` one in the baseline would pin a token beyond the
+ * reach of both later layers.
+ */
+export function isThemableProperty(property: string): boolean {
+  const name = property.trim().toLowerCase()
+  if (name.startsWith('--')) return true
+  if (THEMABLE_PROPERTIES.has(name)) return true
+  return THEMABLE_PROPERTY_PREFIXES.some(
+    (prefix) => name === prefix || name.startsWith(`${prefix}-`)
+  )
+}
+
+// A declaration ending in `!important`, captured as (opening delimiter,
+// property, value). `[^;{}]` keeps the value inside its own declaration, so a
+// following rule can never be swallowed into the match.
+const IMPORTANT_DECLARATION = /([;{]\s*|^\s*)(--[\w-]+|[-\w]+)(\s*:\s*[^;{}]*?)!\s*important/gi
+
+/**
+ * Removes `!important` from declarations of themable properties, leaving every
+ * other important declaration untouched.
+ *
+ * Importance runs the layer order in reverse: an important declaration in
+ * `liebe-base` beats important declarations in `liebe-theme` and `liebe-user`.
+ * A baseline that is importance-free for themable properties is therefore what
+ * makes the promised precedence hold in both directions — and it is why the
+ * vendored Radix stylesheet has to be rewritten rather than merely layered.
+ *
+ * Radix's *behavioural* importance survives, because none of those properties
+ * are themable: the ScrollArea viewport's `display: block`, Skeleton's
+ * `visibility` / `pointer-events` / `user-select` / `cursor` / `animation`.
+ * Nothing a theme needs to override, and stripping them would break scroll
+ * layout and loading states.
+ */
+export function stripThemableImportance(css: string): string {
+  return css.replace(IMPORTANT_DECLARATION, (match, opening, property, value: string) =>
+    // `trimEnd` drops the space that separated the value from `!important`,
+    // leaving the declaration spelled the way it would have been authored.
+    isThemableProperty(property) ? `${opening}${property}${value.trimEnd()}` : match
+  )
+}
+
+// A leading `@charset` rule, which must stay the very first thing in a sheet —
+// including ahead of the layer wrapper.
+const LEADING_CHARSET = /^\s*@charset\s+[^;]+;/i
+
+/**
+ * Wraps a sheet in `layer`, unless it already declares layers of its own.
+ *
+ * Liebe's own sheets are authored inside their layer and are returned
+ * unchanged; vendored sheets and any future unlayered CSS get wrapped. The
+ * order statement is prepended either way, so a root that only ever sees this
+ * one sheet still gets the order right.
+ */
+export function wrapInLayer(css: string, layer: string): string {
+  if (/@layer\b/i.test(css)) return css
+
+  const [charset] = css.match(LEADING_CHARSET) ?? []
+  const body = charset ? css.slice(charset.length) : css
+
+  return `${charset ?? ''}${LAYER_ORDER_STATEMENT}\n@layer ${layer} {\n${body}\n}\n`
+}
+
+/**
+ * Baseline treatment for one stylesheet: importance-free for themable
+ * properties, and inside `liebe-base`.
+ */
+export function prepareBaselineCss(css: string): string {
+  return wrapInLayer(stripThemableImportance(css), BASE_LAYER)
+}

--- a/src/theme/cssLayers.ts
+++ b/src/theme/cssLayers.ts
@@ -101,7 +101,20 @@ export function isThemableProperty(property: string): boolean {
 // A declaration ending in `!important`, captured as (opening delimiter,
 // property, value). `[^;{}]` keeps the value inside its own declaration, so a
 // following rule can never be swallowed into the match.
-const IMPORTANT_DECLARATION = /([;{]\s*|^\s*)(--[\w-]+|[-\w]+)(\s*:\s*[^;{}]*?)!\s*important/gi
+//
+// The trailing lookahead is what makes `!important` a PRIORITY rather than
+// three syllables of text. Without it the pattern matched the token anywhere in
+// a value, quotes included, and rewrote `--label: "not !important"` to
+// `--label: "not "` — silently mangling CSS that never asked for importance.
+// That is not hypothetical for long: the custom-CSS editor feeds user input
+// straight through here. A real priority is the last thing in its declaration,
+// so it must be followed by the declaration's end — `;`, the rule's `}`, or the
+// end of the sheet — and a token inside a value never is. When the lookahead
+// fails the lazy value keeps growing and the regex looks for a LATER
+// `!important` in the same declaration, so a genuine priority still strips even
+// when the value quotes the word first.
+const IMPORTANT_DECLARATION =
+  /([;{]\s*|^\s*)(--[\w-]+|[-\w]+)(\s*:\s*[^;{}]*?)!\s*important(?=\s*(?:[;}]|$))/gi
 
 /**
  * Removes `!important` from declarations of themable properties, leaving every

--- a/src/theme/cssLayers.ts
+++ b/src/theme/cssLayers.ts
@@ -14,6 +14,14 @@
  * the sheets the panel ships, including the ones from `node_modules` that
  * cannot be authored inside a layer) and the browser (`styleInjection.ts` wraps
  * the theme payload it injects into the shadow root).
+ *
+ * They are deliberately lexical rather than a real CSS parse. Their input is
+ * first-party or vendored CSS, where the worst a `{` inside a string can cost
+ * is a redundant layer wrapper, and a parser in the panel bundle would be paid
+ * for on every load. Untrusted input — the user's custom CSS — is a different
+ * problem with a different answer: the theming spec requires it to be parsed
+ * into an AST and re-serialised, which change 0012's PR 2 ships alongside the
+ * sanitizer.
  */
 
 /** Baseline: tokens, component sheets, vendored stylesheets. */
@@ -180,12 +188,14 @@ export function isFullyLayered(css: string): boolean {
  * one sheet still gets the order right.
  */
 export function wrapInLayer(css: string, layer: string): string {
-  if (isFullyLayered(css)) return css
+  const layered = isFullyLayered(css)
+  if (layered && css.includes(LAYER_ORDER_STATEMENT)) return css
 
   const [charset] = css.match(LEADING_CHARSET) ?? []
   const body = charset ? css.slice(charset.length) : css
+  const rules = layered ? body : `@layer ${layer} {\n${body}\n}\n`
 
-  return `${charset ?? ''}${LAYER_ORDER_STATEMENT}\n@layer ${layer} {\n${body}\n}\n`
+  return `${charset ?? ''}${LAYER_ORDER_STATEMENT}\n${rules}`
 }
 
 /**

--- a/src/theme/styleInjection.ts
+++ b/src/theme/styleInjection.ts
@@ -1,0 +1,101 @@
+/**
+ * Runtime style injection for the theme layer.
+ *
+ * The baseline (`liebe-base`) is bundled and linked into the shadow root at
+ * startup; the theme layer is the one that has to change while the panel runs,
+ * because switching themes applies live without a reload (docs/specs/theming —
+ * "Application mechanism"). So the active theme's CSS is injected as a single
+ * `<style data-liebe="theme">` element that is rewritten in place, rather than
+ * imported statically like the baseline sheets.
+ *
+ * The host is whatever root the panel is rendered into: the shadow root in Home
+ * Assistant, the document in the Storybook workshop and in unit tests. Both are
+ * addressed through the same call so the workshop injects exactly what the
+ * panel injects.
+ */
+
+import { THEME_LAYER, wrapInLayer } from './cssLayers'
+
+/** Roots a Liebe tree can be mounted in. */
+export type StyleRoot = Document | ShadowRoot
+
+/** The `data-liebe` value identifying each injected layer element. */
+export const THEME_STYLE_SLOT = 'theme'
+
+/** Narrowing for `Node.getRootNode()`, which is typed as a bare `Node`. */
+export function isStyleRoot(node: Node | null | undefined): node is StyleRoot {
+  return node instanceof Document || node instanceof ShadowRoot
+}
+
+/**
+ * Where a `<style>` belongs in this root: a document keeps them in `<head>`,
+ * a shadow root has no head and holds them directly.
+ */
+function styleHost(root: StyleRoot): Element | ShadowRoot {
+  return root instanceof Document ? root.head : root
+}
+
+/**
+ * Injects (or updates) one layer's `<style>` element in `root`.
+ *
+ * Idempotent by slot: the element is found by its `data-liebe` marker and
+ * rewritten, so a theme switch swaps the CSS text of the element already in the
+ * root instead of stacking sheets whose precedence would then depend on
+ * insertion order.
+ */
+function applyLayerStyle(root: StyleRoot, slot: string, css: string): HTMLStyleElement {
+  const host = styleHost(root)
+  const selector = `style[data-liebe="${slot}"]`
+  const existing = host.querySelector<HTMLStyleElement>(selector)
+  const style = existing ?? host.ownerDocument.createElement('style')
+
+  if (!existing) {
+    style.setAttribute('data-liebe', slot)
+    host.appendChild(style)
+  }
+
+  // Assigning identical text would still invalidate style resolution in some
+  // engines; a theme selection that did not change should cost nothing.
+  if (style.textContent !== css) style.textContent = css
+
+  return style
+}
+
+/**
+ * Applies a theme's CSS as the `liebe-theme` layer of `root`.
+ *
+ * Built-in themes are authored inside their layer, so `wrapInLayer` normally
+ * only prepends the order statement — but it also means a theme payload that
+ * forgot its `@layer` block cannot land unlayered and outrank everything.
+ */
+export function applyThemeCss(root: StyleRoot, css: string): HTMLStyleElement {
+  return applyLayerStyle(root, THEME_STYLE_SLOT, wrapInLayer(css, THEME_LAYER))
+}
+
+/**
+ * Applies a theme to whichever root `node` is mounted in — the caller's way in
+ * from React, where the only handle on the root is an element inside it.
+ *
+ * A node that is in no document and no shadow root (a tree mid-mount, or one
+ * rendered into a detached container) has nowhere to hold a stylesheet;
+ * returning `null` rather than throwing keeps that a non-event, and the next
+ * render in a real root injects.
+ *
+ * From a shadow root the theme is mirrored into the owning document as well,
+ * because Radix dialogs and dropdowns portal to `document.body` — outside the
+ * shadow root and its layers. The mirror is inert elsewhere in the Home
+ * Assistant frontend: theme CSS is scoped to the Radix theme root, a class only
+ * Liebe's own trees carry. It is a stopgap for the portal host the theming spec
+ * calls for ("Portalled UI MUST stay inside the token scope"), not a
+ * replacement for it.
+ */
+export function applyThemeCssToRootOf(
+  node: Node | null | undefined,
+  css: string
+): HTMLStyleElement | null {
+  const root = node?.getRootNode()
+  if (!isStyleRoot(root)) return null
+
+  if (root instanceof ShadowRoot) applyThemeCss(root.ownerDocument, css)
+  return applyThemeCss(root, css)
+}

--- a/src/theme/themeRegistry.ts
+++ b/src/theme/themeRegistry.ts
@@ -1,13 +1,19 @@
 /**
- * Minimal built-in theme registry.
+ * The built-in theme registry.
  *
- * A theme is data — an id, a human label, and which appearances it supports
- * (see docs/specs/theming/index.md, "Theme model"). Only `default` exists
- * today; the Storybook theme toolbar enumerates this registry rather than a
- * hardcoded list, so themes registered by later changes appear in the workshop
- * with no workshop changes. Change 0012 adopts this module as the runtime
- * registry and extends each entry with its CSS payload.
+ * A theme is data — an id, a human label, which appearances it supports, and
+ * the CSS that is its entire payload (see docs/specs/theming/index.md, "Theme
+ * model"). Never JavaScript: everything a theme does, it does by overriding
+ * tokens and by scoped rules on the stable selector contract, which is what
+ * makes adding one (change 0013) additive.
+ *
+ * Both surfaces read this module: the panel injects the active theme's `css`
+ * into its shadow root, and the Storybook toolbar enumerates the registry
+ * rather than a hardcoded list, so a theme registered here appears in the
+ * workshop with no workshop changes.
  */
+
+import defaultThemeCss from './themes/default.css?raw'
 
 /** Appearances a theme is able to render in. */
 export type ThemeAppearanceSupport = 'both' | 'dark-only' | 'light-only'
@@ -22,6 +28,13 @@ export interface ThemeDefinition {
   label: string
   /** Which appearances this theme provides token sets for. */
   appearances: ThemeAppearanceSupport
+  /**
+   * The theme's stylesheet, authored inside the `liebe-theme` layer and
+   * injected as-is when the theme is active (`src/theme/styleInjection.ts`).
+   * Imported raw rather than as a side-effecting `import './x.css'`, which
+   * would apply every registered theme at once.
+   */
+  css: string
 }
 
 export const DEFAULT_THEME_ID = 'default'
@@ -31,7 +44,12 @@ export const DEFAULT_THEME_ID = 'default'
 // caller. Freezing keeps the registry the single source of truth without
 // cloning on every lookup.
 const builtInThemes: readonly ThemeDefinition[] = Object.freeze([
-  Object.freeze<ThemeDefinition>({ id: DEFAULT_THEME_ID, label: 'Default', appearances: 'both' }),
+  Object.freeze<ThemeDefinition>({
+    id: DEFAULT_THEME_ID,
+    label: 'Default',
+    appearances: 'both',
+    css: defaultThemeCss,
+  }),
 ])
 
 /** All registered themes, in registration order. */
@@ -42,6 +60,18 @@ export function listThemes(): ThemeDefinition[] {
 /** Look up a single theme, or `undefined` when the id is not registered. */
 export function getTheme(id: string): ThemeDefinition | undefined {
   return builtInThemes.find((theme) => theme.id === id)
+}
+
+/**
+ * The theme to actually render for `id`.
+ *
+ * An unregistered id is a configuration written against a build that has a
+ * theme this one does not (an import from a newer Liebe, a theme removed
+ * between versions). Rendering the Default theme keeps that dashboard usable
+ * and styled, where an empty theme layer would leave it on bare base tokens.
+ */
+export function getThemeOrDefault(id: string): ThemeDefinition {
+  return getTheme(id) ?? builtInThemes[0]
 }
 
 /**

--- a/src/theme/themeRegistry.ts
+++ b/src/theme/themeRegistry.ts
@@ -71,7 +71,9 @@ export function getTheme(id: string): ThemeDefinition | undefined {
  * and styled, where an empty theme layer would leave it on bare base tokens.
  */
 export function getThemeOrDefault(id: string): ThemeDefinition {
-  return getTheme(id) ?? builtInThemes[0]
+  // The registry always carries Default — `listThemes` is asserted to — so the
+  // fallback is named rather than positional.
+  return getTheme(id) ?? getTheme(DEFAULT_THEME_ID)!
 }
 
 /**

--- a/src/theme/useThemeSelection.ts
+++ b/src/theme/useThemeSelection.ts
@@ -1,0 +1,73 @@
+/**
+ * What the panel renders with: the configured theme and the appearance it
+ * resolves to right now.
+ *
+ * The panel is the only caller — the Storybook workshop drives the same
+ * provider from its toolbar instead, which is what makes the toolbar a stand-in
+ * for the configuration rather than a second theming path.
+ */
+
+import { useSyncExternalStore } from 'react'
+import { useStore } from '@tanstack/react-store'
+import { dashboardStore } from '~/store/dashboardStore'
+import { resolveThemeAppearance, type AppearancePreference } from './appearance'
+import { DEFAULT_THEME_ID, getThemeOrDefault, type ThemeAppearance } from './themeRegistry'
+
+const DARK_SCHEME_QUERY = '(prefers-color-scheme: dark)'
+
+function darkSchemeQuery(): MediaQueryList | undefined {
+  // `matchMedia` is missing in some embedding environments (and in bare test
+  // DOMs); the panel renders light there rather than failing to render.
+  return window.matchMedia?.(DARK_SCHEME_QUERY)
+}
+
+function subscribeToDarkScheme(onChange: () => void): () => void {
+  const query = darkSchemeQuery()
+  if (!query) return () => {}
+
+  query.addEventListener('change', onChange)
+  return () => query.removeEventListener('change', onChange)
+}
+
+function readDarkScheme(): boolean {
+  return darkSchemeQuery()?.matches ?? false
+}
+
+/**
+ * Live `prefers-color-scheme: dark`.
+ *
+ * `useSyncExternalStore` rather than state-plus-effect: the media query is
+ * external state, and reading it in a subscription keeps the first render from
+ * showing the wrong appearance and then correcting itself. No server snapshot —
+ * the panel only ever renders in a browser, inside a custom element.
+ */
+export function usePrefersDark(): boolean {
+  return useSyncExternalStore(subscribeToDarkScheme, readDarkScheme)
+}
+
+export interface ThemeSelection {
+  /** Id of the active theme — stamped as `data-liebe-theme`. */
+  themeId: string
+  /** Appearance actually rendered, after the theme has had its say. */
+  appearance: ThemeAppearance
+}
+
+/**
+ * Resolves the active theme and appearance from the dashboard configuration.
+ *
+ * The configuration still stores appearance as the scalar `theme` field; change
+ * 0012's PR 2 replaces it with `theme.{id, appearance, customCss}` and migrates
+ * existing dashboards, at which point the theme id stops being pinned to the
+ * default here. Everything downstream of this hook already takes both.
+ */
+export function useThemeSelection(): ThemeSelection {
+  const preference: AppearancePreference = useStore(dashboardStore, (state) => state.theme)
+  const prefersDark = usePrefersDark()
+
+  const theme = getThemeOrDefault(DEFAULT_THEME_ID)
+
+  return {
+    themeId: theme.id,
+    appearance: resolveThemeAppearance(theme, preference, { prefersDark }),
+  }
+}

--- a/src/types/css.d.ts
+++ b/src/types/css.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Vite's `?raw` suffix, which yields a module's file contents as a string.
+ *
+ * The theme registry loads each theme's stylesheet this way: a side-effecting
+ * `import './theme.css'` would apply every registered theme at once, and a
+ * theme has to be a string the engine can inject and swap.
+ */
+declare module '*.css?raw' {
+  const content: string
+  export default content
+}

--- a/vite.config.ha.ts
+++ b/vite.config.ha.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import tsConfigPaths from 'vite-tsconfig-paths'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'path'
+import { baselineCssPlugin } from './vite/baselineCssPlugin'
 
 export default defineConfig(({ mode }) => {
   const isProduction = mode === 'production'
@@ -40,6 +41,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     plugins: [
+      baselineCssPlugin(),
       react(),
       tsConfigPaths({
         projects: ['./tsconfig.json'],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import tsConfigPaths from 'vite-tsconfig-paths'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'path'
 import { build } from 'vite'
+import { baselineCssPlugin } from './vite/baselineCssPlugin'
 
 // Path fragments that only ever belong to tests, test helpers, or Storybook.
 // None of them reach the panel bundle, so editing one must not trigger a panel
@@ -65,6 +66,7 @@ function panelPlugin() {
           },
         },
         plugins: [
+          baselineCssPlugin(),
           react({
             jsxRuntime: 'automatic',
           }),
@@ -163,6 +165,7 @@ export default defineConfig({
     include: ['react', 'react-dom', '@tanstack/react-router', '@radix-ui/themes'],
   },
   plugins: [
+    baselineCssPlugin(),
     react({
       jsxRuntime: 'automatic',
     }),

--- a/vite/baselineCssPlugin.ts
+++ b/vite/baselineCssPlugin.ts
@@ -1,0 +1,44 @@
+import type { Plugin } from 'vite'
+import { prepareBaselineCss } from '../src/theme/cssLayers'
+
+/**
+ * Gives every stylesheet the panel ships the baseline treatment: inside the
+ * `liebe-base` cascade layer, and free of `!important` on themable properties.
+ *
+ * Liebe's own sheets are authored inside their layer and pass through
+ * unchanged. The ones that need this are the vendored sheets — Radix Themes,
+ * react-grid-layout, react-resizable — which cannot be authored at all: left
+ * as they ship, they would be *unlayered* author CSS, which outranks every
+ * cascade layer regardless of specificity and would make the components a
+ * theme most wants to restyle the ones it cannot touch. Their `!important`
+ * declarations are worse still, because importance runs the layer order in
+ * reverse: an important baseline rule beats important theme *and* user rules.
+ * See docs/specs/theming/index.md, "Application mechanism".
+ *
+ * A build-time transform rather than a runtime one: the panel links its CSS as
+ * a bundled stylesheet, so this is where the sheets are on their way into the
+ * shadow root, and doing it here costs the panel nothing at startup. The
+ * transform itself is `src/theme/cssLayers.ts` and is unit-tested there,
+ * including against the vendored stylesheet as it actually ships.
+ *
+ * Applied by every config that builds panel CSS — `vite.config.ts`,
+ * `vite.config.ha.ts` and `.storybook/vite.config.ts` — so the workshop keeps
+ * rendering what the panel renders.
+ */
+export function baselineCssPlugin(): Plugin {
+  return {
+    name: 'liebe:baseline-css-layers',
+    // Ahead of Vite's own CSS plugin, so the sheet is still CSS text here and
+    // not the JS module Vite turns it into.
+    enforce: 'pre',
+    transform(code: string, id: string) {
+      // Suffixed ids (`?raw`, `?inline`, `?url`) are asked for as data — the
+      // theme registry loads theme payloads that way — and are not the panel's
+      // baseline.
+      if (!id.endsWith('.css')) return null
+
+      const css = prepareBaselineCss(code)
+      return css === code ? null : { code: css, map: null }
+    },
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,12 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
+    // CSS is stubbed out by default, `?raw` imports included — which would
+    // hand the theme registry an empty stylesheet and make every assertion
+    // about a theme's payload vacuous. Process the theme sheets only: the
+    // vendored stylesheets stay stubbed, so no test pays to parse 800kB of
+    // Radix CSS in jsdom.
+    css: { include: [/src\/theme\/themes\//] },
     // Playwright e2e specs live in tests/e2e and must not be picked up by the
     // vitest unit runner (they import @playwright/test).
     exclude: [...configDefaults.exclude, 'tests/e2e/**'],


### PR DESCRIPTION
## Summary

Stands up the theming engine's foundation — the first task of `docs/changes/0012-theming-engine.md`: cascade-layer injection, the runtime theme registry, appearance resolution and Radix wiring, and root stamping.

The registry is the same module the workshop toolbar has enumerated since the Storybook change, now extended into the runtime registry rather than replaced — so themes added later appear in the toolbar with no workshop changes.

## Where overrides land, and why it matters

Theme and user token overrides are applied on the **Radix theme root** (`.radix-themes`), the element that declares the token contract. This is not a stylistic choice: a `var()` inside a custom property substitutes at the element that declares it, so an override on any descendant would leave a token's derived companions — the `-tint` and `-text` steps — resolving against the old base while the base itself changed. A theme remapping a domain hue would then recolour the surface but not its tint or its text.

The design-system spec recorded this constraint when the token contract landed; this change is the first consumer to depend on it.

## Baseline CSS wrapping

The change document's "wrap all baseline CSS into `liebe-base`" task was already partly done — `src/styles/app.css`'s reset and coarse-pointer touch floor had to be layered during the anatomy work, because an unlayered `* { padding: 0 }` outranks every cascade layer and was zeroing the anatomy's padding. This PR finishes the remaining sheets: the taskbar, sidebar, dashboard, grid section, camera card, connection status, and text card.

Unlayered author rules are the failure mode this closes — any one of them would silently outrank a theme, and the symptom appears in the theme rather than in the sheet that caused it.

## Tests are not vacuous

Vitest stubs CSS imports by default, `?raw` included, which would have handed the theme registry an empty stylesheet and made every assertion about a theme's payload pass trivially. `vitest.config.ts` now processes the theme sheets specifically — the vendored stylesheets stay stubbed, so no test pays to parse Radix's 800kB in jsdom.

That is load-bearing rather than incidental: removing the `css.include` line fails a test, which is what makes the theme-payload assertions meaningful.

## Testing

- `npm test` — 1088 passed, 2 skipped (up from 981)
- `npm run lint`, `npm run typecheck` — clean
- `npm run test:coverage` — 100% patch coverage, verified against branch data as well as lines
- `npm run build-storybook`, `npm run build:ha:prod` — both succeed

## Scope

Config fields, the theme picker and custom-CSS editor, and the injection-time sanitizer are the next task in this change document; the e2e round-trip and spec sync follow it. The change stays `draft` until the final PR lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime theme selection with support for custom theme IDs and light, dark, or automatic appearance.
  * Theme styles now apply consistently across the main app, panels, routed views, portals, and shadow-root content.
  * Added automatic fallback to the default theme for unavailable theme selections.

* **Improvements**
  * Improved styling precedence so user and theme customizations can reliably override baseline styles.
  * Updated Storybook and development previews to use the same runtime theming behavior.

* **Documentation**
  * Marked the theming injection and appearance workstream as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->