### PR TITLE
refactor(cards): migrate the control set onto CardBody

### DIFF
--- a/src/components/CardBody.css
+++ b/src/components/CardBody.css
@@ -84,4 +84,56 @@
     inline-size: auto;
     justify-content: flex-end;
   }
+
+  /*
+   * `controlSize: fill` on a row shape: the control takes the width the icon
+   * and the meta leave instead of hugging the trailing edge, and the meta stops
+   * competing for the same space — a brightness slider is as long as the row
+   * lets it be, while the name beside it stays the width of its text.
+   *
+   * `justify-content` goes back to its initial value with it. Trailing-edge
+   * alignment is what sizes a content-width control against the tile's edge;
+   * once the slot IS the free space, aligning inside it would push a control
+   * that does not fill its slot (a fan's step pills) away from the meta it
+   * belongs to.
+   */
+  .liebe-card-body[data-control-size='fill'] > .liebe-card-body-line > .liebe-card-controls {
+    flex: 1 1 auto;
+    inline-size: auto;
+    justify-content: normal;
+  }
+
+  .liebe-card-body[data-control-size='fill'] > .liebe-card-body-line > .liebe-meta {
+    flex: 0 1 auto;
+  }
+
+  /*
+   * `controlSize: fill` in `tall`: the band between the icon and the meta,
+   * taking whatever height they leave. This is the shape the vertical controls
+   * are for — a slider sized by its content has no length at all, and the tier
+   * exists to give it travel rather than whitespace.
+   *
+   * `min-block-size: 0` because a flex item's automatic minimum size is its
+   * content: without it a control taller than the room left would push the meta
+   * off the bottom of the tile instead of shrinking inside the band.
+   */
+  .liebe-card-body-fill {
+    align-items: center;
+    display: flex;
+    flex: 1 1 auto;
+    justify-content: center;
+    min-block-size: 0;
+  }
+
+  /*
+   * A control slot in that band takes the whole of it rather than being centred
+   * in it: a vertical slider's length IS the height the tier gave it
+   * (`.liebe-slider[data-orientation='vertical']` is `block-size: 100%`, which
+   * resolves against this). Anything that should stay its own size — a step
+   * pill group, a stepper — is centred by `.liebe-card-controls`' own
+   * `align-items`, or by the band itself when the card passes something else.
+   */
+  .liebe-card-body-fill > .liebe-card-controls {
+    align-self: stretch;
+  }
 }

--- a/src/components/CardBody.tsx
+++ b/src/components/CardBody.tsx
@@ -28,8 +28,27 @@ export const DEFAULT_TIER_ARRANGEMENT: Readonly<Record<CardTier, CardArrangement
   full: 'row',
 }
 
