### PR TITLE
feat(entity-state): graph history in the entity detail dialog

### DIFF
--- a/docs/changes/0015-history-and-forecast-data.md
+++ b/docs/changes/0015-history-and-forecast-data.md
@@ -4,7 +4,7 @@
 
 Extend the entity-state pipeline with the two read-side capabilities the card specs depend on: **recent numeric history** (for sensor sparklines/graphs and the detail dialog) and **weather forecasts** (`weather.get_forecasts`). Closes the "sparkline data source" open question in [design-system](../specs/design-system/index.md#open-questions) and the forecast-fetch open question in [options/weather](../specs/entity-cards/options/weather.md).
 
-**Spec:** [entity-state](../specs/entity-state/index.md) · **Status:** draft · **Depends on:** 0014 (PR 3's detail-dialog graph only — PRs 1–2 are pure pipeline work with no dependencies and can run in parallel with the visual track)
+**Spec:** [entity-state](../specs/entity-state/index.md) · **Status:** complete · **Depends on:** 0014 (PR 3's detail-dialog graph only — PRs 1–2 are pure pipeline work with no dependencies and can run in parallel with the visual track)
 
 ## Motivation
 
@@ -46,7 +46,7 @@ The entity-state spec's [Entity History](../specs/entity-state/index.md#entity-h
 
 - [x] **PR 1 — History**: WS history fetch + cache + downsampler (sample/delta modes) + `useEntityHistory` + live append/reconnect; unit tests; e2e fetch against dockerized HA; fixture factories; **spec sync in this PR**: flip the entity-state history contract's status from specified to implemented, close the design-system "sparkline data source" open question, and add the changelog entry
 - [x] **PR 2 — Forecast**: `weather.get_forecasts` client + cache/refresh + `useWeatherForecast` (hourly/daily/twice-daily) + unsupported detection; unit tests; fixtures; **spec sync in this PR**: flip the entity-state forecast contract's status to implemented, close the weather option doc's forecast-fetch open question, and add the changelog entry
-- [ ] **PR 3 — Detail-dialog history + spec sync**: replace the entity detail dialog's history placeholder (from [0014](./0014-universal-card-options.md)) with a graph rendered from `useEntityHistory` via the spark/graph anatomy — numeric entities only, section hidden on `unsupported`/error; component test + story; entity-state spec changelog entry for the dialog integration (the hook contracts and open-question closures were already synced in PRs 1–2)
+- [x] **PR 3 — Detail-dialog history + spec sync**: replace the entity detail dialog's history placeholder (from [0014](./0014-universal-card-options.md)) with a graph rendered from `useEntityHistory` via the spark/graph anatomy — numeric entities only, section hidden on `unsupported`/error; component test + story; entity-state spec changelog entry for the dialog integration (the hook contracts and open-question closures were already synced in PRs 1–2)
 
 ## Out of Scope
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@
 | 0012 | [Theming Engine](changes/0012-theming-engine.md)                                     | [Theming](specs/theming/)                   | complete | 0010             |
 | 0013 | [Built-in Themes: Liquid Glass & LCARS](changes/0013-built-in-themes.md)             | [Theming](specs/theming/)                   | complete | 0012             |
 | 0014 | [Universal Card Options](changes/0014-universal-card-options.md)                     | [Entity Cards](specs/entity-cards/)         | complete | 0010             |
-| 0015 | [History & Forecast Data Pipeline](changes/0015-history-and-forecast-data.md)        | [Entity State](specs/entity-state/)         | draft    | 0014             |
+| 0015 | [History & Forecast Data Pipeline](changes/0015-history-and-forecast-data.md)        | [Entity State](specs/entity-state/)         | complete | 0014             |
 | 0016 | [Light Card to Spec](changes/0016-light-card-to-spec.md)                             | [Entity Cards](specs/entity-cards/)         | draft    | 0011, 0014       |
 | 0017 | [Climate Card to Spec](changes/0017-climate-card-to-spec.md)                         | [Entity Cards](specs/entity-cards/)         | draft    | 0011, 0014       |
 | 0018 | [Sensor Cards to Spec](changes/0018-sensor-cards-to-spec.md)                         | [Entity Cards](specs/entity-cards/)         | draft    | 0011, 0014, 0015 |

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -151,7 +151,7 @@ changes:
     path: changes/0015-history-and-forecast-data.md
     description: Entity-state pipeline capabilities for downsampled numeric history (useEntityHistory) and weather forecasts (useWeatherForecast) with caching and graceful degradation, plus the detail-dialog history graph
     spec: entity-state
-    status: draft
+    status: complete
     depends_on: ['0014']
   - id: '0016'
     name: light-card-to-spec

--- a/docs/specs/entity-state/index.md
+++ b/docs/specs/entity-state/index.md
@@ -476,6 +476,7 @@ export interface ForecastCacheEntry {
 
 - `ConnectionStatus` (`src/components/ConnectionStatus.tsx`) — Radix `Popover` + `TaskbarButton`, driven by `useConnectionStatus`, `useHomeAssistantOptional`, and direct `entityStore` selectors for counts.
 - `ConnectionLogDialog` (`src/components/ConnectionLogDialog.tsx`) — Radix `Dialog` over `connectionStore.log`.
+- `DetailHistory` (`src/components/EntityDetailDialog/DetailHistory.tsx`) — the entity detail dialog's history section and the first consumer of `useEntityHistory`: the window drawn through the sparkline anatomy, a Radix `Skeleton` holding the graph's box open until the first fetch lands, and the whole section absent on `unsupported` or error.
 
 ### Business Logic
 
@@ -574,9 +575,9 @@ Service-call retry (`src/services/hassService.ts:61`):
 - `src/services/forecastData.ts` — pure request/parse/capability/derivation (importable outside the panel bundle, like `historyData`).
 - `src/store/entityDebouncer.ts`, `src/store/entityBatcher.ts`, `src/store/entityStore.ts`, `src/store/connectionStore.ts`, `src/store/entityTypes.ts`, `src/store/historyStore.ts`, `src/store/forecastStore.ts`.
 - `src/hooks/useEntity.ts`, `useEntities.ts`, `useEntityAttribute.ts`, `useEntityConnection.ts`, `useEntityHistory.ts`, `useWeatherForecast.ts`, `useServiceCall.ts`, `useConnectionStatus.ts`.
-- `src/components/ConnectionStatus.tsx`, `src/components/ConnectionLogDialog.tsx`.
+- `src/components/ConnectionStatus.tsx`, `src/components/ConnectionLogDialog.tsx`, `src/components/EntityDetailDialog/DetailHistory.tsx`.
 - `src/test/fixtures/history.ts`, `src/test/fixtures/forecast.ts` — history and forecast factories and cache seeders for stories.
-- Tests: `src/store/__tests__/{entityDebouncer,entityBatcher,entityStore}.test.ts`, `src/services/__tests__/{hassConnection,hassService,historyData,entityHistory,forecastData,weatherForecast}.test.ts`, `src/hooks/__tests__/{useEntity,useEntityHistory,useWeatherForecast,useServiceCall}.test.tsx`, `tests/e2e/entity-history.spec.ts`.
+- Tests: `src/store/__tests__/{entityDebouncer,entityBatcher,entityStore}.test.ts`, `src/services/__tests__/{hassConnection,hassService,historyData,entityHistory,forecastData,weatherForecast}.test.ts`, `src/hooks/__tests__/{useEntity,useEntityHistory,useWeatherForecast,useServiceCall}.test.tsx`, `src/components/EntityDetailDialog/__tests__/DetailHistory.test.tsx`, `tests/e2e/entity-history.spec.ts`.
 - Related specs: `../panel-lifecycle/` (panel custom-element + `liebe-websocket-check` dispatch), `../entity-cards/` (consumers), `../camera-streaming/` (WebRTC).
 
 ## Changelog
@@ -587,3 +588,4 @@ Service-call retry (`src/services/hassService.ts:61`):
 | 2026-07-25 | Added target History & Forecast hook contracts (not yet implemented)                                                                                                                                                                                    | [0015](../../changes/0015-history-and-forecast-data.md) |
 | 2026-07-27 | History contract implemented: `useEntityHistory`, the two-level cache, the sample/delta downsampler, the pre-debounce raw ingress tap, and reconnect invalidation; scenarios given test references; forecast split into its own still-specified section | [0015](../../changes/0015-history-and-forecast-data.md) |
 | 2026-07-27 | Forecast contract implemented: `useWeatherForecast`, the per-type cache and refresh intervals, capability-driven `unsupported` resolution distinct from errors, and the twice-daily → daily derivation with its unpaired-half rules                     | [0015](../../changes/0015-history-and-forecast-data.md) |
+| 2026-07-27 | First history consumer: the entity detail dialog graphs the 24-hour window through the sparkline anatomy, hides the section entirely on `unsupported` and on error, and reserves the graph's box with a skeleton until the first fetch lands            | [0015](../../changes/0015-history-and-forecast-data.md) |

--- a/src/components/EntityDetailDialog/DetailHistory.tsx
+++ b/src/components/EntityDetailDialog/DetailHistory.tsx
@@ -1,12 +1,16 @@
 import { Box, Heading, Skeleton } from '@radix-ui/themes'
 import { Sparkline } from '../anatomy'
 import { useEntityHistory } from '~/hooks/useEntityHistory'
+import { DEFAULT_HISTORY_HOURS } from '~/services/historyData'
 
 /**
- * The window the dialog graphs. The hook's own default, restated here because
- * the graph's accessible label has to say which window it is showing.
+ * The window the dialog graphs — the pipeline's own default, taken from the
+ * pipeline rather than restated. The label has to name the window, and a local
+ * copy would keep naming `24` after the canonical default moved: the request
+ * and the accessible label would then describe different windows, silently, and
+ * the label is all a screen-reader user has to go on.
  */
-const HISTORY_HOURS = 24
+const HISTORY_HOURS = DEFAULT_HISTORY_HOURS
 
 /**
  * Height of the graph area. The skeleton below fills the same box, so the

--- a/src/components/EntityDetailDialog/DetailHistory.tsx
+++ b/src/components/EntityDetailDialog/DetailHistory.tsx
@@ -1,0 +1,77 @@
+import { Box, Heading, Skeleton } from '@radix-ui/themes'
+import { Sparkline } from '../anatomy'
+import { useEntityHistory } from '~/hooks/useEntityHistory'
+
+/**
+ * The window the dialog graphs. The hook's own default, restated here because
+ * the graph's accessible label has to say which window it is showing.
+ */
+const HISTORY_HOURS = 24
+
+/**
+ * Height of the graph area. The skeleton below fills the same box, so the
+ * section occupies its final height from the first render and the attribute
+ * list underneath does not jump when history arrives.
+ */
+const GRAPH_HEIGHT = '96px'
+
+export interface DetailHistoryProps {
+  entityId: string
+}
+
+/**
+ * The detail dialog's history graph — the recent window of an entity's readings,
+ * drawn through the sparkline anatomy so a theme restyles it exactly as it
+ * restyles the same graph on a card
+ * (docs/specs/design-system/index.md — "Card anatomy").
+ *
+ * Numeric entities only, and the judgement of what counts as numeric is NOT
+ * made here: `useEntityHistory` resolves a non-numeric entity to `unsupported`
+ * from its live state, before it costs a request
+ * (docs/specs/entity-state/index.md — "Entity History"). A second opinion in the
+ * dialog would eventually disagree with the service's.
+ *
+ * The whole section is absent — heading included — when there is nothing to
+ * graph: `unsupported`, because the entity will never have a series, and on
+ * error, because history failures are non-fatal by contract and the consumer
+ * "renders without a graph". Neither renders an empty frame or an apology. A
+ * failed refetch therefore takes an already-drawn graph off screen rather than
+ * leaving a stale window standing with no sign that it stopped moving; the
+ * samples survive in the cache, so the next successful fetch brings the graph
+ * back without a gap.
+ */
+export function DetailHistory({ entityId }: DetailHistoryProps) {
+  const { values, isLoading, error, unsupported } = useEntityHistory(entityId, {
+    hours: HISTORY_HOURS,
+  })
+
+  if (unsupported || error !== null) return null
+
+  return (
+    <Box data-testid="detail-history">
+      <Heading size="2" mb="1">
+        History
+      </Heading>
+      <Box height={GRAPH_HEIGHT} data-testid="detail-history-graph">
+        {isLoading && values.length === 0 ? (
+          // Radix's skeleton, the same loading convention the cards use, sized
+          // to the graph it stands in for. A refetch that already has samples
+          // keeps drawing them instead: the spec's refetch "never blanks what is
+          // already on screen".
+          <Skeleton height="100%" data-testid="detail-history-skeleton" />
+        ) : (
+          <Sparkline
+            // The dialog is domain-agnostic chrome and has none of the state a
+            // card resolves its triplet from, so the graph takes the generic
+            // active colour. The part neutralises itself when there is no
+            // series, so an empty window does not draw a saturated baseline.
+            domain={entityId.split('.')[0]}
+            active
+            values={values}
+            label={`${HISTORY_HOURS}-hour history`}
+          />
+        )}
+      </Box>
+    </Box>
+  )
+}

--- a/src/components/EntityDetailDialog/EntityDetailDialog.stories.tsx
+++ b/src/components/EntityDetailDialog/EntityDetailDialog.stories.tsx
@@ -1,24 +1,29 @@
-import { useEffect, useState } from 'react'
+import { useMemo, useState, type ReactNode } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { EntityDetailDialog, type EntityDetailDialogProps } from './index'
 import { GridCardWithComponents as GridCard } from '../GridCard'
 import { CardItemProvider } from '../cardItemContext'
 import { gridCellArgTypes, withGridCell, type GridCellArgs } from '../../../.storybook/decorators'
+import { createMockHass } from '../../../.storybook/mockHass'
+import { HomeAssistantProvider, type HomeAssistant } from '~/contexts/HomeAssistantContext'
+import { entityHistoryService } from '~/services/entityHistory'
+import type { HassEntity } from '~/store/entityTypes'
 import {
   asUnavailable,
+  createHistoryResponse,
   createInputTextEntity,
   createLightEntity,
   createSensorEntity,
+  createTemperatureHistory,
 } from '~/test/fixtures'
 
 /**
  * The entity detail dialog — what `more-info` opens, and therefore what a
  * press-and-hold reaches on every card by default.
  *
- * It is read-only on purpose: name, state, attributes, and a history section
- * that stays a placeholder until history data lands (change 0015). Later card
- * changes mount their own controls in the domain slot between the state and the
- * history section.
+ * It is read-only on purpose: name, state, attributes, and — for entities that
+ * have one — a graph of the last 24 hours. Later card changes mount their own
+ * controls in the domain slot between the state and the history section.
  *
  * The password-helper story is the one to keep an eye on: the dialog renders
  * state and attributes generically, so without redaction it would print in
@@ -36,17 +41,82 @@ const meta: Meta<EntityDetailDialogProps> = {
   },
   // Controlled by the story so the Close button, the overlay and Escape all
   // behave as they do in the panel; the toolbar's `open` arg reopens it.
-  render: function DialogStory({ open, ...rest }) {
-    const [isOpen, setIsOpen] = useState(open)
-    // Follow the arg back up after the dialog has closed itself, so toggling the
-    // `open` control reopens it instead of doing nothing.
-    useEffect(() => setIsOpen(open), [open])
-    return <EntityDetailDialog {...rest} open={isOpen} onOpenChange={setIsOpen} />
-  },
+  render: (args) => <ControlledDialog {...args} />,
 }
 
 export default meta
 type Story = StoryObj<EntityDetailDialogProps>
+
+function ControlledDialog({ open, ...rest }: EntityDetailDialogProps) {
+  const [isOpen, setIsOpen] = useState(open)
+  const [lastArg, setLastArg] = useState(open)
+  // Follow the arg back up after the dialog has closed itself, so toggling the
+  // `open` control reopens it instead of doing nothing. Adjusted during render
+  // rather than in an effect — React's own pattern for a prop the state has to
+  // follow, and the one that does not cost a second commit.
+  if (lastArg !== open) {
+    setLastArg(open)
+    setIsOpen(open)
+  }
+  return <EntityDetailDialog {...rest} open={isOpen} onOpenChange={setIsOpen} />
+}
+
+/**
+ * Substitutes the workshop's `hass` for one whose `callWS` answers the recorder
+ * request the history section makes — the workshop default resolves every
+ * WebSocket message with `undefined`, which is a numeric entity with no recorded
+ * rows and therefore an empty graph.
+ *
+ * The story drives the real pipeline this way rather than seeding the cache:
+ * what these stories are for is the states `useEntityHistory` puts the section
+ * in, and a seeded store would skip the code that decides them.
+ */
+function Recorder({ answer, children }: { answer: RecorderAnswer; children: ReactNode }) {
+  // `callWS` is generic over the response type it is asked for; a story answers
+  // the one message the history service sends, so the cast is the whole gap.
+  const hass = useMemo(
+    () => ({ ...createMockHass(), callWS: answer as HomeAssistant['callWS'] }),
+    [answer]
+  )
+  return <HomeAssistantProvider hass={hass}>{children}</HomeAssistantProvider>
+}
+
+/** How a story's recorder answers `history/history_during_period`. */
+type RecorderAnswer = () => Promise<unknown>
+
+/**
+ * One history story: its own entity id (the window cache is a singleton keyed by
+ * entity, so sharing one id would let the first story's answer decide the rest)
+ * and its own recorder behaviour.
+ */
+function historyStory(entity: HassEntity, answer: RecorderAnswer): Story {
+  return {
+    args: { entityId: entity.entity_id },
+    parameters: { liebe: { entities: [entity] } },
+    // The service outlives the story; without this a second visit renders from
+    // the window the first one fetched.
+    beforeEach: () => {
+      entityHistoryService.reset()
+      return () => entityHistoryService.reset()
+    },
+    render: (args) => (
+      <Recorder answer={answer}>
+        <ControlledDialog {...args} />
+      </Recorder>
+    ),
+  }
+}
+
+const temperature = (entityId: string) =>
+  createSensorEntity({
+    entity_id: entityId,
+    attributes: {
+      friendly_name: 'Living Room Temperature',
+      device_class: 'temperature',
+      unit_of_measurement: '°C',
+      state_class: 'measurement',
+    },
+  })
 
 /** A typical read-only entity: value, unit, and the attributes behind it. */
 export const Default: Story = {}
@@ -89,6 +159,58 @@ export const EntityNotPublished: Story = {
   args: { entityId: 'sensor.removed_by_integration' },
   parameters: { liebe: { entities: [] } },
 }
+
+/**
+ * The history graph: a day of readings drawn through the sparkline anatomy, so
+ * a theme restyles it exactly as it restyles the same graph on a card.
+ */
+export const HistoryGraph: Story = historyStory(temperature('sensor.history_graph'), async () =>
+  createHistoryResponse('sensor.history_graph', createTemperatureHistory({ end: Date.now() }))
+)
+
+/**
+ * The dialog opens before the recorder answers. The skeleton holds the graph's
+ * box open, so the attributes below it do not jump when the series lands — this
+ * story's recorder never answers, so the state stays on screen.
+ */
+export const HistoryLoading: Story = historyStory(
+  temperature('sensor.history_loading'),
+  () => new Promise(() => {})
+)
+
+/**
+ * A numeric entity the recorder has no rows for: the section stays and the
+ * anatomy draws its placeholder baseline, because the entity may yet have a
+ * series.
+ */
+export const HistoryEmpty: Story = historyStory(
+  temperature('sensor.history_empty'),
+  async () => ({})
+)
+
+/**
+ * A failed history fetch is non-fatal: the section is gone entirely — no empty
+ * frame, no apology — and the rest of the dialog is untouched.
+ */
+export const HistoryUnavailable: Story = historyStory(temperature('sensor.history_error'), () =>
+  Promise.reject(new Error('Recorder unavailable'))
+)
+
+/**
+ * A non-numeric entity has nothing to graph. `useEntityHistory` resolves it
+ * `unsupported` from its live state — no request is made at all — and the
+ * section is absent for the same reason as above.
+ */
+export const HistoryUnsupported: Story = historyStory(
+  {
+    ...createSensorEntity({
+      entity_id: 'device_tracker.phone',
+      attributes: { friendly_name: 'Phone', source_type: 'gps' },
+    }),
+    state: 'home',
+  },
+  async () => ({})
+)
 
 /**
  * The gesture itself: press and hold the tile for half a second and the dialog

--- a/src/components/EntityDetailDialog/EntityDetailDialog.stories.tsx
+++ b/src/components/EntityDetailDialog/EntityDetailDialog.stories.tsx
@@ -47,17 +47,22 @@ const meta: Meta<EntityDetailDialogProps> = {
 export default meta
 type Story = StoryObj<EntityDetailDialogProps>
 
-function ControlledDialog({ open, ...rest }: EntityDetailDialogProps) {
+/**
+ * The dialog's own state has to follow the `open` arg back down, so toggling the
+ * control reopens a dialog that closed itself — and it does that by REMOUNTING
+ * on the arg rather than by writing state. The two alternatives are both worse
+ * here: adjusting state during render runs twice under the StrictMode the
+ * workshop and the test runner render in, and syncing in an effect is what
+ * `react-hooks/set-state-in-effect` rejects. The wrapper holds nothing worth
+ * preserving across the toggle, so throwing it away is the cheapest correct
+ * answer.
+ */
+function ControlledDialog(props: EntityDetailDialogProps) {
+  return <DialogOpenedByArg key={String(props.open)} {...props} />
+}
+
+function DialogOpenedByArg({ open, ...rest }: EntityDetailDialogProps) {
   const [isOpen, setIsOpen] = useState(open)
-  const [lastArg, setLastArg] = useState(open)
-  // Follow the arg back up after the dialog has closed itself, so toggling the
-  // `open` control reopens it instead of doing nothing. Adjusted during render
-  // rather than in an effect — React's own pattern for a prop the state has to
-  // follow, and the one that does not cost a second commit.
-  if (lastArg !== open) {
-    setLastArg(open)
-    setIsOpen(open)
-  }
   return <EntityDetailDialog {...rest} open={isOpen} onOpenChange={setIsOpen} />
 }
 

--- a/src/components/EntityDetailDialog/__tests__/DetailHistory.test.tsx
+++ b/src/components/EntityDetailDialog/__tests__/DetailHistory.test.tsx
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { EntityDetailDialog } from '../index'
+import { HomeAssistantProvider, type HomeAssistant } from '~/contexts/HomeAssistantContext'
+import { createMockHomeAssistant } from '~/testUtils/mockHomeAssistant'
+import { entityHistoryService } from '~/services/entityHistory'
+import { historyStore } from '~/store/historyStore'
+import { entityStore } from '~/store/entityStore'
+import type { HassEntity } from '~/store/entityTypes'
+import { createHistoryResponse, createHistorySamples, createSensorEntity } from '~/test/fixtures'
+
+/**
+ * The detail dialog's history graph (change 0015 PR 3).
+ *
+ * Two properties carry the weight here. The first is that the section is drawn
+ * from the real series rather than from the sparkline's placeholder baseline —
+ * asserted against coordinates derived from the seeded samples, so a graph that
+ * rendered but ignored the data fails. The second is that "hidden" means hidden
+ * for the right reason: every hidden-section test renders a graphable entity in
+ * the same test first, so a section that had simply stopped rendering at all
+ * cannot pass by looking absent.
+ */
+describe('EntityDetailDialog history graph', () => {
+  const ENTITY = 'sensor.living_room_temperature'
+  let callWS: ReturnType<typeof vi.fn>
+
+  /**
+   * Ten readings rising 0 → 9 across the window, ending now. Ascending values
+   * mean the drawn path must descend in SVG coordinates from bottom to top,
+   * which is what the graph test asserts. 23 hours rather than 24 so the oldest
+   * sample is safely inside the rolling window the projection recomputes
+   * against `Date.now()` a few milliseconds later.
+   */
+  function risingSamples() {
+    return createHistorySamples((_, index) => index, {
+      hours: 23,
+      count: 10,
+      end: Date.now(),
+    })
+  }
+
+  function seed(...entities: HassEntity[]) {
+    entityStore.setState((state) => ({
+      ...state,
+      entities: Object.fromEntries(entities.map((entity) => [entity.entity_id, entity])),
+      isConnected: true,
+      isInitialLoading: false,
+    }))
+  }
+
+  function renderDialog(entityId: string, hass: HomeAssistant) {
+    return render(
+      <HomeAssistantProvider hass={hass}>
+        <EntityDetailDialog entityId={entityId} open onOpenChange={vi.fn()} />
+      </HomeAssistantProvider>
+    )
+  }
+
+  /** The drawn series, as `[x, y]` pairs read back off the path. */
+  function drawnPoints(): [number, number][] {
+    const line = document.querySelector('.liebe-spark-line')
+    expect(line).not.toBeNull()
+    return (line as SVGPathElement)
+      .getAttribute('d')!
+      .split(' ')
+      .map((command) => command.slice(1).split(',').map(Number) as [number, number])
+  }
+
+  beforeEach(() => {
+    entityHistoryService.reset()
+    entityStore.setState((state) => ({ ...state, entities: {}, isInitialLoading: false }))
+    callWS = vi.fn().mockResolvedValue(createHistoryResponse(ENTITY, risingSamples()))
+  })
+
+  afterEach(() => {
+    entityHistoryService.reset()
+  })
+
+  it('graphs the recorded window through the sparkline anatomy', async () => {
+    seed(createSensorEntity())
+    renderDialog(ENTITY, createMockHomeAssistant({ callWS: callWS as HomeAssistant['callWS'] }))
+
+    await waitFor(() => expect(screen.queryByTestId('detail-history-skeleton')).toBeNull())
+
+    const spark = screen.getByRole('img', { name: '24-hour history' })
+    expect(spark).toHaveClass('liebe-spark')
+    // Drawn from the samples, not the anatomy's "no series yet" baseline.
+    expect(spark).not.toHaveAttribute('data-empty')
+    expect(document.querySelector('.liebe-spark-baseline')).toBeNull()
+
+    const points = drawnPoints()
+    expect(points.length).toBeGreaterThan(1)
+    // Values rise, so the path climbs: y never increases, and it spans the box
+    // from the low sample at the bottom to the high one at the top.
+    const ys = points.map(([, y]) => y)
+    expect(ys).toEqual([...ys].sort((a, b) => b - a))
+    expect(ys[0]).toBeGreaterThan(ys[ys.length - 1])
+  })
+
+  it('marks the graph empty rather than inventing one when the recorder has nothing', async () => {
+    // A numeric entity the recorder has no rows for: the section stays, the
+    // anatomy draws its placeholder baseline.
+    seed(createSensorEntity())
+    callWS.mockResolvedValue({})
+    renderDialog(ENTITY, createMockHomeAssistant({ callWS: callWS as HomeAssistant['callWS'] }))
+
+    await waitFor(() => expect(screen.queryByTestId('detail-history-skeleton')).toBeNull())
+
+    expect(screen.getByTestId('detail-history')).toBeInTheDocument()
+    expect(document.querySelector('.liebe-spark')).toHaveAttribute('data-empty', 'true')
+  })
+
+  it('hides the whole section for an entity whose states are not numeric', async () => {
+    // The positive control first: the same dialog, an entity that does graph.
+    seed(createSensorEntity(), {
+      ...createSensorEntity({ entity_id: 'device_tracker.phone', attributes: {} }),
+      state: 'home',
+    })
+    const hass = createMockHomeAssistant({ callWS: callWS as HomeAssistant['callWS'] })
+    const graphable = renderDialog(ENTITY, hass)
+    await waitFor(() => expect(screen.getByTestId('detail-history')).toBeInTheDocument())
+    graphable.unmount()
+
+    callWS.mockClear()
+    renderDialog('device_tracker.phone', hass)
+
+    expect(screen.queryByTestId('detail-history')).toBeNull()
+    expect(screen.queryByText('History')).toBeNull()
+    // `unsupported` is resolved from the live state before a request is made,
+    // so the dialog does not even pay for the recorder to tell it.
+    expect(callWS).not.toHaveBeenCalled()
+  })
+
+  it('hides the whole section when the recorder fails', async () => {
+    seed(createSensorEntity())
+    const hass = createMockHomeAssistant({ callWS: callWS as HomeAssistant['callWS'] })
+    const graphable = renderDialog(ENTITY, hass)
+    await waitFor(() => expect(screen.getByTestId('detail-history')).toBeInTheDocument())
+    graphable.unmount()
+
+    // Same entity, same dialog — only the recorder's answer differs.
+    entityHistoryService.reset()
+    callWS.mockRejectedValue(new Error('recorder unavailable'))
+    renderDialog(ENTITY, createMockHomeAssistant({ callWS: callWS as HomeAssistant['callWS'] }))
+
+    await waitFor(() => expect(screen.queryByTestId('detail-history')).toBeNull())
+    expect(screen.queryByText('History')).toBeNull()
+    // Non-fatal by contract: the rest of the dialog is untouched.
+    expect(screen.getByTestId('detail-state')).toHaveTextContent('21.4')
+  })
+
+  it('reserves the graph area while the first fetch is in flight', async () => {
+    // The dialog opens before history arrives, so the skeleton stands in the
+    // box the graph will occupy — the attribute list below it must not jump
+    // when the series lands.
+    seed(createSensorEntity())
+    let resolve: (response: unknown) => void = () => {}
+    callWS.mockImplementation(() => new Promise((r) => (resolve = r)))
+    renderDialog(ENTITY, createMockHomeAssistant({ callWS: callWS as HomeAssistant['callWS'] }))
+
+    const area = screen.getByTestId('detail-history-graph')
+    expect(screen.getByTestId('detail-history-skeleton')).toBeInTheDocument()
+    expect(document.querySelector('.liebe-spark')).toBeNull()
+
+    resolve(createHistoryResponse(ENTITY, risingSamples()))
+    await waitFor(() => expect(screen.queryByTestId('detail-history-skeleton')).toBeNull())
+
+    // The same element, still: the graph replaced the skeleton inside the box
+    // rather than the box appearing around it.
+    expect(screen.getByTestId('detail-history-graph')).toBe(area)
+    expect(area.querySelector('.liebe-spark')).not.toBeNull()
+  })
+
+  it('shares one fetch between two dialogs on the same entity', async () => {
+    seed(createSensorEntity())
+    const hass = createMockHomeAssistant({ callWS: callWS as HomeAssistant['callWS'] })
+    render(
+      <HomeAssistantProvider hass={hass}>
+        <EntityDetailDialog entityId={ENTITY} open onOpenChange={vi.fn()} />
+        <EntityDetailDialog entityId={ENTITY} open onOpenChange={vi.fn()} />
+      </HomeAssistantProvider>
+    )
+
+    // Queried by test id rather than by role: the second dialog marks the first
+    // one's subtree `aria-hidden`, so a role query would see only one graph
+    // however many are mounted.
+    await waitFor(() => {
+      const drawn = document.querySelectorAll('.liebe-spark:not([data-empty])')
+      expect(drawn).toHaveLength(2)
+    })
+    expect(callWS).toHaveBeenCalledTimes(1)
+    expect(Object.keys(historyStore.state.entries)).toHaveLength(1)
+  })
+
+  it('draws a reopened dialog from the cached window instead of waiting on a fetch', async () => {
+    seed(createSensorEntity())
+    const hass = createMockHomeAssistant({ callWS: callWS as HomeAssistant['callWS'] })
+    const first = renderDialog(ENTITY, hass)
+    await waitFor(() => expect(screen.queryByTestId('detail-history-skeleton')).toBeNull())
+    const drawn = drawnPoints()
+    first.unmount()
+
+    // The reopen's own refetch never answers. If the dialog were not reading the
+    // cached window it would have nothing to draw at all.
+    let pending = false
+    callWS.mockImplementation(() => {
+      pending = true
+      return new Promise(() => {})
+    })
+    renderDialog(ENTITY, hass)
+
+    expect(screen.queryByTestId('detail-history-skeleton')).toBeNull()
+    expect(drawnPoints()).toEqual(drawn)
+    // One window in the cache, and the reopen cost exactly one further request —
+    // the window went unwatched, so the service closes the gap once, not once
+    // per render.
+    await waitFor(() => expect(pending).toBe(true))
+    expect(callWS).toHaveBeenCalledTimes(2)
+    expect(Object.keys(historyStore.state.entries)).toHaveLength(1)
+  })
+})

--- a/src/components/EntityDetailDialog/index.tsx
+++ b/src/components/EntityDetailDialog/index.tsx
@@ -2,6 +2,7 @@ import { createElement, Fragment } from 'react'
 import { Badge, Box, Flex, Grid, Heading, Spinner, Text } from '@radix-ui/themes'
 import { useEntity } from '~/hooks/useEntity'
 import { Modal } from '../ui'
+import { DetailHistory } from './DetailHistory'
 import { getDetailControls } from './detailControls'
 import { redactState, redactedAttributes } from './redaction'
 
@@ -18,8 +19,9 @@ export interface EntityDetailDialogProps {
  * (docs/specs/entity-cards/options/common.md — "Action type").
  *
  * Deliberately minimal: it exists to make hold-to-more-info mean something now.
- * The history section is a placeholder until change 0015 lands history data, and
- * the domain control slot ships empty for later card changes to register into.
+ * The history section graphs the recent window for entities that have one (see
+ * `DetailHistory`), and the domain control slot ships empty for later card
+ * changes to register into.
  * It carries no link to the card's configuration — configuration stays reachable
  * only through the card's edit-mode settings button — and it cannot open in edit
  * mode, where the shell suppresses every action.
@@ -90,15 +92,8 @@ export function EntityDetailDialog({ entityId, open, onOpenChange }: EntityDetai
           {/* Empty until a card family registers controls for this domain. */}
           {domainControls && createElement(domainControls, { entity })}
 
-          <Box>
-            <Heading size="2" mb="1">
-              History
-            </Heading>
-            {/* Replaced by the real graph in change 0015. */}
-            <Text size="2" color="gray" data-testid="detail-history-placeholder">
-              History is not available yet.
-            </Text>
-          </Box>
+          {/* Absent entirely for an entity with no graphable history. */}
+          <DetailHistory entityId={entityId} />
 
           <Box>
             <Heading size="2" mb="2">

--- a/src/components/__tests__/EntityDetailDialog.test.tsx
+++ b/src/components/__tests__/EntityDetailDialog.test.tsx
@@ -11,6 +11,7 @@ import { GridCardWithComponents as GridCard } from '../GridCard'
 import { HomeAssistantProvider } from '~/contexts/HomeAssistantContext'
 import { createMockHomeAssistant } from '~/testUtils/mockHomeAssistant'
 import { entityStore } from '~/store/entityStore'
+import { entityHistoryService } from '~/services/entityHistory'
 import { useEntity } from '~/hooks/useEntity'
 import { dashboardActions } from '~/store'
 import { HOLD_DURATION_MS } from '~/store/cardActions'
@@ -89,12 +90,17 @@ describe('EntityDetailDialog', () => {
   }
 
   beforeEach(() => {
+    // The dialog's history section subscribes a cached window and starts a
+    // maintenance timer; without this the cache — and the timer — outlive the
+    // test that created them.
+    entityHistoryService.reset()
     entityStore.setState((state) => ({ ...state, entities: {}, isInitialLoading: false }))
     dashboardActions.resetState()
     dialogRenders.props.length = 0
   })
 
   afterEach(() => {
+    entityHistoryService.reset()
     dashboardActions.resetState()
   })
 
@@ -119,11 +125,14 @@ describe('EntityDetailDialog', () => {
     expect(screen.queryByRole('button', { name: /configure|settings|copy/i })).toBeNull()
   })
 
-  it('renders a history placeholder until history data lands', () => {
+  it('renders the history section for an entity that has a graphable window', async () => {
+    // The 0014 placeholder is gone; the section itself, and every state it can
+    // be in, is covered in `EntityDetailDialog/__tests__/DetailHistory.test.tsx`.
     seed(createSensorEntity())
     renderDialog('sensor.living_room_temperature')
 
-    expect(screen.getByTestId('detail-history-placeholder')).toBeInTheDocument()
+    expect(await screen.findByTestId('detail-history')).toBeInTheDocument()
+    expect(screen.queryByTestId('detail-history-placeholder')).toBeNull()
   })
 
   it('falls back to the entity id when the entity has no friendly name', () => {


### PR DESCRIPTION
## Summary

Replaces the entity detail dialog's history placeholder with the recent window drawn through the sparkline anatomy, so a theme restyles it exactly as it restyles the same graph on a card. **Final PR of change 0015**, which flips to `complete` here.

## Numeric-only is the service's judgement, not the dialog's

A non-numeric entity resolves `unsupported` from its live state *before* a request is made, and the section is then absent entirely — heading included. The dialog consumes that resolution rather than re-deriving "is this graphable", because a second opinion in the view layer drifts from the service that owns the judgement. A side effect worth having: an unsupported entity costs no recorder call at all.

## Hiding on error, and why the graph goes with it

The section is likewise absent on error. History failures are non-fatal by contract, so a failed refetch takes an already-drawn graph off screen rather than leaving a stale window standing with no indication it had stopped moving. The samples survive in the cache, so the next successful fetch restores the graph without a gap — the store keeps its data, only the view withdraws.

## Loading

A Radix skeleton fills the graph's box while the first fetch is in flight, so the attribute list below does not jump when the series lands. A refetch that already holds samples keeps drawing them instead, per the spec's rule that a refetch never blanks what is already on screen.

## Caching

Repeated opens share the cached window: two dialogs on one entity cost one fetch, and a reopen draws from the cache while the service closes the unwatched gap behind it.

## Testing

Two properties carry the weight, and both are built to be capable of failing:

- The graph is asserted against **coordinates derived from the seeded samples**, so a graph that rendered but ignored its data fails rather than passing on the sparkline's placeholder baseline.
- Every hidden-section test first renders a **graphable entity in the same test** as a positive control, so a section that had simply stopped rendering at all cannot pass by looking absent.

Verified by probe in both directions: forcing the section to always hide fails all 7 cases; forcing it to never hide fails 2. A test that only ever checks for absence would have survived the first.

- [x] `npm test` — 1986 passed, 2 skipped
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — patch clean, verified against `BRDA` branch entries rather than line hits alone
- [x] `npm run build-storybook` and `npm run build:ha:prod`
