### PR TITLE
feat(cards): add the shared non-scalar card option controls

### DIFF
--- a/docs/changes/0014-universal-card-options.md
+++ b/docs/changes/0014-universal-card-options.md
@@ -4,7 +4,7 @@
 
 Implement the [common option contract](../specs/entity-cards/options/common.md) across all existing entity cards: `name`, `icon`, `hideName`, `hideState`, `color`, and the `tapAction`/`holdAction`/`doubleTapAction` action system (default / toggle / more-info / navigate / call-service / none), including the entity detail dialog that `more-info` opens and the config-form controls for editing these options. Per-card domain options build on this in 0016+.
 
-**Spec:** [entity-cards](../specs/entity-cards/index.md) → [options/common](../specs/entity-cards/options/common.md) · **Status:** draft · **Depends on:** 0010 (this change precedes 0011's card layouts — the action system must exist before glance tiers remove embedded controls; tier-composition rules like icon-only glance are stated here but verified by 0011, which lands after)
+**Spec:** [entity-cards](../specs/entity-cards/index.md) → [options/common](../specs/entity-cards/options/common.md) · **Status:** complete · **Depends on:** 0010 (this change precedes 0011's card layouts — the action system must exist before glance tiers remove embedded controls; tier-composition rules like icon-only glance are stated here but verified by 0011, which lands after)
 
 ## Motivation
 
@@ -45,7 +45,7 @@ The [common option contract](../specs/entity-cards/options/common.md) owns the u
 - [x] **PR 1 — Action system**: gesture controller in the shell; action resolution + per-card `default` declarations; edit-mode suppression; config schema + validation; the **action editor** form control (parameterized `navigate` targets and `call-service` service+data); unit tests
 - [x] **PR 2 — Detail dialog**: entity detail dialog (portalled), `more-info` wiring, hold default across cards; **password-helper redaction in the state display and attribute list, with a regression test** (the dialog must not ship able to reveal a secret the card masks); component tests + story; e2e hold flow
 - [x] **PR 3 — Display options**: `name`/`icon`/`hideName`/`hideState`/`color` in shell + shared ConfigDefinition fragment merged into all existing cards' config modals; icon-only glance layout; stories; YAML round-trip test
-- [ ] **PR 4 — Shared non-scalar form controls**: the remaining `ConfigDefinition` extensions this change's functional requirements mandate — **entity picker** (consumed later by `motionEntity`/`doorEntity`/`batteryEntity` in [0021](./0021-camera-presentation-options.md)/[0024](./0024-security-cards.md)/[0026](./0026-person-card.md)), **number array** (`brightnessPresets`, [0016](./0016-light-card-to-spec.md)), and **ordered multi-select** (`armModes`, [0024](./0024-security-cards.md)) — each schema-validated, unit-tested, and given a story. This change MUST NOT be marked complete without them: the later card changes assume these controls already exist rather than inventing one apiece.
+- [x] **PR 4 — Shared non-scalar form controls**: the remaining `ConfigDefinition` extensions this change's functional requirements mandate — **entity picker** (consumed later by `motionEntity`/`doorEntity`/`batteryEntity` in [0021](./0021-camera-presentation-options.md)/[0024](./0024-security-cards.md)/[0026](./0026-person-card.md)), **number array** (`brightnessPresets`, [0016](./0016-light-card-to-spec.md)), and **ordered multi-select** (`armModes`, [0024](./0024-security-cards.md)) — each schema-validated, unit-tested, and given a story. This change MUST NOT be marked complete without them: the later card changes assume these controls already exist rather than inventing one apiece.
 
 ## Out of Scope
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@
 | 0011 | [Size-Adaptive Layout Tiers](changes/0011-layout-tiers.md)                           | [Design System](specs/design-system/)       | draft    | 0010, 0014       |
 | 0012 | [Theming Engine](changes/0012-theming-engine.md)                                     | [Theming](specs/theming/)                   | complete | 0010             |
 | 0013 | [Built-in Themes: Liquid Glass & LCARS](changes/0013-built-in-themes.md)             | [Theming](specs/theming/)                   | draft    | 0012             |
-| 0014 | [Universal Card Options](changes/0014-universal-card-options.md)                     | [Entity Cards](specs/entity-cards/)         | draft    | 0010             |
+| 0014 | [Universal Card Options](changes/0014-universal-card-options.md)                     | [Entity Cards](specs/entity-cards/)         | complete | 0010             |
 | 0015 | [History & Forecast Data Pipeline](changes/0015-history-and-forecast-data.md)        | [Entity State](specs/entity-state/)         | draft    | 0014             |
 | 0016 | [Light Card to Spec](changes/0016-light-card-to-spec.md)                             | [Entity Cards](specs/entity-cards/)         | draft    | 0011, 0014       |
 | 0017 | [Climate Card to Spec](changes/0017-climate-card-to-spec.md)                         | [Entity Cards](specs/entity-cards/)         | draft    | 0011, 0014       |

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -144,7 +144,7 @@ changes:
     path: changes/0014-universal-card-options.md
     description: Universal option surface for all entity cards — name/icon overrides, hide toggles, color, tap/hold/double-tap action system, and the entity detail dialog
     spec: entity-cards
-    status: draft
+    status: complete
     depends_on: ['0010']
   - id: '0015'
     name: history-and-forecast-data

--- a/docs/specs/entity-cards/index.md
+++ b/docs/specs/entity-cards/index.md
@@ -168,9 +168,9 @@ See [card reference — Input helpers](./card-reference.md#input-helper-cards), 
 - **WHEN** the user focuses it and types
 - **THEN** the content persists via `dashboardActions.updateGridItem` under the item id (`TextCard.tsx:80-116`).
 
-### Card options (target surface — specified, not yet implemented)
+### Card options
 
-The per-card option surface is specified in [options/](./options/common.md): a universal contract every entity card MUST adopt (name/icon overrides, hide toggles, accent color, tap/hold/double-tap actions) plus one document per card family defining domain options, defaults, and how content maps to the [design-system layout tiers](../design-system/index.md#size-adaptive-layouts). These documents describe the desired state; the requirements elsewhere in this spec remain the implemented baseline until implementing changes land. Per-card docs: [light](./options/light.md) · [switch](./options/switch.md) · [climate](./options/climate.md) · [sensor](./options/sensor.md) · [media-player](./options/media-player.md) · [camera](./options/camera.md) · [cover](./options/cover.md) · [fan](./options/fan.md) · [weather](./options/weather.md) · [security](./options/security.md) · [vacuum](./options/vacuum.md) · [person](./options/person.md) · [scene](./options/scene.md) · [input-helpers](./options/input-helpers.md)
+The per-card option surface is specified in [options/](./options/common.md): a universal contract every entity card MUST adopt (name/icon overrides, hide toggles, accent color, tap/hold/double-tap actions) plus one document per card family defining domain options, defaults, and how content maps to the [design-system layout tiers](../design-system/index.md#size-adaptive-layouts). Each of those documents carries its own status line — the universal contract is implemented, the per-card surfaces are not — and for a family whose options have not landed, the requirements elsewhere in this spec remain the implemented baseline. Per-card docs: [light](./options/light.md) · [switch](./options/switch.md) · [climate](./options/climate.md) · [sensor](./options/sensor.md) · [media-player](./options/media-player.md) · [camera](./options/camera.md) · [cover](./options/cover.md) · [fan](./options/fan.md) · [weather](./options/weather.md) · [security](./options/security.md) · [vacuum](./options/vacuum.md) · [person](./options/person.md) · [scene](./options/scene.md) · [input-helpers](./options/input-helpers.md)
 
 New card families introduced there (media player, lock/alarm, vacuum, person, scene/script/button) MUST register through the existing `domainToCard` registry and `CardProps` contract when implemented.
 
@@ -311,7 +311,7 @@ Registry functions (`cardRegistry.ts:60-98`): `getCardForDomain`, `getCardForEnt
 
 - Registry & dispatch: `src/components/cardRegistry.ts`, `src/components/GridView.tsx:22-67`, `src/utils/cardDimensions.ts`
 - Shell & boundary: `src/components/GridCard.tsx`, `src/components/ErrorBoundary.tsx`
-- Configuration: `src/components/CardConfig.tsx`, `src/components/configurations/cardConfigurations.ts`
+- Configuration: `src/components/CardConfig.tsx`, `src/components/configurations/cardConfigurations.ts`; non-scalar option controls in `ActionEditor.tsx`, `EntityPicker.tsx`, `NumberArrayEditor.tsx`, `OrderedMultiSelect.tsx`, with their value contracts in `src/store/configControls.ts`
 - Discovery: `src/components/EntityBrowser.tsx`, `src/components/EntitiesBrowserTab.tsx`, `src/components/CardsBrowserTab.tsx`
 - Cards: `LightCard.tsx`, `ClimateCard.tsx`, `CoverCard.tsx`, `FanCard.tsx`, `SensorCard.tsx`, `BinarySensorCard.tsx`, `ButtonCard.tsx`, `TextCard.tsx`, `Separator.tsx`, `WeatherCard/`, `Input{Boolean,Number,Select,Text,DateTime}Card.tsx`
 - Companion: [card-reference.md](./card-reference.md)
@@ -319,7 +319,8 @@ Registry functions (`cardRegistry.ts:60-98`): `getCardForDomain`, `getCardForEnt
 
 ## Changelog
 
-| Date       | Change                                                                                                             | Document |
-| ---------- | ------------------------------------------------------------------------------------------------------------------ | -------- |
-| 2026-07-18 | Initial spec created (baseline of existing implementation)                                                         | —        |
-| 2026-07-25 | Added target per-card option surface under `options/` (common contract + 14 card-family docs, not yet implemented) | —        |
+| Date       | Change                                                                                                                 | Document                                                                    |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| 2026-07-18 | Initial spec created (baseline of existing implementation)                                                             | —                                                                           |
+| 2026-07-25 | Added target per-card option surface under `options/` (common contract + 14 card-family docs, not yet implemented)     | —                                                                           |
+| 2026-07-27 | Common option contract implemented: universal options, action system, detail dialog, shared non-scalar config controls | [0014-universal-card-options](../../changes/0014-universal-card-options.md) |

--- a/docs/specs/entity-cards/options/common.md
+++ b/docs/specs/entity-cards/options/common.md
@@ -1,6 +1,6 @@
 # Card Options — Common Contract
 
-Part of the [entity-cards spec](../index.md). **Status: specified, not yet implemented** — this defines the target per-card option surface; current per-card config is sparse (see [card-reference](../card-reference.md)).
+Part of the [entity-cards spec](../index.md). **Status: implemented** by change [0014](../../../changes/0014-universal-card-options.md) — the universal option keys, the action system, the entity detail dialog `more-info` opens, and the shared configuration controls the per-card docs build on (action editor, entity picker, number array, ordered multi-select). The per-card documents in this folder remain **specified, not yet implemented**: each domain's own options land with its own change (0016–0027), so current per-card config is still sparse (see [card-reference](../card-reference.md)). The tier-composition rule below is stated here and verified by [0011](../../../changes/0011-layout-tiers.md).
 
 Options are stored under `item.config`, are editable from the card's own configuration UI in edit mode, and MUST round-trip through YAML export/import ([dashboard-config](../../dashboard-config/)). Per-card docs in this folder specify domain-specific options; this file specifies what **every** entity card MUST support.
 

--- a/src/components/CardConfig.tsx
+++ b/src/components/CardConfig.tsx
@@ -18,6 +18,9 @@ import { actionConfigOptions, displayConfigOptions } from './configurations/univ
 import type { GridItem } from '~/store/types'
 import type { CardAction } from '~/store/cardActions'
 import { ActionEditor } from './ActionEditor'
+import { EntityPicker } from './EntityPicker'
+import { NumberArrayEditor } from './NumberArrayEditor'
+import { OrderedMultiSelect } from './OrderedMultiSelect'
 import { CardItemProvider } from './cardItemContext'
 import { IconSelect } from './IconSelect'
 import { WeatherCard } from './WeatherCard'
@@ -44,15 +47,29 @@ interface ContentProps {
 
 // Configuration option types
 export interface ConfigOption {
-  type: 'boolean' | 'string' | 'number' | 'select' | 'textarea' | 'icon' | 'action'
+  type:
+    | 'boolean'
+    | 'string'
+    | 'number'
+    | 'select'
+    | 'textarea'
+    | 'icon'
+    | 'action'
+    | 'entity'
+    | 'number-array'
+    | 'ordered-multi-select'
   default: unknown
   label: string
   description?: string
   placeholder?: string
-  options?: Array<{ value: string; label: string }> // For select type
-  min?: number // For number type
-  max?: number // For number type
-  step?: number // For number type
+  options?: Array<{ value: string; label: string }> // For select and ordered-multi-select types
+  min?: number // For number and number-array types
+  max?: number // For number and number-array types
+  step?: number // For number and number-array types
+  integer?: boolean // For number-array type: whole numbers only
+  unit?: string // For number-array type: suffix shown after each value
+  domains?: string[] // For entity type: narrows what the picker offers
+  deviceClasses?: string[] // For entity type: narrows it further
 }
 
 export interface ConfigDefinition {
@@ -236,6 +253,56 @@ function Component({ title, description, configDefinition, config, onChange }: C
             value={config[key]}
             defaultValue={option.default as CardAction}
             onChange={(action) => handleChange(key, action)}
+          />
+        )
+
+      /*
+       * The three shared non-scalar controls. Each takes the stored value raw
+       * and resolves it itself, because "what this build does with a value it
+       * does not recognise" is part of each control's contract rather than
+       * something the form can decide for them
+       * (docs/specs/entity-cards/options/common.md).
+       */
+      case 'entity':
+        return (
+          <EntityPicker
+            key={key}
+            label={option.label}
+            description={option.description}
+            value={currentValue}
+            domains={option.domains}
+            deviceClasses={option.deviceClasses}
+            placeholder={option.placeholder}
+            onChange={(entityId) => handleChange(key, entityId)}
+          />
+        )
+
+      case 'number-array':
+        return (
+          <NumberArrayEditor
+            key={key}
+            label={option.label}
+            description={option.description}
+            value={currentValue}
+            min={option.min}
+            max={option.max}
+            step={option.step}
+            integer={option.integer}
+            unit={option.unit}
+            placeholder={option.placeholder}
+            onChange={(values) => handleChange(key, values)}
+          />
+        )
+
+      case 'ordered-multi-select':
+        return (
+          <OrderedMultiSelect
+            key={key}
+            label={option.label}
+            description={option.description}
+            value={currentValue}
+            options={option.options ?? []}
+            onChange={(values) => handleChange(key, values)}
           />
         )
 

--- a/src/components/EntityPicker.stories.tsx
+++ b/src/components/EntityPicker.stories.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Box, Code, Flex, Text } from '@radix-ui/themes'
+import { EntityPicker } from './EntityPicker'
+import { createBinarySensorEntity, createLightEntity, createSensorEntity } from '~/test/fixtures'
+
+const MOTION = createBinarySensorEntity({
+  entity_id: 'binary_sensor.driveway_motion',
+  attributes: { friendly_name: 'Driveway Motion', device_class: 'motion' },
+})
+
+const HALLWAY_MOTION = createBinarySensorEntity({
+  entity_id: 'binary_sensor.hallway_motion',
+  attributes: { friendly_name: 'Hallway Motion', device_class: 'motion' },
+})
+
+const BATTERY = createSensorEntity({
+  entity_id: 'sensor.phone_battery',
+  state: '64',
+  attributes: { friendly_name: 'Phone Battery', device_class: 'battery', unit_of_measurement: '%' },
+})
+
+const ENTITIES = [
+  MOTION,
+  HALLWAY_MOTION,
+  createBinarySensorEntity(),
+  BATTERY,
+  createLightEntity(),
+  createSensorEntity(),
+]
+
+/**
+ * The entity picker — the configuration control behind every option that links
+ * a second entity to a card (`motionEntity` on the camera card, `doorEntity` on
+ * the lock card, `batteryEntity` on the person and vacuum cards).
+ *
+ * The value is one entity id, picked from the list rather than typed, so the
+ * control cannot produce a link that points nowhere. What it is *given* is a
+ * different matter: an id this Home Assistant does not have is kept and
+ * reported, never rewritten — a dashboard shared as YAML regularly lands on an
+ * instance that names its sensors differently.
+ */
+const meta: Meta<typeof EntityPicker> = {
+  title: 'Shell/Card Configuration/Entity Picker',
+  component: EntityPicker,
+  args: { label: 'Motion sensor' },
+  parameters: { liebe: { entities: ENTITIES } },
+  render: function Render({ value: initialValue, ...args }) {
+    const [value, setValue] = useState<string>((initialValue as string) ?? '')
+
+    return (
+      <Box style={{ maxWidth: '380px' }}>
+        <Flex direction="column" gap="3">
+          <EntityPicker {...args} value={value} onChange={setValue} />
+          <Flex direction="column" gap="1">
+            <Text size="1" color="gray">
+              Stored as
+            </Text>
+            <Code size="1">{JSON.stringify(value)}</Code>
+          </Flex>
+        </Flex>
+      </Box>
+    )
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof EntityPicker>
+
+/** The default for every linking option: nothing linked. */
+export const Empty: Story = {
+  args: { value: '', description: 'Adds a motion line to the camera overlay.' },
+}
+
+/** A linked entity reads as its friendly name, not its id. */
+export const Linked: Story = {
+  args: { value: 'binary_sensor.driveway_motion' },
+}
+
+/** Narrowed to what the option can actually use — here, motion sensors. */
+export const FilteredToMotionSensors: Story = {
+  args: {
+    value: '',
+    domains: ['binary_sensor'],
+    deviceClasses: ['motion'],
+    placeholder: 'No motion sensor',
+  },
+}
+
+/** Battery sensors, the shape `batteryEntity` asks for on the person card. */
+export const FilteredToBatterySensors: Story = {
+  args: { value: 'sensor.phone_battery', domains: ['sensor'], deviceClasses: ['battery'] },
+}
+
+/**
+ * The imported-dashboard case: the linked entity does not exist here. The card
+ * renders without it, and the configuration keeps the id until the user changes
+ * it.
+ */
+export const LinkedEntityMissing: Story = {
+  args: { value: 'binary_sensor.moved_house' },
+}
+
+/** With no entities at all, the list says so rather than looking broken. */
+export const NoEntities: Story = {
+  args: { value: '' },
+  parameters: { liebe: { entities: [] } },
+}

--- a/src/components/EntityPicker.tsx
+++ b/src/components/EntityPicker.tsx
@@ -12,6 +12,9 @@ import type { HassEntity } from '~/store/entityTypes'
  */
 const MAX_RESULTS = 50
 
+/** Shared empty list, so a closed picker's memo keeps a stable reference. */
+const NO_ENTITIES: HassEntity[] = []
+
 export interface EntityPickerProps {
   label: string
   description?: string
@@ -140,12 +143,23 @@ export function EntityPicker({
    * tell them apart: an option that asks for `motion binary_sensor` on an
    * instance with none of them is empty before the user types anything, and
    * that is a different sentence from a search that found nothing.
+   *
+   * Both steps are gated on `open`, and that gate carries real weight. The
+   * picker's filters are predicates over domain and `device_class`, not a list
+   * of ids, so there is nothing narrower for `useEntities()` to subscribe to —
+   * it takes the whole store map and this component re-renders on every batch
+   * Home Assistant sends. Sorting a few thousand names on each of those, for a
+   * list behind a closed popover, is what makes a config form stutter while the
+   * user types in an unrelated field. Nothing is deferred past the point it is
+   * needed: `open` flips during render, so the frame that opens the popover
+   * builds the list from the entities as they are right then.
    */
   const available = React.useMemo(() => {
+    if (!open) return NO_ENTITIES
     return Object.values(entities)
       .filter((entity) => matchesFilters(entity, domains, deviceClasses))
       .sort((a, b) => friendlyNameOf(a).localeCompare(friendlyNameOf(b)))
-  }, [entities, domains, deviceClasses])
+  }, [open, entities, domains, deviceClasses])
 
   const matches = React.useMemo(
     () => available.filter((entity) => matchesSearch(entity, search)),
@@ -154,14 +168,18 @@ export function EntityPicker({
 
   const shown = matches.slice(0, MAX_RESULTS)
 
-  const emptyMessage = emptyListMessage({
-    isLoading,
-    isConnected,
-    hasEntities: Object.keys(entities).length > 0,
-    hasAvailable: available.length > 0,
-    domains,
-    deviceClasses,
-  })
+  // Only the open popover renders this, and counting the keys of every entity
+  // in Home Assistant is not free either.
+  const emptyMessage = open
+    ? emptyListMessage({
+        isLoading,
+        isConnected,
+        hasEntities: Object.keys(entities).length > 0,
+        hasAvailable: available.length > 0,
+        domains,
+        deviceClasses,
+      })
+    : ''
 
   /*
    * Closing is the only place the search resets, and every way of closing goes

--- a/src/components/EntityPicker.tsx
+++ b/src/components/EntityPicker.tsx
@@ -1,0 +1,215 @@
+import * as React from 'react'
+import { Box, Button, Flex, Popover, ScrollArea, Text, TextField } from '@radix-ui/themes'
+import { MagnifyingGlassIcon } from '@radix-ui/react-icons'
+import { useEntities } from '~/hooks'
+import { entityLinkSchema, ENTITY_LINK_DEFAULT } from '~/store/configControls'
+import type { HassEntity } from '~/store/entityTypes'
+
+/**
+ * How many matches the list renders at once. A Home Assistant install with a
+ * few thousand entities would otherwise put all of them in the popover; the
+ * search field is the way past the cap, and the footer says so.
+ */
+const MAX_RESULTS = 50
+
+export interface EntityPickerProps {
+  label: string
+  description?: string
+  /** The stored value, which may be anything a hand-edited config contains. */
+  value: unknown
+  /** Narrows what the list offers. A stored id outside it is still kept. */
+  domains?: string[]
+  /** Narrows the list further by `device_class`, for the same reason. */
+  deviceClasses?: string[]
+  /** Trigger text while nothing is linked. */
+  placeholder?: string
+  onChange: (entityId: string) => void
+}
+
+function friendlyNameOf(entity: HassEntity): string {
+  return entity.attributes.friendly_name || entity.entity_id
+}
+
+function matchesFilters(
+  entity: HassEntity,
+  domains: string[] | undefined,
+  deviceClasses: string[] | undefined
+): boolean {
+  if (domains && !domains.includes(entity.entity_id.split('.')[0])) return false
+  if (deviceClasses && !deviceClasses.includes(String(entity.attributes.device_class))) return false
+  return true
+}
+
+function matchesSearch(entity: HassEntity, search: string): boolean {
+  if (!search) return true
+  const needle = search.toLowerCase()
+  return (
+    entity.entity_id.toLowerCase().includes(needle) ||
+    friendlyNameOf(entity).toLowerCase().includes(needle)
+  )
+}
+
+/**
+ * The entity picker — the config control behind every option that links a
+ * second entity to a card (`motionEntity`, `doorEntity`, `batteryEntity`).
+ *
+ * The option's value is one entity id, so the control is a search-and-pick
+ * rather than a text field: an id typed by hand is a config that silently does
+ * nothing, and there is no reason to make the user produce one when the panel
+ * already knows every entity there is.
+ *
+ * **A stored id is never rewritten.** Home Assistant instances differ, and a
+ * dashboard shared as YAML lands on one where the linked entity may not exist —
+ * so an unresolvable id is shown as configured, with a note saying the card will
+ * render without it, and left exactly as stored until the user changes it
+ * (docs/specs/dashboard-config/index.md — "Forward Compatibility"). The same
+ * holds for an id outside the picker's own filters: it stays selected and
+ * labelled, because the filters describe what the list *offers*, not what the
+ * option is allowed to hold.
+ */
+export function EntityPicker({
+  label,
+  description,
+  value,
+  domains,
+  deviceClasses,
+  placeholder = 'No entity linked',
+  onChange,
+}: EntityPickerProps) {
+  const { entities, isConnected, isLoading } = useEntities()
+  const [open, setOpen] = React.useState(false)
+  const [search, setSearch] = React.useState('')
+
+  /*
+   * The search box is the only local state: unlike the action editor, this
+   * control has no half-typed intermediate value to protect. Every commit is a
+   * whole entity id picked from the list, so `value` can stay the single source
+   * of what is selected.
+   */
+  const parsed = entityLinkSchema.safeParse(value)
+  const selectedId = parsed.success ? parsed.data : ENTITY_LINK_DEFAULT
+  const selectedEntity = selectedId ? entities[selectedId] : undefined
+
+  const matches = React.useMemo(() => {
+    return Object.values(entities)
+      .filter((entity) => matchesFilters(entity, domains, deviceClasses))
+      .filter((entity) => matchesSearch(entity, search))
+      .sort((a, b) => friendlyNameOf(a).localeCompare(friendlyNameOf(b)))
+  }, [entities, domains, deviceClasses, search])
+
+  const shown = matches.slice(0, MAX_RESULTS)
+
+  /*
+   * An empty list has three causes and only one of them is the user's search.
+   * Saying "no match" while the panel is still loading, or while it is not
+   * talking to Home Assistant at all, describes the config as the problem when
+   * the connection is.
+   */
+  const emptyMessage = isLoading
+    ? 'Still loading entities from Home Assistant…'
+    : !isConnected
+      ? 'Not connected to Home Assistant — no entities to choose from.'
+      : 'No entity matches that search.'
+
+  const commit = (entityId: string) => {
+    onChange(entityId)
+    setOpen(false)
+    setSearch('')
+  }
+
+  return (
+    <Flex direction="column" gap="1">
+      <Text size="2" weight="medium">
+        {label}
+      </Text>
+
+      <Popover.Root open={open} onOpenChange={setOpen}>
+        <Popover.Trigger>
+          <Button size="3" variant="soft" color="gray" aria-label={label}>
+            <Text truncate>
+              {selectedEntity ? friendlyNameOf(selectedEntity) : selectedId || placeholder}
+            </Text>
+          </Button>
+        </Popover.Trigger>
+
+        <Popover.Content style={{ width: '340px' }}>
+          <TextField.Root
+            size="3"
+            mb="2"
+            autoFocus
+            value={search}
+            placeholder="Search entities…"
+            aria-label={`${label} search`}
+            onChange={(event) => setSearch(event.target.value)}
+          >
+            <TextField.Slot>
+              <MagnifyingGlassIcon height="16" width="16" />
+            </TextField.Slot>
+          </TextField.Root>
+
+          <ScrollArea type="always" scrollbars="vertical" style={{ height: 260 }}>
+            <Flex direction="column" gap="1" p="1">
+              {shown.map((entity) => (
+                <Button
+                  key={entity.entity_id}
+                  size="3"
+                  variant={entity.entity_id === selectedId ? 'solid' : 'soft'}
+                  color={entity.entity_id === selectedId ? 'blue' : 'gray'}
+                  style={{ justifyContent: 'flex-start', height: 'auto', padding: '8px 12px' }}
+                  onClick={() => commit(entity.entity_id)}
+                >
+                  <Flex direction="column" align="start" gap="0">
+                    <Text size="2">{friendlyNameOf(entity)}</Text>
+                    <Text size="1" color="gray">
+                      {entity.entity_id}
+                    </Text>
+                  </Flex>
+                </Button>
+              ))}
+            </Flex>
+
+            {shown.length === 0 && (
+              <Box p="4">
+                <Text size="2" color="gray">
+                  {emptyMessage}
+                </Text>
+              </Box>
+            )}
+          </ScrollArea>
+
+          <Flex
+            justify="between"
+            align="center"
+            mt="2"
+            pt="2"
+            style={{ borderTop: '1px solid var(--gray-a5)' }}
+          >
+            <Text size="1" color="gray">
+              {matches.length > shown.length
+                ? `Showing ${shown.length} of ${matches.length} — keep typing to narrow it down`
+                : `${matches.length} available`}
+            </Text>
+            {selectedId && (
+              <Button size="3" variant="ghost" color="gray" onClick={() => commit('')}>
+                Clear
+              </Button>
+            )}
+          </Flex>
+        </Popover.Content>
+      </Popover.Root>
+
+      {selectedId && !selectedEntity && (
+        <Text size="1" color="red">
+          {selectedId} is not in this Home Assistant. It stays configured, and the card renders
+          without it.
+        </Text>
+      )}
+
+      {description && (
+        <Text size="1" color="gray">
+          {description}
+        </Text>
+      )}
+    </Flex>
+  )
+}

--- a/src/components/EntityPicker.tsx
+++ b/src/components/EntityPicker.tsx
@@ -111,10 +111,21 @@ export function EntityPicker({
       ? 'Not connected to Home Assistant — no entities to choose from.'
       : 'No entity matches that search.'
 
-  const commit = (entityId: string) => {
-    onChange(entityId)
+  /*
+   * Closing is the only place the search resets, and every way of closing goes
+   * through it — picking an entity, but also Escape and a click outside. A
+   * search that outlived its popover would silently re-apply itself on the next
+   * open, and a filtered list that nobody asked to filter reads as "that entity
+   * is not in Home Assistant".
+   */
+  const close = () => {
     setOpen(false)
     setSearch('')
+  }
+
+  const commit = (entityId: string) => {
+    onChange(entityId)
+    close()
   }
 
   return (
@@ -123,7 +134,7 @@ export function EntityPicker({
         {label}
       </Text>
 
-      <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Root open={open} onOpenChange={(next) => (next ? setOpen(true) : close())}>
         <Popover.Trigger>
           <Button size="3" variant="soft" color="gray" aria-label={label}>
             <Text truncate>

--- a/src/components/EntityPicker.tsx
+++ b/src/components/EntityPicker.tsx
@@ -50,6 +50,51 @@ function matchesSearch(entity: HassEntity, search: string): boolean {
 }
 
 /**
+ * Names the kind of entity the list is restricted to, so an empty list can say
+ * what it was looking for — `motion binary_sensor`, `battery sensor`. Only
+ * called when at least one filter is set, because with no filters an empty
+ * list is the "no entities at all" case instead.
+ */
+function describeFilters(domains: string[] | undefined, deviceClasses: string[] | undefined) {
+  return [deviceClasses?.join('/'), domains?.join('/')].filter(Boolean).join(' ')
+}
+
+interface EmptyListState {
+  isLoading: boolean
+  isConnected: boolean
+  /** Whether Home Assistant has any entities at all, before any filtering. */
+  hasEntities: boolean
+  /** Whether any entity survived `domains`/`deviceClasses`, before the search. */
+  hasAvailable: boolean
+  domains?: string[]
+  deviceClasses?: string[]
+}
+
+/**
+ * Why the list is empty, in the user's terms. Four causes reach this, and only
+ * the last one is the search: the panel may still be loading, may not be
+ * talking to Home Assistant at all, or may have had nothing to offer before a
+ * key was pressed. Blaming a search the user never typed sends them to fix a
+ * config that is not the problem.
+ */
+function emptyListMessage({
+  isLoading,
+  isConnected,
+  hasEntities,
+  hasAvailable,
+  domains,
+  deviceClasses,
+}: EmptyListState): string {
+  if (isLoading) return 'Still loading entities from Home Assistant…'
+  if (!isConnected) return 'Not connected to Home Assistant — no entities to choose from.'
+  if (!hasEntities) return 'This Home Assistant has no entities to choose from.'
+  if (!hasAvailable) {
+    return `This Home Assistant has no ${describeFilters(domains, deviceClasses)} entities to link.`
+  }
+  return 'No entity matches that search.'
+}
+
+/**
  * The entity picker — the config control behind every option that links a
  * second entity to a card (`motionEntity`, `doorEntity`, `batteryEntity`).
  *
@@ -90,26 +135,33 @@ export function EntityPicker({
   const selectedId = parsed.success ? parsed.data : ENTITY_LINK_DEFAULT
   const selectedEntity = selectedId ? entities[selectedId] : undefined
 
-  const matches = React.useMemo(() => {
+  /*
+   * The filters and the search are applied in two steps so the empty list can
+   * tell them apart: an option that asks for `motion binary_sensor` on an
+   * instance with none of them is empty before the user types anything, and
+   * that is a different sentence from a search that found nothing.
+   */
+  const available = React.useMemo(() => {
     return Object.values(entities)
       .filter((entity) => matchesFilters(entity, domains, deviceClasses))
-      .filter((entity) => matchesSearch(entity, search))
       .sort((a, b) => friendlyNameOf(a).localeCompare(friendlyNameOf(b)))
-  }, [entities, domains, deviceClasses, search])
+  }, [entities, domains, deviceClasses])
+
+  const matches = React.useMemo(
+    () => available.filter((entity) => matchesSearch(entity, search)),
+    [available, search]
+  )
 
   const shown = matches.slice(0, MAX_RESULTS)
 
-  /*
-   * An empty list has three causes and only one of them is the user's search.
-   * Saying "no match" while the panel is still loading, or while it is not
-   * talking to Home Assistant at all, describes the config as the problem when
-   * the connection is.
-   */
-  const emptyMessage = isLoading
-    ? 'Still loading entities from Home Assistant…'
-    : !isConnected
-      ? 'Not connected to Home Assistant — no entities to choose from.'
-      : 'No entity matches that search.'
+  const emptyMessage = emptyListMessage({
+    isLoading,
+    isConnected,
+    hasEntities: Object.keys(entities).length > 0,
+    hasAvailable: available.length > 0,
+    domains,
+    deviceClasses,
+  })
 
   /*
    * Closing is the only place the search resets, and every way of closing goes

--- a/src/components/NumberArrayEditor.stories.tsx
+++ b/src/components/NumberArrayEditor.stories.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Box, Code, Flex, Text } from '@radix-ui/themes'
+import { NumberArrayEditor } from './NumberArrayEditor'
+
+/**
+ * The number-array editor — the configuration control behind list-of-number
+ * options, the first of which is the light card's `brightnessPresets`.
+ *
+ * Values are added one at a time against the option's own bounds and removed by
+ * tapping them; the stored order is the order the card renders them in, so the
+ * control never sorts. What the card stores is shown under each story, because
+ * that array is what round-trips through the YAML export.
+ */
+const meta: Meta<typeof NumberArrayEditor> = {
+  title: 'Shell/Card Configuration/Number Array Editor',
+  component: NumberArrayEditor,
+  args: {
+    label: 'Brightness presets',
+    min: 1,
+    max: 100,
+    step: 1,
+    integer: true,
+    unit: '%',
+  },
+  render: function Render({ value: initialValue, ...args }) {
+    const [value, setValue] = useState<unknown>(initialValue ?? [])
+
+    return (
+      <Box style={{ maxWidth: '380px' }}>
+        <Flex direction="column" gap="3">
+          <NumberArrayEditor {...args} value={value} onChange={setValue} />
+          <Flex direction="column" gap="1">
+            <Text size="1" color="gray">
+              Stored as
+            </Text>
+            <Code size="1">{JSON.stringify(value)}</Code>
+          </Flex>
+        </Flex>
+      </Box>
+    )
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof NumberArrayEditor>
+
+/** The default: an empty list, which hides the preset row on the card. */
+export const Empty: Story = {
+  args: { value: [], description: 'Percent presets, shown as pills on full-size cards.' },
+}
+
+/** A configured set. The order is the user's, and is kept as stored. */
+export const Configured: Story = {
+  args: { value: [20, 50, 100] },
+}
+
+/**
+ * A configuration this build cannot fully use — `150` is out of range and
+ * `"ten"` is not a number. Both are shown greyed and kept: removing `20` leaves
+ * them exactly where they were.
+ */
+export const WithUnusableEntries: Story = {
+  args: { value: [150, 'ten', 20] },
+}
+
+/** Unbounded, for options that accept any finite number. */
+export const WithoutBounds: Story = {
+  args: {
+    label: 'Values',
+    value: [3.5, -2],
+    min: undefined,
+    max: undefined,
+    integer: false,
+    unit: undefined,
+  },
+}

--- a/src/components/NumberArrayEditor.tsx
+++ b/src/components/NumberArrayEditor.tsx
@@ -1,0 +1,175 @@
+import * as React from 'react'
+import { Button, Flex, Text, TextField } from '@radix-ui/themes'
+import { X } from 'lucide-react'
+import { numberEntrySchema, readStoredList, type NumberEntryBounds } from '~/store/configControls'
+
+export interface NumberArrayEditorProps extends NumberEntryBounds {
+  label: string
+  description?: string
+  /** The stored value, which may be anything a hand-edited config contains. */
+  value: unknown
+  /** Spinner increment for the add field; does not constrain what is accepted. */
+  step?: number
+  /** Suffix shown after each value — `%` for brightness presets. */
+  unit?: string
+  placeholder?: string
+  onChange: (values: unknown[]) => void
+}
+
+/**
+ * The number-array editor — the config control behind list-of-number options
+ * such as the light card's `brightnessPresets`.
+ *
+ * Values are added one at a time and removed by tapping them, which keeps the
+ * whole control to two touch targets per entry and needs no drag affordance.
+ * Stored order is the order they render in, so the control never sorts: the
+ * user's arrangement is part of the configuration.
+ *
+ * **Only a value the entry schema accepts is ever added**, and an entry already
+ * in the list is refused rather than silently deduplicated — the same rule the
+ * action editor follows, for the same reason: a config that fails the import
+ * gate on someone else's machine is a defect a long way from its cause.
+ *
+ * **Entries this build cannot use are shown, not dropped.** A stored `150` in a
+ * 1–100 option, or an entry that is not a number at all, is rendered greyed with
+ * what will happen to it spelled out, and removing a *different* entry leaves it
+ * exactly as stored (docs/specs/dashboard-config/index.md — "Forward
+ * Compatibility"). Rewriting it would turn opening the form into a silent edit.
+ */
+export function NumberArrayEditor({
+  label,
+  description,
+  value,
+  min,
+  max,
+  integer,
+  step,
+  unit = '',
+  placeholder = 'Add a value',
+  onChange,
+}: NumberArrayEditorProps) {
+  const [draft, setDraft] = React.useState('')
+  const [error, setError] = React.useState<string | null>(null)
+
+  const entries = readStoredList(value)
+  const entrySchema = numberEntrySchema({ min, max, integer })
+
+  const isUsable = (entry: unknown) => entrySchema.safeParse(entry).success
+  const describe = (entry: unknown) =>
+    typeof entry === 'number' ? `${entry}${unit}` : String(entry)
+
+  const ignoredCount = entries.filter((entry) => !isUsable(entry)).length
+
+  const add = () => {
+    if (!draft.trim()) {
+      setError('Enter a number to add.')
+      return
+    }
+
+    const parsed = entrySchema.safeParse(Number(draft))
+    if (!parsed.success) {
+      setError(parsed.error.issues[0].message)
+      return
+    }
+
+    if (entries.some((entry) => entry === parsed.data)) {
+      setError(`${describe(parsed.data)} is already in the list.`)
+      return
+    }
+
+    setError(null)
+    setDraft('')
+    onChange([...entries, parsed.data])
+  }
+
+  const removeAt = (index: number) => {
+    // Filtered by position rather than by value: the list may legitimately hold
+    // an entry this build does not understand, and matching on value would need
+    // to understand it.
+    onChange(entries.filter((_, entryIndex) => entryIndex !== index))
+  }
+
+  return (
+    <Flex direction="column" gap="1">
+      <Text size="2" weight="medium">
+        {label}
+      </Text>
+
+      {entries.length === 0 ? (
+        <Text size="1" color="gray">
+          Nothing set — the card renders no values.
+        </Text>
+      ) : (
+        <Flex gap="2" wrap="wrap">
+          {entries.map((entry, index) => (
+            <Button
+              key={`${describe(entry)}-${index}`}
+              size="3"
+              variant="soft"
+              color={isUsable(entry) ? 'blue' : 'gray'}
+              /*
+               * Radix's accent-11 text on an accent-3 surface lands at 4.25:1 in
+               * the light appearance — under AA for text this size. The
+               * high-contrast step is the design system's own answer to that
+               * (docs/specs/storybook/index.md — a11y), and it costs nothing in
+               * the dark appearance, which already passes.
+               */
+              highContrast
+              aria-label={`Remove ${describe(entry)}`}
+              onClick={() => removeAt(index)}
+            >
+              {describe(entry)}
+              {!isUsable(entry) && ' (ignored)'}
+              <X size={14} />
+            </Button>
+          ))}
+        </Flex>
+      )}
+
+      {ignoredCount > 0 && (
+        <Text size="1" color="gray">
+          Greyed values stay in the configuration but are skipped when the card renders.
+        </Text>
+      )}
+
+      <Flex gap="2" mt="1">
+        <TextField.Root
+          size="3"
+          type="number"
+          style={{ flex: 1 }}
+          // The refusal is only useful if it reaches the field it is about:
+          // `aria-invalid` marks the input, and the message below announces
+          // itself, so a screen-reader user finds out why Add did nothing.
+          aria-invalid={Boolean(error)}
+          value={draft}
+          min={min}
+          max={max}
+          step={step}
+          placeholder={placeholder}
+          aria-label={`${label} to add`}
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key !== 'Enter') return
+            event.preventDefault()
+            add()
+          }}
+        />
+        <Button size="3" variant="soft" onClick={add}>
+          Add
+        </Button>
+      </Flex>
+
+      {error ? (
+        <Text size="1" color="red" role="alert">
+          {error}
+        </Text>
+      ) : (
+        description && (
+          <Text size="1" color="gray">
+            {description}
+          </Text>
+        )
+      )}
+    </Flex>
+  )
+}

--- a/src/components/OrderedMultiSelect.stories.tsx
+++ b/src/components/OrderedMultiSelect.stories.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Box, Code, Flex, Text } from '@radix-ui/themes'
+import { OrderedMultiSelect } from './OrderedMultiSelect'
+
+/**
+ * The ordered multi-select — the configuration control behind options that are
+ * an ordered subset of a canonical enum, the first of which is the alarm card's
+ * `armModes`.
+ *
+ * Order is data, not decoration: the first entry is the mode the small tiers
+ * offer as their single pill, so selecting and arranging are separate gestures.
+ * The choice list is the canonical enum narrowed to what the entity supports —
+ * these stories use the alarm arm modes, and the last one shows what happens
+ * when a stored mode is not in that list.
+ */
+const ARM_MODES = [
+  { value: 'away', label: 'Away' },
+  { value: 'home', label: 'Home' },
+  { value: 'night', label: 'Night' },
+  { value: 'vacation', label: 'Vacation' },
+]
+
+const meta: Meta<typeof OrderedMultiSelect> = {
+  title: 'Shell/Card Configuration/Ordered Multi-Select',
+  component: OrderedMultiSelect,
+  args: { label: 'Arm modes', options: ARM_MODES },
+  render: function Render({ value: initialValue, ...args }) {
+    const [value, setValue] = useState<unknown>(initialValue ?? [])
+
+    return (
+      <Box style={{ maxWidth: '380px' }}>
+        <Flex direction="column" gap="3">
+          <OrderedMultiSelect {...args} value={value} onChange={setValue} />
+          <Flex direction="column" gap="1">
+            <Text size="1" color="gray">
+              Stored as
+            </Text>
+            <Code size="1">{JSON.stringify(value)}</Code>
+          </Flex>
+        </Flex>
+      </Box>
+    )
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof OrderedMultiSelect>
+
+/** Everything the panel supports, in the default order. */
+export const AllModes: Story = {
+  args: {
+    value: ['away', 'home', 'night', 'vacation'],
+    description: 'The first mode is the one small cards offer.',
+  },
+}
+
+/** A household that hides the modes it never uses, and leads with Night. */
+export const Rearranged: Story = {
+  args: { value: ['night', 'away'] },
+}
+
+/** Nothing selected — a valid configuration, and the card shows no pills. */
+export const Empty: Story = {
+  args: { value: [] },
+}
+
+/** A panel whose `supported_features` advertises only two of the four modes. */
+export const NarrowedChoiceList: Story = {
+  args: {
+    value: ['away', 'home'],
+    options: ARM_MODES.slice(0, 2),
+  },
+}
+
+/**
+ * A stored mode this build was not offered — from a newer version, a
+ * hand-edited config, or a panel that stopped advertising it. It is kept in
+ * place and marked, never quietly dropped.
+ */
+export const WithUnavailableMode: Story = {
+  args: { value: ['away', 'armed_custom_bypass', 'night'] },
+}

--- a/src/components/OrderedMultiSelect.tsx
+++ b/src/components/OrderedMultiSelect.tsx
@@ -1,0 +1,144 @@
+import { Button, Flex, IconButton, Text } from '@radix-ui/themes'
+import { ChevronDown, ChevronUp, Plus, X } from 'lucide-react'
+import { readStoredList } from '~/store/configControls'
+
+export interface OrderedMultiSelectOption {
+  value: string
+  label: string
+}
+
+export interface OrderedMultiSelectProps {
+  label: string
+  description?: string
+  /** The stored value, which may be anything a hand-edited config contains. */
+  value: unknown
+  /**
+   * The canonical choice list, in the order it is offered. A card whose entity
+   * supports only some of the values passes the narrowed list — the control
+   * offers what it is given and keeps what it is stored.
+   */
+  options: OrderedMultiSelectOption[]
+  onChange: (values: unknown[]) => void
+}
+
+/**
+ * The ordered multi-select — the config control behind options that are a
+ * subset of a canonical enum *in a user-chosen order*, such as the alarm card's
+ * `armModes`, whose first entry is also the mode its single-pill tiers offer.
+ *
+ * Order is why this is not a set of checkboxes: the stored sequence is data the
+ * card reads, so selecting has to be separable from arranging. Each selected
+ * value therefore carries its own move-up/move-down/remove controls, and the
+ * unselected values are appended from a row of add buttons.
+ *
+ * **A stored value the caller did not offer is kept in place.** It arrives that
+ * way from a newer build, from a hand-edited config, or from an entity whose
+ * `supported_features` no longer advertises it — none of which make it the
+ * form's business to delete. It renders where it is stored, marked as not
+ * available, and moves and removes like any other entry, so the user can act on
+ * it deliberately (docs/specs/dashboard-config/index.md — "Forward
+ * Compatibility").
+ */
+export function OrderedMultiSelect({
+  label,
+  description,
+  value,
+  options,
+  onChange,
+}: OrderedMultiSelectProps) {
+  const selected = readStoredList(value)
+  const labelOf = (entry: unknown) =>
+    options.find((option) => option.value === entry)?.label ?? String(entry)
+  const isOffered = (entry: unknown) => options.some((option) => option.value === entry)
+
+  const available = options.filter((option) => !selected.includes(option.value))
+
+  const move = (index: number, delta: number) => {
+    const next = [...selected]
+    const [entry] = next.splice(index, 1)
+    next.splice(index + delta, 0, entry)
+    onChange(next)
+  }
+
+  const removeAt = (index: number) => {
+    onChange(selected.filter((_, entryIndex) => entryIndex !== index))
+  }
+
+  return (
+    <Flex direction="column" gap="1">
+      <Text size="2" weight="medium">
+        {label}
+      </Text>
+
+      {selected.length === 0 ? (
+        <Text size="1" color="gray">
+          Nothing selected — the card shows none of these.
+        </Text>
+      ) : (
+        <Flex direction="column" gap="1">
+          {selected.map((entry, index) => (
+            <Flex key={`${String(entry)}-${index}`} align="center" gap="2">
+              <Text size="2" color={isOffered(entry) ? undefined : 'gray'} style={{ flex: 1 }}>
+                {labelOf(entry)}
+                {!isOffered(entry) && ' (not available)'}
+              </Text>
+              <IconButton
+                size="3"
+                variant="soft"
+                color="gray"
+                aria-label={`Move ${labelOf(entry)} up`}
+                disabled={index === 0}
+                onClick={() => move(index, -1)}
+              >
+                <ChevronUp size={16} />
+              </IconButton>
+              <IconButton
+                size="3"
+                variant="soft"
+                color="gray"
+                aria-label={`Move ${labelOf(entry)} down`}
+                disabled={index === selected.length - 1}
+                onClick={() => move(index, 1)}
+              >
+                <ChevronDown size={16} />
+              </IconButton>
+              <IconButton
+                size="3"
+                variant="soft"
+                color="gray"
+                aria-label={`Remove ${labelOf(entry)}`}
+                onClick={() => removeAt(index)}
+              >
+                <X size={16} />
+              </IconButton>
+            </Flex>
+          ))}
+        </Flex>
+      )}
+
+      {available.length > 0 && (
+        <Flex gap="2" wrap="wrap" mt="1">
+          {available.map((option) => (
+            <Button
+              key={option.value}
+              size="3"
+              variant="soft"
+              color="gray"
+              aria-label={`Add ${option.label}`}
+              onClick={() => onChange([...selected, option.value])}
+            >
+              <Plus size={14} />
+              {option.label}
+            </Button>
+          ))}
+        </Flex>
+      )}
+
+      {description && (
+        <Text size="1" color="gray">
+          {description}
+        </Text>
+      )}
+    </Flex>
+  )
+}

--- a/src/components/__tests__/CardConfig.test.tsx
+++ b/src/components/__tests__/CardConfig.test.tsx
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { CardConfig } from '../CardConfig'
+import { CardConfig, type ConfigDefinition } from '../CardConfig'
 import { Theme } from '@radix-ui/themes'
+import { entityStore } from '~/store/entityStore'
 import type { GridItem } from '~/store/types'
+import { createBinarySensorEntity } from '~/test/fixtures'
 
 // Mock the store
 vi.mock('~/store', () => ({
@@ -591,6 +593,134 @@ describe('CardConfig', () => {
       await user.click(screen.getByRole('button', { name: /save changes/i }))
 
       expect(mockOnSave).toHaveBeenCalledWith({ config: { icon: '' } })
+    })
+  })
+
+  /**
+   * The three shared non-scalar controls, reached the way a card reaches them:
+   * through its `ConfigDefinition`. No card declares one yet — they exist so the
+   * per-card changes that need them (`motionEntity`, `brightnessPresets`,
+   * `armModes`) consume a control rather than invent one — so what is asserted
+   * here is the form wiring: the right control for the type, seeded with the
+   * option's default, writing back under the option's key.
+   */
+  describe('Non-scalar option types', () => {
+    const definition: ConfigDefinition = {
+      motionEntity: {
+        type: 'entity',
+        default: '',
+        label: 'Motion sensor',
+        domains: ['binary_sensor'],
+        deviceClasses: ['motion'],
+        placeholder: 'No motion sensor',
+      },
+      brightnessPresets: {
+        type: 'number-array',
+        default: [],
+        label: 'Brightness presets',
+        min: 1,
+        max: 100,
+        step: 1,
+        integer: true,
+        unit: '%',
+      },
+      armModes: {
+        type: 'ordered-multi-select',
+        default: ['away', 'home'],
+        label: 'Arm modes',
+        options: [
+          { value: 'away', label: 'Away' },
+          { value: 'home', label: 'Home' },
+        ],
+      },
+    }
+
+    function renderForm(config: Record<string, unknown> = {}) {
+      const onChange = vi.fn()
+      render(
+        <Theme>
+          <CardConfig.Component
+            title="Card"
+            configDefinition={definition}
+            config={config}
+            onChange={onChange}
+          />
+        </Theme>
+      )
+      return onChange
+    }
+
+    beforeEach(() => {
+      entityStore.setState((state) => ({
+        ...state,
+        entities: {
+          'binary_sensor.driveway_motion': createBinarySensorEntity({
+            entity_id: 'binary_sensor.driveway_motion',
+            attributes: { friendly_name: 'Driveway Motion', device_class: 'motion' },
+          }),
+        },
+        isConnected: true,
+        isInitialLoading: false,
+      }))
+    })
+
+    it('renders each control against its option’s default', () => {
+      renderForm()
+
+      expect(screen.getByRole('button', { name: 'Motion sensor' })).toHaveTextContent(
+        'No motion sensor'
+      )
+      expect(screen.getByText('Nothing set — the card renders no values.')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Move Away up' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Move Home down' })).toBeInTheDocument()
+    })
+
+    it('writes the entity picker’s choice back under its key', async () => {
+      const user = userEvent.setup()
+      const onChange = renderForm()
+
+      await user.click(screen.getByRole('button', { name: 'Motion sensor' }))
+      await user.click(await screen.findByText('Driveway Motion'))
+
+      expect(onChange).toHaveBeenCalledWith({ motionEntity: 'binary_sensor.driveway_motion' })
+    })
+
+    it('writes an added number back under its key', async () => {
+      const user = userEvent.setup()
+      const onChange = renderForm()
+
+      await user.type(screen.getByLabelText('Brightness presets to add'), '50')
+      await user.click(screen.getByRole('button', { name: 'Add' }))
+
+      expect(onChange).toHaveBeenCalledWith({ brightnessPresets: [50] })
+    })
+
+    it('writes a reordered selection back under its key', async () => {
+      const user = userEvent.setup()
+      const onChange = renderForm({ armModes: ['away', 'home'] })
+
+      await user.click(screen.getByRole('button', { name: 'Move Home up' }))
+
+      expect(onChange).toHaveBeenCalledWith({ armModes: ['home', 'away'] })
+    })
+
+    it('renders an ordered multi-select that was given no choices at all', () => {
+      render(
+        <Theme>
+          <CardConfig.Component
+            title="Card"
+            configDefinition={{
+              armModes: { type: 'ordered-multi-select', default: [], label: 'Arm modes' },
+            }}
+            config={{}}
+            onChange={vi.fn()}
+          />
+        </Theme>
+      )
+
+      expect(
+        screen.getByText('Nothing selected — the card shows none of these.')
+      ).toBeInTheDocument()
     })
   })
 })

--- a/src/components/__tests__/EntityPicker.test.tsx
+++ b/src/components/__tests__/EntityPicker.test.tsx
@@ -164,6 +164,67 @@ describe('EntityPicker', () => {
     }
   )
 
+  it('says the instance is empty when there is nothing to choose from at all', async () => {
+    // Connected, done loading, and no entities: the user has not searched, and
+    // no filter is in the way. Nothing about their config is wrong.
+    seed([])
+    renderPicker()
+    await openPicker()
+
+    expect(
+      screen.getByText('This Home Assistant has no entities to choose from.')
+    ).toBeInTheDocument()
+    expect(screen.queryByText('No entity matches that search.')).not.toBeInTheDocument()
+  })
+
+  it('names the kind of entity it wanted when the filters leave nothing', async () => {
+    // The instance has entities, just none of the kind this option links. The
+    // next action is to add such an entity in Home Assistant, not to search.
+    seed([battery])
+    renderPicker({ domains: ['binary_sensor'], deviceClasses: ['motion'] })
+    await openPicker()
+
+    expect(
+      screen.getByText('This Home Assistant has no motion binary_sensor entities to link.')
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText('Motion sensor search')).toHaveValue('')
+  })
+
+  it('names only the filter it was given', async () => {
+    seed([battery])
+    renderPicker({ domains: ['light'] })
+    await openPicker()
+
+    expect(
+      screen.getByText('This Home Assistant has no light entities to link.')
+    ).toBeInTheDocument()
+  })
+
+  it('blames the filters, not the search, when both would come up empty', async () => {
+    // A search typed into a list that was already empty must not change the
+    // diagnosis: the filters emptied it, and clearing the search fixes nothing.
+    seed([battery])
+    renderPicker({ domains: ['light'] })
+    await openPicker()
+    fireEvent.change(screen.getByLabelText('Motion sensor search'), {
+      target: { value: 'kitchen' },
+    })
+
+    expect(
+      screen.getByText('This Home Assistant has no light entities to link.')
+    ).toBeInTheDocument()
+  })
+
+  it('blames the search only when there was something to search', async () => {
+    renderPicker()
+    await openPicker()
+    fireEvent.change(screen.getByLabelText('Motion sensor search'), {
+      target: { value: 'nothing like this' },
+    })
+
+    expect(screen.getByText('No entity matches that search.')).toBeInTheDocument()
+  })
+
   it('falls back to the entity id for an entity with no friendly name', async () => {
     seed([createSensorEntity({ entity_id: 'sensor.unnamed', attributes: { friendly_name: '' } })])
     renderPicker()

--- a/src/components/__tests__/EntityPicker.test.tsx
+++ b/src/components/__tests__/EntityPicker.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Theme } from '@radix-ui/themes'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { EntityPicker } from '../EntityPicker'
-import { entityStore } from '~/store/entityStore'
+import { entityStore, entityStoreActions } from '~/store/entityStore'
 import type { HassEntity } from '~/store/entityTypes'
 import { createBinarySensorEntity, createSensorEntity } from '~/test/fixtures'
 
@@ -290,6 +290,93 @@ describe('EntityPicker', () => {
       'No entity linked'
     )
     expect(onChange).not.toHaveBeenCalled()
+  })
+
+  /**
+   * The picker reads every entity there is, because its filters are predicates
+   * over domain and `device_class` rather than a list of ids — so it re-renders
+   * on every entity-store batch, and a real Home Assistant produces those
+   * continuously for thousands of entities. The list must therefore cost
+   * nothing while nobody is looking at it: this control sits in every card's
+   * config form, and sorting a few thousand names behind a closed popover is
+   * what makes typing in an unrelated field stutter.
+   *
+   * The probe counts reads of `friendly_name`, which is what building the list
+   * does — the sort comparator reads two per comparison. Zero reads is the
+   * assertion, and it holds only if nothing is built, filtered, sorted or
+   * sliced.
+   */
+  describe('while the popover is closed', () => {
+    let nameReads = 0
+
+    function probe(index: number): HassEntity {
+      const id = `sensor.probe_${String(index).padStart(3, '0')}`
+      const entity = createSensorEntity({ entity_id: id, attributes: { friendly_name: '' } })
+      Object.defineProperty(entity.attributes, 'friendly_name', {
+        get: () => {
+          nameReads++
+          return `Probe ${String(index).padStart(3, '0')}`
+        },
+        configurable: true,
+      })
+      return entity
+    }
+
+    beforeEach(() => {
+      nameReads = 0
+      seed(Array.from({ length: 400 }, (_, index) => probe(index)))
+    })
+
+    /** Tens of batches, each touching a handful of entities, as HA delivers them. */
+    function driveUpdates(batches = 30) {
+      for (let batch = 0; batch < batches; batch++) {
+        act(() => {
+          entityStoreActions.updateEntities(
+            Array.from({ length: 5 }, (_, offset) => probe((batch * 5 + offset) % 400))
+          )
+        })
+      }
+    }
+
+    it('never builds the list, however many entity updates arrive', () => {
+      renderPicker()
+      nameReads = 0
+
+      driveUpdates()
+
+      expect(nameReads).toBe(0)
+    })
+
+    it('still has a current list in the first frame it opens', async () => {
+      renderPicker()
+      driveUpdates()
+      // A name that changed while the popover was closed. Deferred work must not
+      // show the list as it was before these updates, nor show it empty first.
+      act(() => {
+        entityStoreActions.updateEntities([
+          createSensorEntity({
+            entity_id: 'sensor.probe_000',
+            attributes: { friendly_name: 'Aaa Renamed While Closed' },
+          }),
+        ])
+      })
+
+      await openPicker()
+
+      expect(screen.getByText('Aaa Renamed While Closed')).toBeInTheDocument()
+      expect(
+        screen.getByText('Showing 50 of 400 — keep typing to narrow it down')
+      ).toBeInTheDocument()
+    })
+
+    it('keeps showing the linked entity by name', () => {
+      // The trigger reads one name on every render and must go on doing so: the
+      // gate is about the list, not about the selection.
+      renderPicker({ value: 'sensor.probe_007' })
+      driveUpdates()
+
+      expect(screen.getByRole('button', { name: 'Motion sensor' })).toHaveTextContent('Probe 007')
+    })
   })
 
   it('renders its description when given one', () => {

--- a/src/components/__tests__/EntityPicker.test.tsx
+++ b/src/components/__tests__/EntityPicker.test.tsx
@@ -119,6 +119,29 @@ describe('EntityPicker', () => {
     expect(screen.getByText('No entity matches that search.')).toBeInTheDocument()
   })
 
+  it('forgets the search when the popover is dismissed without a selection', async () => {
+    renderPicker()
+    await openPicker()
+    fireEvent.change(screen.getByLabelText('Motion sensor search'), {
+      target: { value: 'driveway' },
+    })
+    expect(screen.queryByText('Phone Battery')).not.toBeInTheDocument()
+
+    // Escape and a click outside are how a user abandons a search, and neither
+    // goes through the commit path. A search that survived would filter the
+    // next open without the field showing it — the entity looks missing.
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+    await waitFor(() =>
+      expect(screen.queryByLabelText('Motion sensor search')).not.toBeInTheDocument()
+    )
+
+    await openPicker()
+    expect(screen.getByLabelText('Motion sensor search')).toHaveValue('')
+    expect(screen.getByText('Phone Battery')).toBeInTheDocument()
+    expect(screen.getByText('3 available')).toBeInTheDocument()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
   it.each([
     [
       'still loading',

--- a/src/components/__tests__/EntityPicker.test.tsx
+++ b/src/components/__tests__/EntityPicker.test.tsx
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Theme } from '@radix-ui/themes'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { EntityPicker } from '../EntityPicker'
+import { entityStore } from '~/store/entityStore'
+import type { HassEntity } from '~/store/entityTypes'
+import { createBinarySensorEntity, createSensorEntity } from '~/test/fixtures'
+
+/**
+ * The picker behind every option that links a second entity to a card
+ * (`motionEntity`, `doorEntity`, `batteryEntity`).
+ *
+ * Two things carry the weight: what it emits is always an entity that exists
+ * (it is picked from the list, never typed), and what it is *given* is never
+ * rewritten — a dashboard shared as YAML routinely lands on an instance that
+ * does not have the linked entity, and opening the config form must not be the
+ * thing that deletes the link.
+ */
+describe('EntityPicker', () => {
+  const onChange = vi.fn()
+
+  const motion = createBinarySensorEntity({
+    entity_id: 'binary_sensor.driveway_motion',
+    attributes: { friendly_name: 'Driveway Motion', device_class: 'motion' },
+  })
+  const door = createBinarySensorEntity()
+  const battery = createSensorEntity({
+    entity_id: 'sensor.phone_battery',
+    attributes: { friendly_name: 'Phone Battery', device_class: 'battery' },
+  })
+
+  function seed(entities: HassEntity[]) {
+    entityStore.setState((state) => ({
+      ...state,
+      entities: Object.fromEntries(entities.map((entity) => [entity.entity_id, entity])),
+      isConnected: true,
+      isInitialLoading: false,
+    }))
+  }
+
+  function renderPicker(props: Partial<React.ComponentProps<typeof EntityPicker>> = {}) {
+    return render(
+      <Theme>
+        <EntityPicker label="Motion sensor" value="" onChange={onChange} {...props} />
+      </Theme>
+    )
+  }
+
+  async function openPicker(label = 'Motion sensor') {
+    fireEvent.click(screen.getByRole('button', { name: label }))
+    await waitFor(() => expect(screen.getByLabelText(`${label} search`)).toBeInTheDocument())
+  }
+
+  beforeEach(() => {
+    onChange.mockClear()
+    seed([motion, door, battery])
+  })
+
+  afterEach(() => {
+    entityStore.setState((state) => ({ ...state, entities: {} }))
+  })
+
+  it('says nothing is linked, and offers every entity when unfiltered', async () => {
+    renderPicker()
+    expect(screen.getByRole('button', { name: 'Motion sensor' })).toHaveTextContent(
+      'No entity linked'
+    )
+
+    await openPicker()
+    expect(screen.getByText('Driveway Motion')).toBeInTheDocument()
+    expect(screen.getByText('Phone Battery')).toBeInTheDocument()
+    expect(screen.getByText('3 available')).toBeInTheDocument()
+  })
+
+  it('uses the caller’s placeholder when it has one', () => {
+    renderPicker({ placeholder: 'Link a motion sensor' })
+    expect(screen.getByRole('button', { name: 'Motion sensor' })).toHaveTextContent(
+      'Link a motion sensor'
+    )
+  })
+
+  it('offers only the requested domains and device classes', async () => {
+    renderPicker({ domains: ['binary_sensor'], deviceClasses: ['motion'] })
+    await openPicker()
+
+    expect(screen.getByText('Driveway Motion')).toBeInTheDocument()
+    // A door sensor is the right domain and the wrong class; the battery sensor
+    // is neither.
+    expect(screen.queryByText('Front Door')).not.toBeInTheDocument()
+    expect(screen.queryByText('Phone Battery')).not.toBeInTheDocument()
+  })
+
+  it('emits the picked entity id and closes', async () => {
+    renderPicker()
+    await openPicker()
+
+    fireEvent.click(screen.getByText('Driveway Motion'))
+
+    expect(onChange).toHaveBeenCalledWith('binary_sensor.driveway_motion')
+    await waitFor(() =>
+      expect(screen.queryByLabelText('Motion sensor search')).not.toBeInTheDocument()
+    )
+  })
+
+  it('searches by friendly name and by entity id', async () => {
+    renderPicker()
+    await openPicker()
+    const search = screen.getByLabelText('Motion sensor search')
+
+    fireEvent.change(search, { target: { value: 'driveway' } })
+    expect(screen.getByText('Driveway Motion')).toBeInTheDocument()
+    expect(screen.queryByText('Phone Battery')).not.toBeInTheDocument()
+
+    fireEvent.change(search, { target: { value: 'sensor.phone' } })
+    expect(screen.getByText('Phone Battery')).toBeInTheDocument()
+    expect(screen.queryByText('Driveway Motion')).not.toBeInTheDocument()
+
+    fireEvent.change(search, { target: { value: 'nothing like this' } })
+    expect(screen.getByText('No entity matches that search.')).toBeInTheDocument()
+  })
+
+  it.each([
+    [
+      'still loading',
+      { isConnected: false, isInitialLoading: true },
+      'Still loading entities from Home Assistant…',
+    ],
+    [
+      'disconnected',
+      { isConnected: false, isInitialLoading: false },
+      'Not connected to Home Assistant — no entities to choose from.',
+    ],
+  ])(
+    'says the list is empty because it is %s, not because nothing matched',
+    async (_case, connection, message) => {
+      entityStore.setState((state) => ({ ...state, entities: {}, ...connection }))
+      renderPicker()
+      await openPicker()
+
+      expect(screen.getByText(message)).toBeInTheDocument()
+    }
+  )
+
+  it('falls back to the entity id for an entity with no friendly name', async () => {
+    seed([createSensorEntity({ entity_id: 'sensor.unnamed', attributes: { friendly_name: '' } })])
+    renderPicker()
+    await openPicker()
+
+    expect(screen.getAllByText('sensor.unnamed').length).toBeGreaterThan(0)
+  })
+
+  it('caps the list and says how many matched', async () => {
+    seed(
+      Array.from({ length: 60 }, (_, index) =>
+        createSensorEntity({
+          entity_id: `sensor.probe_${index}`,
+          attributes: { friendly_name: `Probe ${String(index).padStart(2, '0')}` },
+        })
+      )
+    )
+    renderPicker()
+    await openPicker()
+
+    expect(screen.getByText('Showing 50 of 60 — keep typing to narrow it down')).toBeInTheDocument()
+    expect(screen.getByText('Probe 49')).toBeInTheDocument()
+    expect(screen.queryByText('Probe 59')).not.toBeInTheDocument()
+  })
+
+  it('shows the linked entity by name, and clears back to nothing linked', async () => {
+    renderPicker({ value: 'binary_sensor.driveway_motion' })
+    expect(screen.getByRole('button', { name: 'Motion sensor' })).toHaveTextContent(
+      'Driveway Motion'
+    )
+
+    await openPicker()
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }))
+
+    expect(onChange).toHaveBeenCalledWith('')
+  })
+
+  it('keeps a stored id this instance cannot resolve, and says what will happen', () => {
+    renderPicker({ value: 'binary_sensor.moved_house' })
+
+    expect(screen.getByRole('button', { name: 'Motion sensor' })).toHaveTextContent(
+      'binary_sensor.moved_house'
+    )
+    expect(screen.getByText(/is not in this Home Assistant/)).toBeInTheDocument()
+    // Reporting it is the whole response: the form has not written anything.
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('keeps a stored entity the filters would not have offered', () => {
+    // The filters describe what the list offers, not what the option may hold —
+    // a config built against a different filter, or by hand, is still valid.
+    renderPicker({ value: 'sensor.phone_battery', domains: ['binary_sensor'] })
+
+    expect(screen.getByRole('button', { name: 'Motion sensor' })).toHaveTextContent('Phone Battery')
+    expect(screen.queryByText(/is not in this Home Assistant/)).not.toBeInTheDocument()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('shows a malformed stored value as nothing linked without rewriting it', () => {
+    renderPicker({ value: { entity: 'binary_sensor.driveway_motion' } })
+
+    expect(screen.getByRole('button', { name: 'Motion sensor' })).toHaveTextContent(
+      'No entity linked'
+    )
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('renders its description when given one', () => {
+    renderPicker({ description: 'Adds a motion line to the camera overlay.' })
+    expect(screen.getByText('Adds a motion line to the camera overlay.')).toBeInTheDocument()
+  })
+})

--- a/src/components/__tests__/NumberArrayEditor.test.tsx
+++ b/src/components/__tests__/NumberArrayEditor.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Theme } from '@radix-ui/themes'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { NumberArrayEditor } from '../NumberArrayEditor'
+
+/**
+ * The editor behind list-of-number options such as the light card's
+ * `brightnessPresets`.
+ *
+ * It emits only values its entry schema accepts, and it never rewrites the list
+ * it was handed: an entry this build ignores is shown as ignored and survives an
+ * edit to the entries around it (docs/specs/dashboard-config/index.md —
+ * "Forward Compatibility").
+ */
+describe('NumberArrayEditor', () => {
+  const onChange = vi.fn()
+
+  function renderEditor(props: Partial<React.ComponentProps<typeof NumberArrayEditor>> = {}) {
+    return render(
+      <Theme>
+        <NumberArrayEditor
+          label="Brightness presets"
+          value={[]}
+          min={1}
+          max={100}
+          integer
+          unit="%"
+          onChange={onChange}
+          {...props}
+        />
+      </Theme>
+    )
+  }
+
+  function addField() {
+    return screen.getByLabelText('Brightness presets to add')
+  }
+
+  function type(value: string) {
+    fireEvent.change(addField(), { target: { value } })
+  }
+
+  beforeEach(() => {
+    onChange.mockClear()
+  })
+
+  it('says an empty list renders nothing, and appends the first value', () => {
+    renderEditor()
+    expect(screen.getByText('Nothing set — the card renders no values.')).toBeInTheDocument()
+    expect(addField()).toHaveAttribute('placeholder', 'Add a value')
+
+    type('50')
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    expect(onChange).toHaveBeenCalledWith([50])
+  })
+
+  it('appends to the end rather than sorting — stored order is the render order', () => {
+    renderEditor({ value: [100, 20] })
+
+    type('50')
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    expect(onChange).toHaveBeenCalledWith([100, 20, 50])
+  })
+
+  it('adds on Enter, and ignores every other key', () => {
+    renderEditor()
+
+    type('20')
+    fireEvent.keyDown(addField(), { key: 'a' })
+    expect(onChange).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(addField(), { key: 'Enter' })
+    expect(onChange).toHaveBeenCalledWith([20])
+  })
+
+  it('refuses an empty entry, and says so where the field is', () => {
+    renderEditor()
+    expect(addField()).toHaveAttribute('aria-invalid', 'false')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    // A refusal nothing announces is a button that silently does nothing.
+    expect(screen.getByRole('alert')).toHaveTextContent('Enter a number to add.')
+    expect(addField()).toHaveAttribute('aria-invalid', 'true')
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('refuses a value the entry schema rejects, reporting what the schema said', () => {
+    renderEditor()
+
+    type('150')
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    expect(screen.getByText(/less than or equal to 100/i)).toBeInTheDocument()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('refuses a duplicate rather than silently collapsing it', () => {
+    renderEditor({ value: [20] })
+
+    type('20')
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    expect(screen.getByText('20% is already in the list.')).toBeInTheDocument()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('accepts a fractional value when the option sets no bounds', () => {
+    renderEditor({
+      min: undefined,
+      max: undefined,
+      integer: undefined,
+      unit: undefined,
+      step: 0.5,
+    })
+    expect(addField()).toHaveAttribute('step', '0.5')
+
+    type('3.5')
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    expect(onChange).toHaveBeenCalledWith([3.5])
+  })
+
+  it('removes the tapped value by position', () => {
+    renderEditor({ value: [20, 50, 100] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove 50%' }))
+
+    expect(onChange).toHaveBeenCalledWith([20, 100])
+  })
+
+  it('shows entries it cannot use as ignored, and keeps them through an edit', () => {
+    renderEditor({ value: [150, 'ten', 20] })
+
+    expect(screen.getByRole('button', { name: 'Remove 150%' })).toHaveTextContent('(ignored)')
+    expect(screen.getByRole('button', { name: 'Remove ten' })).toHaveTextContent('(ignored)')
+    expect(
+      screen.getByText(
+        'Greyed values stay in the configuration but are skipped when the card renders.'
+      )
+    ).toBeInTheDocument()
+
+    // Removing a usable entry must not take the unusable ones with it: they are
+    // somebody's configuration, not this build's to tidy.
+    fireEvent.click(screen.getByRole('button', { name: 'Remove 20%' }))
+    expect(onChange).toHaveBeenCalledWith([150, 'ten'])
+  })
+
+  it('reads a stored value that is not a list as empty, and writes nothing', () => {
+    renderEditor({ value: '20,50' })
+
+    expect(screen.getByText('Nothing set — the card renders no values.')).toBeInTheDocument()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('uses the caller’s placeholder, and swaps the description for an error', () => {
+    renderEditor({ placeholder: 'Add a percentage', description: 'Shown as pills on full cards.' })
+    expect(addField()).toHaveAttribute('placeholder', 'Add a percentage')
+    expect(screen.getByText('Shown as pills on full cards.')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    expect(screen.queryByText('Shown as pills on full cards.')).not.toBeInTheDocument()
+    expect(screen.getByText('Enter a number to add.')).toBeInTheDocument()
+  })
+})

--- a/src/components/__tests__/OrderedMultiSelect.test.tsx
+++ b/src/components/__tests__/OrderedMultiSelect.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Theme } from '@radix-ui/themes'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { OrderedMultiSelect } from '../OrderedMultiSelect'
+
+/**
+ * The control behind options that are an ordered subset of a canonical enum,
+ * such as the alarm card's `armModes` — where the first entry is also the mode
+ * the single-pill tiers offer, so arranging matters as much as selecting.
+ *
+ * A stored value the caller did not offer — a mode from a newer build, or one
+ * the entity's `supported_features` no longer advertises — stays where it is
+ * (docs/specs/dashboard-config/index.md — "Forward Compatibility").
+ */
+describe('OrderedMultiSelect', () => {
+  const onChange = vi.fn()
+
+  const ARM_MODE_OPTIONS = [
+    { value: 'away', label: 'Away' },
+    { value: 'home', label: 'Home' },
+    { value: 'night', label: 'Night' },
+    { value: 'vacation', label: 'Vacation' },
+  ]
+
+  function renderControl(props: Partial<React.ComponentProps<typeof OrderedMultiSelect>> = {}) {
+    return render(
+      <Theme>
+        <OrderedMultiSelect
+          label="Arm modes"
+          value={[]}
+          options={ARM_MODE_OPTIONS}
+          onChange={onChange}
+          {...props}
+        />
+      </Theme>
+    )
+  }
+
+  beforeEach(() => {
+    onChange.mockClear()
+  })
+
+  it('says an empty selection shows nothing, and appends what is added', () => {
+    renderControl()
+    expect(screen.getByText('Nothing selected — the card shows none of these.')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Night' }))
+
+    expect(onChange).toHaveBeenCalledWith(['night'])
+  })
+
+  it('offers only what is not already selected, and nothing once all of it is', () => {
+    const { rerender } = renderControl({ value: ['away', 'home'] })
+    expect(screen.queryByRole('button', { name: 'Add Away' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add Night' })).toBeInTheDocument()
+
+    rerender(
+      <Theme>
+        <OrderedMultiSelect
+          label="Arm modes"
+          value={['away', 'home', 'night', 'vacation']}
+          options={ARM_MODE_OPTIONS}
+          onChange={onChange}
+        />
+      </Theme>
+    )
+
+    expect(screen.queryByRole('button', { name: /^Add / })).not.toBeInTheDocument()
+  })
+
+  it('moves an entry through the order, with the ends fixed', () => {
+    renderControl({ value: ['away', 'home', 'night'] })
+
+    expect(screen.getByRole('button', { name: 'Move Away up' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Move Night down' })).toBeDisabled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move Night up' }))
+    expect(onChange).toHaveBeenLastCalledWith(['away', 'night', 'home'])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move Away down' }))
+    expect(onChange).toHaveBeenLastCalledWith(['home', 'away', 'night'])
+  })
+
+  it('removes an entry by position', () => {
+    renderControl({ value: ['away', 'home'] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Away' }))
+
+    expect(onChange).toHaveBeenCalledWith(['home'])
+  })
+
+  it('keeps a stored value it was not offered, in place and still editable', () => {
+    renderControl({ value: ['away', 'armed_custom_bypass'] })
+
+    const kept = screen.getByRole('button', { name: 'Move armed_custom_bypass up' })
+    expect(kept).toBeInTheDocument()
+    expect(screen.getByText(/armed_custom_bypass \(not available\)/)).toBeInTheDocument()
+
+    // Editing around it must not drop it — the user removes it deliberately or
+    // it stays in the config.
+    fireEvent.click(kept)
+    expect(onChange).toHaveBeenLastCalledWith(['armed_custom_bypass', 'away'])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Night' }))
+    expect(onChange).toHaveBeenLastCalledWith(['away', 'armed_custom_bypass', 'night'])
+  })
+
+  it('reads a stored value that is not a list as nothing selected, and writes nothing', () => {
+    renderControl({ value: 'away' })
+
+    expect(screen.getByText('Nothing selected — the card shows none of these.')).toBeInTheDocument()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('renders its description when given one', () => {
+    renderControl({ description: 'The first mode is the one small cards offer.' })
+    expect(screen.getByText('The first mode is the one small cards offer.')).toBeInTheDocument()
+  })
+})

--- a/src/store/__tests__/configControls.test.ts
+++ b/src/store/__tests__/configControls.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ENTITY_LINK_DEFAULT,
+  entityIdSchema,
+  entityLinkSchema,
+  numberArraySchema,
+  numberEntrySchema,
+  orderedSelectionSchema,
+  readEntityLink,
+  readNumberArray,
+  readOrderedSelection,
+  readStoredList,
+} from '../configControls'
+
+/**
+ * The value contracts behind the shared non-scalar config controls. The split
+ * that matters here is schemas versus readers: the schemas are what the import
+ * gate rejects a bad config with, and the readers are what the render path
+ * survives one with — resolving what this build understands and leaving
+ * everything else exactly as stored (docs/specs/dashboard-config/index.md —
+ * "Forward Compatibility").
+ */
+describe('entity link', () => {
+  it.each([
+    ['', 'nothing linked'],
+    ['binary_sensor.driveway_motion', 'an entity id'],
+    ['sensor.gone_away', 'an id no instance may currently have'],
+  ])('accepts %s (%s)', (value) => {
+    expect(entityLinkSchema.safeParse(value).success).toBe(true)
+  })
+
+  it.each([
+    ['binary_sensor'],
+    ['Binary_Sensor.Motion'],
+    ['sensor.'],
+    ['sensor.a.b'],
+    // The same forms Home Assistant's own `valid_entity_id` refuses: a leading,
+    // trailing, or doubled underscore in either segment.
+    ['sensor._motion'],
+    ['sensor.motion_'],
+    ['_sensor.motion'],
+    ['sensor__aux.motion'],
+    ['sensor.front__door'],
+  ])('rejects the malformed id %s', (value) => {
+    expect(entityIdSchema.safeParse(value).success).toBe(false)
+  })
+
+  it('reads a stored id verbatim, including one this instance cannot resolve', () => {
+    // Whether the entity exists is a question for the machine rendering the
+    // card, not for the config: a shared dashboard lands on instances that name
+    // their sensors differently, and the link must survive the trip.
+    expect(readEntityLink({ motionEntity: 'binary_sensor.not_here' }, 'motionEntity')).toBe(
+      'binary_sensor.not_here'
+    )
+  })
+
+  it.each([
+    ['an absent key', undefined],
+    ['a malformed id', 'binary_sensor'],
+    ['a value that is not a string', 42],
+  ])('resolves %s to nothing linked', (_case, stored) => {
+    expect(readEntityLink({ doorEntity: stored }, 'doorEntity')).toBe(ENTITY_LINK_DEFAULT)
+    expect(readEntityLink(undefined, 'doorEntity')).toBe(ENTITY_LINK_DEFAULT)
+  })
+})
+
+describe('number array', () => {
+  const percent = { min: 1, max: 100, integer: true }
+
+  it('accepts a fractional value when the option is not restricted to integers', () => {
+    expect(numberEntrySchema().safeParse(3.5).success).toBe(true)
+  })
+
+  it.each([
+    ['a fraction', 3.5],
+    ['zero, below the floor', 0],
+    ['a value over the ceiling', 101],
+    ['not a number', NaN],
+    ['infinite', Infinity],
+  ])('rejects %s as a percentage entry', (_case, value) => {
+    expect(numberEntrySchema(percent).safeParse(value).success).toBe(false)
+  })
+
+  it('validates the whole array for the import gate', () => {
+    expect(numberArraySchema(percent).safeParse([20, 50, 100]).success).toBe(true)
+    expect(numberArraySchema(percent).safeParse([20, 150]).success).toBe(false)
+    expect(numberArraySchema(percent).safeParse(['20']).success).toBe(false)
+  })
+
+  it('reads a stored list as a list, and anything else as empty', () => {
+    expect(readStoredList([1, 'two'])).toEqual([1, 'two'])
+    expect(readStoredList('20,50')).toEqual([])
+  })
+
+  it('keeps the usable entries in stored order and leaves the stored value alone', () => {
+    const stored = [50, 150, 'ten', 20]
+    const config = { brightnessPresets: stored }
+
+    expect(readNumberArray(config, 'brightnessPresets', percent)).toEqual([50, 20])
+    // The render path resolves; it does not repair. Rewriting here would turn
+    // merely opening a dashboard into an edit of somebody else's config.
+    expect(stored).toEqual([50, 150, 'ten', 20])
+  })
+
+  it('reads an absent key as no values', () => {
+    expect(readNumberArray({}, 'brightnessPresets', percent)).toEqual([])
+    expect(readNumberArray(undefined, 'brightnessPresets')).toEqual([])
+  })
+})
+
+describe('ordered selection', () => {
+  const ARM_MODES = ['away', 'home', 'night', 'vacation'] as const
+  const schema = orderedSelectionSchema(ARM_MODES)
+
+  it('accepts any subset, in any order', () => {
+    expect(schema.safeParse(['night', 'away']).success).toBe(true)
+    expect(schema.safeParse([]).success).toBe(true)
+  })
+
+  it('rejects a value outside the canonical list', () => {
+    expect(schema.safeParse(['away', 'armed_custom_bypass']).success).toBe(false)
+  })
+
+  it('rejects a repeated value, since order is meaningful and repetition is not', () => {
+    const parsed = schema.safeParse(['away', 'away'])
+    expect(parsed.success).toBe(false)
+    expect(parsed.error?.issues[0].message).toBe('each option may be listed only once')
+  })
+
+  it('reads the stored order, ignoring what this build cannot use', () => {
+    const stored = ['night', 'armed_custom_bypass', 7, 'night', 'away']
+    const config = { armModes: stored }
+
+    expect(readOrderedSelection(config, 'armModes', ARM_MODES)).toEqual(['night', 'away'])
+    expect(stored).toEqual(['night', 'armed_custom_bypass', 7, 'night', 'away'])
+  })
+
+  it('reads an absent key as nothing selected', () => {
+    expect(readOrderedSelection({}, 'armModes', ARM_MODES)).toEqual([])
+    expect(readOrderedSelection(undefined, 'armModes', ARM_MODES)).toEqual([])
+  })
+})

--- a/src/store/__tests__/configControls.test.ts
+++ b/src/store/__tests__/configControls.test.ts
@@ -45,6 +45,91 @@ describe('entity link', () => {
     expect(entityIdSchema.safeParse(value).success).toBe(false)
   })
 
+  /*
+   * The pattern is a restatement of Home Assistant's own `valid_entity_id`,
+   * written without lookbehind so it parses on engines that lack it (Safari
+   * before 16.4, where a lookbehind literal is a module-killing syntax error
+   * rather than a validation quirk). "Restatement" is only true if it is
+   * checked, so these tests run Core's pattern beside ours and require them to
+   * agree — including on the strings a hand-edited config is most likely to
+   * contain.
+   *
+   * Core's regex is built with `new RegExp` from a string on purpose: as a
+   * literal it would be parsed at module load, which is precisely the failure
+   * the production pattern exists to avoid.
+   */
+  const HA_VALID_ENTITY_ID = new RegExp(
+    String.raw`^(?!.+__)(?!_)[\da-z_]+(?<!_)\.(?!_)[\da-z_]+(?<!_)$`
+  )
+  const accepts = (value: string) => entityIdSchema.safeParse(value).success
+
+  it.each([
+    // Accepted shapes.
+    ['sensor.motion', 'the ordinary case'],
+    ['binary_sensor.driveway_motion', 'underscores in both segments'],
+    ['a.b', 'single-character segments'],
+    ['1.2', 'digits only'],
+    ['sensor2.motion_3', 'digits mixed in'],
+    ['a_1.b_2', 'an underscore between a letter and a digit'],
+    // Leading underscore.
+    ['_sensor.motion', 'a leading underscore on the domain'],
+    ['sensor._motion', 'a leading underscore on the object id'],
+    ['__sensor.motion', 'a doubled leading underscore'],
+    // Trailing underscore.
+    ['sensor_.motion', 'a trailing underscore on the domain'],
+    ['sensor.motion_', 'a trailing underscore on the object id'],
+    ['sensor.motion__', 'a doubled trailing underscore'],
+    // Doubled underscore, in either segment and longer runs of it.
+    ['sensor__aux.motion', 'a doubled underscore in the domain'],
+    ['sensor.front__door', 'a doubled underscore in the object id'],
+    ['sensor.mot___ion', 'a tripled underscore'],
+    ['_._', 'nothing but underscores'],
+    ['sensor._', 'an object id that is one underscore'],
+    // Empty segments, missing and extra separators.
+    ['', 'the empty string'],
+    ['.', 'a bare dot'],
+    ['.motion', 'an empty domain'],
+    ['sensor.', 'an empty object id'],
+    ['sensor', 'no dot at all'],
+    ['sensor.a.b', 'two dots'],
+    ['sensor..motion', 'a doubled dot'],
+    // Characters outside the alphabet.
+    ['Sensor.Motion', 'uppercase in both segments'],
+    ['sensor.Motion', 'uppercase in the object id'],
+    ['SENSOR.MOTION', 'all uppercase'],
+    ['sensor.motión', 'a non-ASCII letter'],
+    ['sensör.motion', 'a non-ASCII letter in the domain'],
+    ['sensor.日本', 'a non-Latin script'],
+    ['sensor.mot ion', 'a space'],
+    ['sensor.motion-1', 'a hyphen'],
+    // Anchoring: `$` in JavaScript stops at the end of input, with no
+    // concession for a trailing newline. Both patterns must agree on that too.
+    ['sensor.motion\n', 'a trailing newline'],
+    ['\nsensor.motion', 'a leading newline'],
+    ['sensor.motion\nlight.kitchen', 'two ids on separate lines'],
+  ])('agrees with Home Assistant on %s (%s)', (value) => {
+    expect(accepts(value)).toBe(HA_VALID_ENTITY_ID.test(value))
+  })
+
+  it('agrees with Home Assistant on every short string over the relevant alphabet', () => {
+    // The named cases above say what each category is; this says the two
+    // patterns are the same function. Four characters — a letter, a digit, the
+    // underscore, and the separator — generate every structural arrangement
+    // that matters, and exhausting lengths 1 through 5 covers all 1364 of them.
+    const alphabet = ['a', '1', '_', '.']
+    let strings = ['']
+    const divergent: string[] = []
+
+    for (let length = 1; length <= 5; length++) {
+      strings = strings.flatMap((prefix) => alphabet.map((character) => prefix + character))
+      for (const value of strings) {
+        if (accepts(value) !== HA_VALID_ENTITY_ID.test(value)) divergent.push(value)
+      }
+    }
+
+    expect(divergent).toEqual([])
+  })
+
   it('reads a stored id verbatim, including one this instance cannot resolve', () => {
     // Whether the entity exists is a question for the machine rendering the
     // card, not for the config: a shared dashboard lands on instances that name

--- a/src/store/configControls.ts
+++ b/src/store/configControls.ts
@@ -28,9 +28,24 @@ import { z } from 'zod'
  * same rule Core's own `valid_entity_id` applies: lowercase alphanumerics and
  * underscores, with no leading, trailing, or doubled underscore in either
  * segment. Copied rather than loosened so the schema rejects exactly what Home
- * Assistant would refuse to create.
+ * Assistant would refuse to create. Core spells it this way — read from the
+ * running Home Assistant container's own `homeassistant/core.py`:
+ *
+ *     ^(?!.+__)(?!_)[\da-z_]+(?<!_)\.(?!_)[\da-z_]+(?<!_)$
+ *
+ * We accept and reject exactly those strings, but without the lookarounds:
+ * `(?<!_)` is lookbehind, which Safari before 16.4 cannot *parse*, so a regex
+ * literal using it is a syntax error that takes the whole module down rather
+ * than degrading validation — and a wall-mounted tablet or an iPhone running
+ * the companion app is a realistic client for this panel. Writing the segment
+ * as "alphanumeric runs joined by single underscores" states the rule directly
+ * instead of asserting three separate things about it, and uses nothing beyond
+ * ES3 regex syntax. `configControls.test.ts` pins the two forms together over
+ * an exhaustive corpus, so this stays a restatement and never drifts into a
+ * relaxation.
  */
-const ENTITY_ID_PATTERN = /^(?!.+__)(?!_)[\da-z_]+(?<!_)\.(?!_)[\da-z_]+(?<!_)$/
+const ENTITY_ID_SEGMENT = String.raw`[\da-z]+(?:_[\da-z]+)*`
+const ENTITY_ID_PATTERN = new RegExp(`^${ENTITY_ID_SEGMENT}\\.${ENTITY_ID_SEGMENT}$`)
 
 export const entityIdSchema = z
   .string()

--- a/src/store/configControls.ts
+++ b/src/store/configControls.ts
@@ -1,0 +1,145 @@
+import { z } from 'zod'
+
+/**
+ * The value contracts behind the shared non-scalar configuration controls — the
+ * entity picker, the number array, and the ordered multi-select.
+ *
+ * Spec: docs/specs/entity-cards/options/common.md. Unlike `cardActions.ts` and
+ * `cardDisplay.ts`, which own specific universal keys, this module owns *shapes*
+ * that later per-card changes bind to their own keys: `motionEntity` /
+ * `doorEntity` / `batteryEntity` are entity links, `brightnessPresets` is a
+ * bounded number array, and `armModes` is an ordered selection over a canonical
+ * enum. Building the shapes once is the point of change 0014 — a card change
+ * that invented its own would also invent its own validation.
+ *
+ * Two kinds of function live here, and the difference is the whole design:
+ *
+ * - The **schemas** are strict, and are what a config schema composes so the
+ *   import gate rejects a bad value naming the field that produced it.
+ * - The **readers** are for the render path, which must never crash a dashboard
+ *   over a value it cannot interpret. They resolve what this build understands
+ *   and ignore the rest **without rewriting anything** — a stored value this
+ *   version does not recognise survives the round trip untouched
+ *   (docs/specs/dashboard-config/index.md — "Forward Compatibility").
+ */
+
+/**
+ * `domain.object_id`, the only shape a Home Assistant entity id takes — the
+ * same rule Core's own `valid_entity_id` applies: lowercase alphanumerics and
+ * underscores, with no leading, trailing, or doubled underscore in either
+ * segment. Copied rather than loosened so the schema rejects exactly what Home
+ * Assistant would refuse to create.
+ */
+const ENTITY_ID_PATTERN = /^(?!.+__)(?!_)[\da-z_]+(?<!_)\.(?!_)[\da-z_]+(?<!_)$/
+
+export const entityIdSchema = z
+  .string()
+  .regex(ENTITY_ID_PATTERN, 'entity id must be written as "domain.object_id"')
+
+/**
+ * A linked-entity option: an entity id, or `''` for "nothing linked" — the
+ * default every consumer of the picker uses, because linking an entity is
+ * always opt-in (common contract, convention 3: an option reads an entity the
+ * user already has, it never creates one).
+ *
+ * An id naming an entity this Home Assistant does not have is **valid**: the
+ * entity may be renamed, disabled, or simply not exist on the machine importing
+ * the config. Only a malformed id is rejected.
+ */
+export const entityLinkSchema = z.union([z.literal(''), entityIdSchema])
+
+/** The stored default for every entity-link option. */
+export const ENTITY_LINK_DEFAULT = ''
+
+/** Read a linked-entity option; anything unusable resolves to "not linked". */
+export function readEntityLink(config: Record<string, unknown> | undefined, key: string): string {
+  const parsed = entityLinkSchema.safeParse(config?.[key])
+  return parsed.success ? parsed.data : ENTITY_LINK_DEFAULT
+}
+
+/** What a single entry of a number-array option is allowed to be. */
+export interface NumberEntryBounds {
+  min?: number
+  max?: number
+  /** Whole numbers only — percentages and step counts, not measurements. */
+  integer?: boolean
+}
+
+/** The schema for one entry of a number array. */
+export function numberEntrySchema({ min, max, integer = false }: NumberEntryBounds = {}) {
+  let schema = z.number().finite()
+  if (integer) schema = schema.int()
+  if (min !== undefined) schema = schema.min(min)
+  if (max !== undefined) schema = schema.max(max)
+  return schema
+}
+
+/**
+ * The strict schema a config gate composes for a number-array option
+ * (`brightnessPresets: numberArraySchema({ min: 1, max: 100, integer: true })`).
+ */
+export function numberArraySchema(bounds: NumberEntryBounds = {}) {
+  return z.array(numberEntrySchema(bounds))
+}
+
+/**
+ * The stored value of a list option, as a list to work with.
+ *
+ * Deliberately `unknown[]` rather than a parsed array: the editors render every
+ * entry, including the ones this build ignores, so removing one entry cannot
+ * quietly drop another. A stored value that is not a list at all has no entries
+ * to show and reads as empty — still without rewriting it.
+ */
+export function readStoredList(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : []
+}
+
+/** Read a number-array option, keeping only the entries this build can use. */
+export function readNumberArray(
+  config: Record<string, unknown> | undefined,
+  key: string,
+  bounds: NumberEntryBounds = {}
+): number[] {
+  const entry = numberEntrySchema(bounds)
+  return readStoredList(config?.[key]).filter(
+    (value): value is number => entry.safeParse(value).success
+  )
+}
+
+/**
+ * The strict schema a config gate composes for an ordered multi-select. The
+ * value list is canonical and closed (REVIEW.md — "Enum-typed options need a
+ * canonical, schema-validated value list"), and an option may be listed once:
+ * order is meaningful, repetition is not.
+ */
+export function orderedSelectionSchema<T extends string>(values: readonly [T, ...T[]]) {
+  return z
+    .array(z.enum(values))
+    .refine((list) => new Set(list).size === list.length, 'each option may be listed only once')
+}
+
+/**
+ * Read an ordered multi-select option: the stored order, restricted to the
+ * values this build knows, with repeats collapsed.
+ *
+ * Filtering is render-time resolution only. A card whose choice set is narrower
+ * still than the canonical list — the alarm panel offering only the arm modes
+ * its `supported_features` advertises — filters further on top of this, and
+ * likewise stores nothing back.
+ */
+export function readOrderedSelection(
+  config: Record<string, unknown> | undefined,
+  key: string,
+  values: readonly string[]
+): string[] {
+  const selected: string[] = []
+
+  for (const entry of readStoredList(config?.[key])) {
+    if (typeof entry !== 'string') continue
+    if (!values.includes(entry)) continue
+    if (selected.includes(entry)) continue
+    selected.push(entry)
+  }
+
+  return selected
+}


### PR DESCRIPTION
## Summary

The three shared non-scalar config controls — the final task of `docs/changes/0014-universal-card-options.md`, which this PR marks **complete**.

The change document is emphatic that it must not be marked complete without them, and the reason is concrete: changes 0016, 0021, 0024 and 0026 all assume these controls exist rather than inventing one apiece. Nothing consumes them yet by design; those changes bind them to their keys.

| Control | Type | First consumer |
|---|---|---|
| Entity picker | `entity` | `motionEntity` / `doorEntity` / `batteryEntity` (0021, 0024, 0026) |
| Number array | `number-array` | `brightnessPresets` (0016) |
| Ordered multi-select | `ordered-multi-select` | `armModes` (0024) |

Strict schemas live in `src/store/configControls.ts` for the import gate, deliberately split from the readers used on the render path.

## Forward compatibility, verified rather than asserted

`docs/specs/dashboard-config/index.md` requires that a configuration this build cannot fully interpret survives a round-trip unchanged — resolve for display, never rewrite or truncate. That bites these controls harder than most, because each one can hold a value this build does not recognise.

Each handles it, and I verified the store is genuinely untouched rather than trusting the display behaviour:

- **Entity picker** — an id absent from this Home Assistant is returned and shown as configured ("It stays configured, and the card renders without it"), not blanked. An id outside the picker's own domain filters stays selected and named.
- **Number array** — entries the schema rejects render greyed and marked ignored; removing a *different* entry still emits the unusable ones, because removal is positional.
- **Ordered multi-select** — an unknown mode renders in place as unavailable and moves and removes like any other entry.

Probed directly: reading a config containing `[10, 150, 'ten', 50]` under 1–100 bounds returns `[10, 50]` for display while the stored array remains byte-identical, and the same holds for an `armModes` list carrying `armed_custom_bypass`. A sanity assertion in the same probe confirms the readers return real data for recognised input, so "unchanged" is not passing vacuously.

## Details worth noting

The entity-id schema uses Home Assistant Core's own `valid_entity_id` rule. CodeRabbit caught the first, looser pattern accepting `sensor._motion` — worth having, since a config gate that accepts ids HA itself would reject produces a document that imports here and fails there.

The ordered multi-select's schema is `z.array(z.enum(values))` refined to reject repeats — the canonical, closed value list REVIEW.md requires, with the caller narrowing `values` to what the entity actually supports.

Number arrays are append-only and never sorted, because stored order is what `brightnessPresets` renders.

## Testing

- `npm test` — 1543 passed, 2 skipped
- `npm run lint`, `npm run typecheck` — clean
- `npm run test:coverage` — 100% patch coverage on the new files, lines and branches
- `npm run build-storybook`, `npm run build:ha:prod` — both succeed
- axe over all 24 card-configuration stories in both appearances: zero serious or critical, nothing added to **#191** / **#197** / **#204** / **#210**. One real find fixed on the way — Radix soft-blue chips measured 4.25:1 in light, so the chips take `highContrast`.

`codex` was unavailable (usage limit until 1 August); CodeRabbit ran and its five findings are resolved.

## Change status

`docs/changes/0014-universal-card-options.md` flips to **complete**, with matching flips in `docs/index.yml` and `docs/index.md`. The options spec records the universal contract, action system, detail dialog and shared controls as implemented, while the per-card option docs correctly remain "specified, not yet implemented".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared configuration controls for selecting entities, editing numeric lists, and managing ordered multi-selections.
  * Entity selection supports search, filtering, clearing, and clear warnings for unavailable entities.
  * Numeric list editing supports validation, duplicate prevention, ordering, and removal.
  * Ordered selections support adding, reordering, removing, and preserving unavailable values.
* **Documentation**
  * Marked the universal card options contract as complete and clarified remaining card-specific documentation status.
* **Tests**
  * Added comprehensive coverage for the new controls, validation, filtering, and data-handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->