+/**
+ * How the control slot is sized.
+ *
+ * `content` — the default — leaves the slot as wide (or as tall) as what is in
+ * it: a switch, a stepper, a select trigger. `fill` gives it the room the tier
+ * has left over instead — the width the icon and the meta do not use on a row,
+ * the height they do not use in `tall`.
+ *
+ * The distinction is not cosmetic. A slider has no intrinsic length: sized by
+ * its content it collapses to nothing, and the whole point of a `tall` tile is
+ * that a taller tile gives the control more travel rather than more whitespace
+ * (docs/specs/entity-cards/options/light.md, cover.md — "Tier layouts"). A
+ * stepper is the opposite case — grown to the tile's height it would float its
+ * buttons apart — which is why this is the card's call and not the tier's.
+ */
+export type CardControlSize = 'content' | 'fill'
+
 export interface CardBodyProps {
   arrangement: CardArrangement
+  /** How much of the tier's room the control slot takes. */
+  controlSize?: CardControlSize
   /**
    * The tile's anchor — the icon circle for most cards, or whatever replaces it
    * where a card's option doc says so (a sensor's big value in `glance`).
@@ -73,15 +92,23 @@ export interface CardBodyProps {
  * tier decided does not fit, which one `display: revert` in the themable
  * cascade (docs/specs/theming) could otherwise do.
  *
- * `data-arrangement` is internal, not part of the stable selector contract:
- * `data-tier` on the shell is the public signal. It is stamped because the
- * shape is otherwise only observable through CSS, and a test that cannot see
- * the shape can only prove a tier rendered, not that it rendered as its tier.
+ * `data-arrangement` and `data-control-size` are internal, not part of the
+ * stable selector contract: `data-tier` on the shell is the public signal. They
+ * are stamped because the shape is otherwise only observable through CSS, and a
+ * test that cannot see the shape can only prove a tier rendered, not that it
+ * rendered as its tier.
  */
-export function CardBody({ arrangement, lead, meta, control, extra }: CardBodyProps) {
+export function CardBody({
+  arrangement,
+  controlSize = 'content',
+  lead,
+  meta,
+  control,
+  extra,
+}: CardBodyProps) {
   if (arrangement === 'row') {
     return (
-      <div className="liebe-card-body" data-arrangement="row">
+      <div className="liebe-card-body" data-arrangement="row" data-control-size={controlSize}>
         <div className="liebe-card-body-line">
           {lead}
           {meta}
@@ -92,12 +119,30 @@ export function CardBody({ arrangement, lead, meta, control, extra }: CardBodyPr
     )
   }
 
+  /*
+   * A filling control in `tall` gets a wrapper of its own rather than growing
+   * in place. The slot's content is the card's — a `GridCard.Controls`, a
+   * stepper, a select — and giving it `flex: 1` here would mean reaching into
+   * whatever the card passed. The wrapper is the one element this component
+   * owns, so it is the one that can be told to take the height.
+   *
+   * Only when there is something to put in it: an empty growing box would eat
+   * the `space-between` that centres a tall tile whose card has no control.
+   */
+  const filling = arrangement === 'tall' && controlSize === 'fill' && Boolean(control)
+
   return (
-    <div className="liebe-card-body" data-arrangement={arrangement}>
+    <div className="liebe-card-body" data-arrangement={arrangement} data-control-size={controlSize}>
       {lead}
       {/* `tall` runs icon → control → meta down the tile; `stack` has no room
           beside the meta, so whatever control it keeps goes underneath. */}
-      {arrangement === 'tall' ? control : null}
+      {arrangement === 'tall' ? (
+        filling ? (
+          <div className="liebe-card-body-fill">{control}</div>
+        ) : (
+          control
+        )
+      ) : null}
       {meta}
       {arrangement === 'stack' ? control : null}
       {extra}

--- a/src/components/ClimateCard.tsx
+++ b/src/components/ClimateCard.tsx
@@ -4,6 +4,7 @@ import { Thermometer } from 'lucide-react'
 import { useEntity, useServiceCall } from '~/hooks'
 import { memo, useCallback, useMemo, useState, useRef, useEffect, type ReactNode } from 'react'
 import { GridCardWithComponents as GridCard } from './GridCard'
+import { CardBody, DEFAULT_TIER_ARRANGEMENT } from './CardBody'
 import { CardState, CardValue, Pill, PillGroup } from './anatomy'
 import { SkeletonCard, ErrorDisplay } from './ui'
 import { useDashboardStore } from '~/store'
@@ -825,29 +826,19 @@ function ClimateCardComponent({
         title={error || undefined}
         className="climate-card"
       >
-        {isTall ? (
-          <Flex direction="column" align="center" gap="2" height="100%">
-            {compactIcon}
-            <Box flexGrow="1" style={{ display: 'flex', alignItems: 'center', minHeight: 0 }}>
-              {compactControls}
-            </Box>
-            {compactMeta}
-          </Flex>
-        ) : tier === 'glance' ? (
-          <Flex direction="column" align="center" justify="center" gap="2">
-            {compactIcon}
-            {compactMeta}
-            {compactControls}
-          </Flex>
-        ) : (
-          <Flex align="center" gap="3">
-            {compactIcon}
-            {compactMeta}
-            <Box flexGrow="1">
-              <Flex justify="end">{compactControls}</Flex>
-            </Box>
-          </Flex>
-        )}
+        {/*
+         * The stepper fills the band between icon and meta in `tall`, which is
+         * the axis that tier gives the card room on; everywhere else it stays
+         * the size of its two buttons and their readout — grown to a row's
+         * width it would float them apart.
+         */}
+        <CardBody
+          arrangement={DEFAULT_TIER_ARRANGEMENT[tier]}
+          controlSize={isTall ? 'fill' : 'content'}
+          lead={compactIcon}
+          meta={compactMeta}
+          control={compactControls}
+        />
       </GridCard>
     )
   }
@@ -870,9 +861,22 @@ function ClimateCardComponent({
       title={error || undefined}
       className="climate-card"
     >
-      {/* No inner height floor: the shell owns it now, keyed on the tier
-          (`GridCard.css`), so a `glance` tile can actually be one cell tall
-          instead of being propped open from the inside. */}
+      {/*
+       * No inner height floor: the shell owns it now, keyed on the tier
+       * (`GridCard.css`), so a `glance` tile can actually be one cell tall
+       * instead of being propped open from the inside.
+       *
+       * And no `CardBody`, unlike the three compact tiers above. The dial is
+       * not the four-slot shape wearing a different arrangement: it replaces
+       * lead, meta and control with one composite surface that draws the name,
+       * the reading, the setpoint and the touch target as a single dial. There
+       * is nothing here for the slots to hold, so putting it behind `CardBody`
+       * would name a shape it does not have. Change 0017 replaces this layout
+       * outright — `full` becomes the compact stepper plus mode pills, with the
+       * dial behind `variant: dial` — and that is the change that decides which
+       * of the two shapes it ends up in
+       * (docs/specs/entity-cards/options/climate.md — "Tier layouts").
+       */}
       <Flex direction="column" align="center" gap="2">
         {/* Name */}
         <GridCard.Title className="climate-card-name">{friendlyName}</GridCard.Title>

--- a/src/components/CoverCard.tsx
+++ b/src/components/CoverCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Text, Button } from '@radix-ui/themes'
+import { Flex, Text, Button } from '@radix-ui/themes'
 import {
   CaretUpIcon,
   CaretDownIcon,
@@ -11,6 +11,7 @@ import { useEntity, useServiceCall } from '~/hooks'
 import { memo, useState, useCallback, useMemo } from 'react'
 import { SkeletonCard, ErrorDisplay } from './ui'
 import { GridCardWithComponents as GridCard } from './GridCard'
+import { CardBody, DEFAULT_TIER_ARRANGEMENT } from './CardBody'
 import { Pill, PillGroup, Slider } from './anatomy'
 import { useDashboardStore } from '~/store'
 import type { DomainColorName } from '~/theme/tokens'
@@ -282,10 +283,9 @@ function CoverCardComponent({
    *   full    row content plus the open/stop/close row, then the tilt controls
    *           when the cover supports tilt.
    */
-  const isGlance = tier === 'glance'
   const isTall = tier === 'tall'
   const isFull = tier === 'full'
-  const showPositionSlider = !isGlance && !isEditMode && supportsSetPosition
+  const showPositionSlider = tier !== 'glance' && !isEditMode && supportsSetPosition
   const showButtons = isFull && !isEditMode
   const showTilt = isFull && !isEditMode && supportsTilt
 
@@ -310,21 +310,23 @@ function CoverCardComponent({
     </GridCard.Meta>
   )
 
-  const positionSlider = (orientation: 'horizontal' | 'vertical') => (
+  const positionSlider = showPositionSlider ? (
     <GridCard.Controls>
       <Slider
         domain="cover"
         color={stateColor}
         active={displayPosition > 0}
         label="Position"
-        orientation={orientation}
+        // Vertical in `tall`, where the top of the track is fully open and the
+        // control reads as a miniature of the blind it drives.
+        orientation={isTall ? 'vertical' : 'horizontal'}
         value={displayPosition}
         readout={`${displayPosition}%`}
         onValueChange={handlePositionChange}
         onValueCommit={handlePositionCommit}
       />
     </GridCard.Controls>
-  )
+  ) : undefined
 
   const buttons = (
     <GridCard.Controls>
@@ -461,34 +463,24 @@ function CoverCardComponent({
       title={error || undefined}
       className="cover-card"
     >
-      {isGlance ? (
-        <Flex direction="column" align="center" justify="center" gap="2">
-          {icon}
-          {meta}
-        </Flex>
-      ) : isTall ? (
-        <Flex direction="column" align="center" gap="2" height="100%">
-          {icon}
-          {/* Top of the track is fully open, so the control reads as a
-              miniature of the blind it drives. */}
-          {showPositionSlider && (
-            <Box flexGrow="1" style={{ display: 'flex', minHeight: 0 }}>
-              {positionSlider('vertical')}
-            </Box>
-          )}
-          {meta}
-        </Flex>
-      ) : (
-        <Flex direction="column" gap="3">
-          <Flex align="center" gap="3">
-            {icon}
-            {meta}
-            {showPositionSlider && <Box flexGrow="1">{positionSlider('horizontal')}</Box>}
-          </Flex>
-          {showButtons && buttons}
-          {showTilt && tilt}
-        </Flex>
-      )}
+      {/* The slider takes the room its tier leaves over — the width the icon
+          and the meta do not use on a row, the height they do not use in
+          `tall`. The button row and the tilt block are `full`'s secondary
+          content, and stay out of the DOM at every other tier rather than
+          being hidden there. */}
+      <CardBody
+        arrangement={DEFAULT_TIER_ARRANGEMENT[tier]}
+        controlSize="fill"
+        lead={icon}
+        meta={meta}
+        control={positionSlider}
+        extra={
+          <>
+            {showButtons && buttons}
+            {showTilt && tilt}
+          </>
+        }
+      />
     </GridCard>
   )
 }

--- a/src/components/FanCard.tsx
+++ b/src/components/FanCard.tsx
@@ -4,6 +4,7 @@ import { useEntity, useServiceCall } from '~/hooks'
 import React, { memo, useCallback } from 'react'
 import { SkeletonCard, ErrorDisplay } from './ui'
 import { GridCardWithComponents as GridCard } from './GridCard'
+import { CardBody, DEFAULT_TIER_ARRANGEMENT } from './CardBody'
 import { Pill, PillGroup } from './anatomy'
 import { useDashboardStore } from '~/store'
 import type { CardTier } from '~/utils/cardTier'
@@ -203,11 +204,10 @@ function FanCardComponent({
    * percentage; a preset-only fan keeps the preset select as its primary,
    * because dropping it would leave that fan with no speed control at all.
    */
-  const isGlance = tier === 'glance'
   const isTall = tier === 'tall'
   const isFull = tier === 'full'
   const hasPresets = supportsPresetMode && (fanAttributes.preset_modes?.length ?? 0) > 0
-  const controlsVisible = !isEditMode && !isGlance && isOn
+  const controlsVisible = !isEditMode && tier !== 'glance' && isOn
   const showSpeedPills = controlsVisible && supportsSpeed
   const showPresetSelect = controlsVisible && hasPresets && (isFull || !supportsSpeed)
 
@@ -235,35 +235,38 @@ function FanCardComponent({
     </GridCard.Meta>
   )
 
-  const speedPills = (
-    <PillGroup label="Fan speed" orientation={isTall ? 'vertical' : 'horizontal'}>
-      {(
-        [
-          { value: '25', label: 'Low speed (25%)', glyph: 12 },
-          { value: '50', label: 'Medium-low speed (50%)', glyph: 14 },
-          { value: '75', label: 'Medium-high speed (75%)', glyph: 16 },
-          { value: '100', label: 'High speed (100%)', glyph: 18 },
-        ] as const
-      ).map(({ value, label, glyph }) => (
-        <Pill
-          key={value}
-          domain="fan"
-          color="ok"
-          active={selectedButton === value}
-          label={label}
-          hideLabel
-          icon={<Wind size={glyph} />}
-          disabled={isLoading}
-          onClick={() => handleSpeedChange(value)}
-        />
-      ))}
-    </PillGroup>
-  )
+  const speedControl = showSpeedPills ? (
+    <GridCard.Controls>
+      <PillGroup label="Fan speed" orientation={isTall ? 'vertical' : 'horizontal'}>
+        {(
+          [
+            { value: '25', label: 'Low speed (25%)', glyph: 12 },
+            { value: '50', label: 'Medium-low speed (50%)', glyph: 14 },
+            { value: '75', label: 'Medium-high speed (75%)', glyph: 16 },
+            { value: '100', label: 'High speed (100%)', glyph: 18 },
+          ] as const
+        ).map(({ value, label, glyph }) => (
+          <Pill
+            key={value}
+            domain="fan"
+            color="ok"
+            active={selectedButton === value}
+            label={label}
+            hideLabel
+            icon={<Wind size={glyph} />}
+            disabled={isLoading}
+            onClick={() => handleSpeedChange(value)}
+          />
+        ))}
+      </PillGroup>
+    </GridCard.Controls>
+  ) : undefined
 
-  // Built only where there is something to build it from: `hasPresets` is what
-  // makes the modes list non-empty, and a fan without one renders no select at
+  // Built only where it is going to be rendered. `showPresetSelect` carries
+  // `hasPresets`, which is what makes the modes list non-empty and what the
+  // non-null assertions below stand on — a fan without one renders no select at
   // any tier.
-  const presetSelect = hasPresets ? (
+  const presetSelect = showPresetSelect ? (
     <Box style={{ width: '100%', maxWidth: '200px' }} onClick={(e) => e.stopPropagation()}>
       <Select.Root
         value={currentPresetMode || fanAttributes.preset_modes![0]}
@@ -280,7 +283,7 @@ function FanCardComponent({
         </Select.Content>
       </Select.Root>
     </Box>
-  ) : null
+  ) : undefined
 
   return (
     <GridCard
@@ -299,36 +302,21 @@ function FanCardComponent({
       onClick={handleToggle}
       title={error || undefined}
     >
-      {isGlance ? (
-        <Flex direction="column" align="center" justify="center" gap="2">
-          {icon}
-          {meta}
-        </Flex>
-      ) : isTall ? (
-        <Flex direction="column" align="center" gap="2" height="100%">
-          {icon}
-          {showSpeedPills && (
-            <Box flexGrow="1" style={{ display: 'flex', alignItems: 'center', minHeight: 0 }}>
-              <GridCard.Controls>{speedPills}</GridCard.Controls>
-            </Box>
-          )}
-          {showPresetSelect && presetSelect}
-          {meta}
-        </Flex>
-      ) : (
-        <Flex direction="column" gap="2">
-          <Flex align="center" gap="3">
-            {icon}
-            {meta}
-            {showSpeedPills && (
-              <Box flexGrow="1">
-                <GridCard.Controls>{speedPills}</GridCard.Controls>
-              </Box>
-            )}
-          </Flex>
-          {showPresetSelect && presetSelect}
-        </Flex>
-      )}
+      {/*
+       * `tall` has one control band between the icon and the meta, so whatever
+       * the fan's primary control is goes in it — the step pills, or the preset
+       * select for a fan that has no percentage to set. The row shapes give the
+       * preset select a line of its own underneath instead, which is where
+       * `full` puts it when the pills are already on the row.
+       */}
+      <CardBody
+        arrangement={DEFAULT_TIER_ARRANGEMENT[tier]}
+        controlSize="fill"
+        lead={icon}
+        meta={meta}
+        control={isTall ? (speedControl ?? presetSelect) : speedControl}
+        extra={isTall ? undefined : presetSelect}
+      />
     </GridCard>
   )
 }

--- a/src/components/LightCard.tsx
+++ b/src/components/LightCard.tsx
@@ -1,9 +1,9 @@
-import { Box, Flex } from '@radix-ui/themes'
 import { SunIcon } from '@radix-ui/react-icons'
 import { useEntity, useServiceCall } from '~/hooks'
 import { memo, useState, useCallback, useMemo } from 'react'
 import { SkeletonCard, ErrorDisplay } from './ui'
 import { GridCardWithComponents as GridCard } from './GridCard'
+import { CardBody, DEFAULT_TIER_ARRANGEMENT } from './CardBody'
 import { Slider } from './anatomy'
 import { useDashboardStore, dashboardActions } from '~/store'
 import { CardConfig } from './CardConfig'
@@ -201,9 +201,9 @@ function LightCardComponent({
    *           controls — none of which exist yet, so `full` renders the row
    *           content and those slots arrive with change 0016.
    */
-  const isGlance = tier === 'glance'
   const isTall = tier === 'tall'
-  const showBrightness = !isGlance && !isEditMode && isOn && supportsBrightness && enableBrightness
+  const showBrightness =
+    tier !== 'glance' && !isEditMode && isOn && supportsBrightness && enableBrightness
 
   const icon = (
     <GridCard.Icon>
@@ -224,21 +224,23 @@ function LightCardComponent({
     </GridCard.Meta>
   )
 
-  const brightnessSlider = (orientation: 'horizontal' | 'vertical') => (
+  const brightnessSlider = showBrightness ? (
     <GridCard.Controls>
       <Slider
         domain="light"
         color="light"
         active={isOn}
         label="Brightness"
-        orientation={orientation}
+        // `tall` is the tier that gives a control its own axis; every other one
+        // runs it along the row.
+        orientation={isTall ? 'vertical' : 'horizontal'}
         value={displayBrightness}
         readout={`${displayBrightness}%`}
         onValueChange={handleBrightnessChange}
         onValueCommit={handleBrightnessCommit}
       />
     </GridCard.Controls>
-  )
+  ) : undefined
 
   return (
     <>
@@ -267,31 +269,18 @@ function LightCardComponent({
         title={error || undefined}
         className="light-card"
       >
-        {isGlance ? (
-          <Flex direction="column" align="center" justify="center" gap="2">
-            {icon}
-            {meta}
-          </Flex>
-        ) : isTall ? (
-          <Flex direction="column" align="center" gap="2" height="100%">
-            {icon}
-            {/* The slider fills whatever is left between the icon and the meta
-                block — the tier's whole point is that a taller tile gives the
-                control more travel rather than more whitespace. */}
-            {showBrightness && (
-              <Box flexGrow="1" style={{ display: 'flex', minHeight: 0 }}>
-                {brightnessSlider('vertical')}
-              </Box>
-            )}
-            {meta}
-          </Flex>
-        ) : (
-          <Flex align="center" gap="3">
-            {icon}
-            {meta}
-            {showBrightness && <Box flexGrow="1">{brightnessSlider('horizontal')}</Box>}
-          </Flex>
-        )}
+        {/* The slider takes the room its tier leaves over rather than being
+            sized by its content — the width the icon and the meta do not use
+            on a row, the height they do not use in `tall`. That is the tier's
+            whole point: a taller tile gives the control more travel rather
+            than more whitespace. */}
+        <CardBody
+          arrangement={DEFAULT_TIER_ARRANGEMENT[tier]}
+          controlSize="fill"
+          lead={icon}
+          meta={meta}
+          control={brightnessSlider}
+        />
       </GridCard>
 
       {item && (

--- a/src/components/__tests__/controlCardTierLayouts.test.tsx
+++ b/src/components/__tests__/controlCardTierLayouts.test.tsx
@@ -18,10 +18,12 @@ import type { HomeAssistant } from '~/contexts/HomeAssistantContext'
  * What each control-set card KEEPS and what it DROPS at every tier.
  *
  * The simple set has its own file, `cardTierLayouts.test.tsx` (change 0011
- * PR 2). The two are split by card family rather than combined because they
- * were written against different card shapes — the simple set reads the shared
- * `CardBody`'s `data-arrangement`, while the control cards still arrange their
- * own slots per tier — and each carries the helpers its own cards need.
+ * PR 2). The two are split by card family rather than combined because each
+ * carries the helpers its own cards need — the control set's sliders, pill
+ * groups and steppers against the simple set's switches and text fields. Both
+ * families now render through the shared `CardBody`, so both read the shape off
+ * its `data-arrangement`; the last describe block below is where this file
+ * asserts that.
  *
  * The tier tables live in the per-card option docs
  * (docs/specs/entity-cards/options/) under the design system's omit-never-clip
@@ -90,6 +92,17 @@ function stampedTier(): string | null {
 function sliderOrientation(label: string): string | null {
   return screen.getByLabelText(label).closest('.liebe-slider')!.getAttribute('data-orientation')
 }
+
+/** The shape the shared body laid the tile out in. */
+const arrangement = () =>
+  document.querySelector('.liebe-card-body')!.getAttribute('data-arrangement')
+
+/** How the body sized the control slot — content-width, or the tier's leftover room. */
+const controlSize = () =>
+  document.querySelector('.liebe-card-body')!.getAttribute('data-control-size')
+
+/** The `tall` band a filling control sits in, or null when no band was rendered. */
+const fillBand = () => document.querySelector('.liebe-card-body-fill')
 
 beforeEach(() => {
   hass = createMockHomeAssistant({ callService: vi.fn().mockResolvedValue(undefined) })
@@ -815,5 +828,137 @@ describe('WeatherCard tiers', () => {
     expect(screen.queryByText('Temperature')).not.toBeInTheDocument()
     expect(screen.queryByText('Humidity')).not.toBeInTheDocument()
     expect(screen.getByText('22°C')).toBeInTheDocument()
+  })
+})
+
+describe('control-set cards — the shared body', () => {
+  /*
+   * The control set arranges its tiers through `CardBody` rather than through
+   * four hand-written per-tier layouts. Asserted here rather than left to the
+   * per-card blocks above because it is one claim about four cards, and because
+   * the shape is otherwise only observable through CSS: `data-arrangement` and
+   * `data-control-size` are stamped precisely so a test can see it.
+   *
+   * `CardBody`'s own contract — which slot goes where in each arrangement — is
+   * pinned by the simple set in `cardTierLayouts.test.tsx`. What is new here is
+   * the filling control slot the vertical controls need, which the simple set
+   * has no card for.
+   */
+
+  const light = makeEntity('light.living_room', 'on', {
+    friendly_name: 'Living Room',
+    brightness: 128,
+    supported_color_modes: ['brightness'],
+  })
+
+  it('lays each tier out in the arrangement its tier table names', () => {
+    for (const [tier, shape] of [
+      ['glance', 'stack'],
+      ['row', 'row'],
+      ['tall', 'tall'],
+      ['full', 'row'],
+    ] as const) {
+      seed(light)
+      const { unmount } = renderCard(<LightCard entityId="light.living_room" tier={tier} />)
+
+      expect(arrangement()).toBe(shape)
+      unmount()
+    }
+  })
+
+  it('gives the vertical controls the band between the icon and the meta', () => {
+    /*
+     * The extension the control set needed: a control slot that takes the
+     * height the icon and the meta leave, rather than one sized by its content.
+     * A slider has no intrinsic length, so without it a `tall` tile would give
+     * the control no travel at all — which is the one thing that tier is for.
+     */
+    seed(light)
+    const { unmount } = renderCard(<LightCard entityId="light.living_room" tier="tall" />)
+
+    expect(controlSize()).toBe('fill')
+    expect(fillBand()).toContainElement(screen.getByLabelText('Brightness'))
+    unmount()
+
+    seed(
+      makeEntity('cover.living_room', 'open', {
+        friendly_name: 'Blinds',
+        current_position: 60,
+        supported_features: 127,
+      })
+    )
+    const cover = renderCard(<CoverCard entityId="cover.living_room" tier="tall" />)
+
+    expect(fillBand()).toContainElement(screen.getByLabelText('Position'))
+    cover.unmount()
+
+    seed(
+      makeEntity('fan.living_room', 'on', {
+        friendly_name: 'Living Room Fan',
+        percentage: 50,
+        supported_features: 1,
+      })
+    )
+    const fan = renderCard(<FanCard entityId="fan.living_room" tier="tall" />)
+
+    expect(fillBand()).toContainElement(screen.getByRole('group', { name: 'Fan speed' }))
+    fan.unmount()
+
+    seed(
+      makeEntity('climate.hallway', 'heat', {
+        friendly_name: 'Hallway',
+        current_temperature: 19,
+        temperature: 21,
+        min_temp: 7,
+        max_temp: 35,
+        target_temp_step: 0.5,
+        temperature_unit: '°C',
+        hvac_modes: ['off', 'heat'],
+        supported_features: 1,
+      })
+    )
+    renderCard(
+      <ClimateCard entityId="climate.hallway" tier="tall" span={{ width: 1, height: 3 }} />
+    )
+
+    expect(fillBand()).toContainElement(screen.getByLabelText('Increase temperature'))
+  })
+
+  it('renders no band at all when the tall tier has no control to put in it', () => {
+    // An empty band would still take the height, which would push the icon and
+    // the meta to the ends of a tile that has nothing between them.
+    seed(
+      makeEntity('light.living_room', 'off', {
+        friendly_name: 'Living Room',
+        supported_color_modes: ['brightness'],
+      })
+    )
+    renderCard(<LightCard entityId="light.living_room" tier="tall" />)
+
+    expect(screen.queryByLabelText('Brightness')).not.toBeInTheDocument()
+    expect(fillBand()).toBeNull()
+  })
+
+  it('keeps a stepper content-sized on the tiers that are not tall', () => {
+    // The other half of the fill decision, and why it is the card's rather than
+    // the tier's: grown to a row's width the thermostat's two buttons would
+    // float apart from the readout between them.
+    seed(
+      makeEntity('climate.hallway', 'heat', {
+        friendly_name: 'Hallway',
+        current_temperature: 19,
+        temperature: 21,
+        min_temp: 7,
+        max_temp: 35,
+        target_temp_step: 0.5,
+        temperature_unit: '°C',
+        hvac_modes: ['off', 'heat'],
+        supported_features: 1,
+      })
+    )
+    renderCard(<ClimateCard entityId="climate.hallway" tier="row" span={{ width: 2, height: 1 }} />)
+
+    expect(controlSize()).toBe('content')
+    expect(fillBand()).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

Light, cover, fan and climate each composed the same three locals — an icon circle, a name/state stack and a control slot — and arranged them per tier by hand, while the simple card set had already converged on the shared `CardBody` that change 0011 introduced. Four hand-written copies of one tier table is four places for it to drift, and the twelve card-to-spec changes ahead (0016–0027) all touch these files.

All four now render through `CardBody`, so every tier's shape comes from one place and is observable through `data-arrangement` rather than only through CSS.

Scheduled deliberately between change 0011 completing and the card-to-spec work starting: doing it after those begin would mean four independent half-migrations landing inside four unrelated PRs, each reviewed against a different mental model.

## `CardBody` needed one extension

A control slot that takes the room its tier leaves over, rather than being sized by its content — the width the icon and meta do not use on a `row`, the height they do not use in `tall`. A slider has no intrinsic length, so a content-sized one collapses; the new `controlSize` prop is what the vertical brightness, position and speed controls stand on. `tall` puts a filling control in a band of its own, and only when the tier has a control to put there, so a tall tile without one still centres.

The `full` shape needed nothing — the row arrangement's `extra` slot already stacked secondary rows under the primary line, and cover's open/stop/close row and tilt block plus fan's preset select are its first users.

Extending rather than working around was the instruction, on the grounds that an abstraction four of nine cards have to bypass is not yet the right abstraction.

## Behaviour is unchanged

The pre-existing tier and accessible-name suites pass **unmodified** — the only deletions in this diff's test file are four lines of a header comment that described the pre-migration split. No assertion was changed or removed; the additions are new coverage for the migrated arrangements.

Preserved deliberately, each having a real defect behind it from change 0011:

- **Climate keeps its compact stepper at `glance`** — its dialog controls do not arrive until change 0017, and a control-free glance would be a thermostat nobody can turn up.
- **Cover's Open/Close disabling stays position-gated**, not derived from `coverState`, so a 60%-open cover can still be driven fully open.
- **Feature masks stay boolean at their source** — reverting them to raw masked bits puts a literal `0` on screen, since React renders a numeric zero as text.
- **`unknown` stays inert** alongside `unavailable`: no enabled control dispatching a service call against an entity whose state nobody knows.

Climate's `full` tier keeps its bespoke dial layout, which is not the four-slot shape and which change 0017 replaces outright.

## Testing

- [x] `npm test` — 2085 passed, 2 skipped
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — patch clean, verified against `BRDA` branch entries rather than the percentage summary
- [x] `npm run build-storybook` and `npm run build:ha:prod`
- [x] The 25-case accessible-name sweep across all five control cards at all four tiers passes unchanged
